### PR TITLE
CI with unit tests and static lint with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+---
+name: Automated Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+# Boostrap of the testing environment of this Python application cannot be
+# performed the traditional way with actions/setup-python as some of the Python
+# dependencies (rpm, dnf) are not available in PyPI, they are only distributed
+# as system packages in major Linux distributions repositories. For this reason,
+# containers are used with distribution package manager to install all
+# dependencies.
+
+jobs:
+  tests:
+    strategy:
+      # Disable automatic cancellation of other running jobs as soon as one
+      # failure occurs in the matrix.
+      fail-fast: false
+      matrix:
+        envs:
+        - container: "almalinux/8-base"
+          epel: 8
+          ocean-repos: 3.8-1
+        - container: "fedora"
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.envs.container }}
+      # Option --privileged is required for mount and mock+podman on fedora
+      options: --device=/dev/kvm --privileged
+    steps:
+      - uses: actions/checkout@v4
+
+      # Mount binfmt_misc virtual FS to register support of additional binary
+      # formats for multi-arch builds.
+      - name: Mount binfmt_misc virtual filesystem
+        run: |
+          mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+
+      # On Almalinux, enable EPEL repository to install mock and all its
+      # dependencies.
+      - name: Enable EPEL repository
+        if: ${{ startsWith(matrix.envs.container, 'almalinux') }}
+        run: |
+          dnf -y install 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled powertools
+          dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{ matrix.envs.epel }}.noarch.rpm
+
+      # On almalinux, enable Ocean repositories in order to install qemu version
+      # required by Rift.
+      - name: Enable Ocean repository
+        if: ${{ startsWith(matrix.envs.container, 'almalinux') }}
+        run:
+          dnf -y install https://ocean.eupex.eu/install/ocean-repos-${{ matrix.envs.ocean-repos }}.x86_64.rpm
+
+      - name: Install tests dependencies
+        run: |
+          dnf -y install python3-pip python3-jinja2 python3-PyYAML python3-rpm python3-dnf python3-pytest python3-pytest-cov sudo rpm-sign rpmlint openssh-clients genisoimage qemu qemu-user qemu-img qemu-virtiofsd mock createrepo_c
+      
+      - name: Register binary formats supported by qemu-user-static
+        run: |
+          /usr/lib/systemd/systemd-binfmt
+
+      - name: Install application
+        run: pip3 install -e .
+
+      # Some tests expect to run as non-root with kvm, mock and sudo permissions
+      # sudo required for sudo virtiosfd --version
+      - name: Create unprivileged user
+        run: |
+          useradd ci
+          usermod -aG $(stat -c %G /dev/kvm) ci
+          usermod -aG mock ci
+          echo "ci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/00-ci
+
+      # Move coverage data file in ~ci because ci unprilived user does not have
+      # permissions in working directory after checkout by root.
+      - name: Run tests
+        run: |
+          cat <<EOF > .coveragerc
+          [run]
+          data_file = ~ci/.coverage
+          EOF
+          su ci -c pytest-3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+---
+name: Pylint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install python and pip
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install python3-pip
+
+    # Install latest version of Pylint
+    - name: Install pylint
+      run: |
+        pip install pylint
+
+    # Install rift dependencies to avoid E0401 errors.
+    - name: Install rift dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install python3-rpm python3-dnf python3-yaml python3-jinja2
+
+    - name: Analysing the code with pylint
+      run: |
+        pylint lib/rift

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -52,7 +52,7 @@ from rift.Gerrit import Review
 from rift.Mock import Mock
 from rift.Package import Package, Test
 from rift.Repository import LocalRepository, ProjectArchRepositories
-from rift.RPM import RPM, Spec, RPMLINT_CONFIG
+from rift.RPM import RPM, Spec, RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2
 from rift.TempDir import TempDir
 from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
@@ -1285,7 +1285,7 @@ def _patched_file_updated_package(patched_file, config, modules, staff):
         logging.info('Detected spec file')
 
     # rpmlint config file
-    elif names == [RPMLINT_CONFIG]:
+    elif names in [RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2]:
         logging.debug('Detecting rpmlint config file')
 
     # sources/

--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -78,7 +78,7 @@ class Mock():
             repo_ctx = {
                 'name': repo.name or 'repo%s' % idx,
                 'priority': prio,
-                'url': repo.url,
+                'url': repo.generic_url(self._arch),
                 }
             if repo.module_hotfixes:
                 repo_ctx['module_hotfixes'] = repo.module_hotfixes

--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -99,7 +99,20 @@ class RPM():
         self.name = _header_values(hdr[rpm.RPMTAG_NAME])
         self.arch = _header_values(hdr[rpm.RPMTAG_ARCH])
         self.source_rpm = _header_values(hdr[rpm.RPMTAG_SOURCERPM])
-        self.is_signed = hdr[rpm.RPMTAG_SIGPGP] is not None
+        # With RPM format v3, signature can be found in SIGPIP tag. Starting
+        # with RPM format v4, signature is either stored in RSAHEADER or
+        # DSAHEADER tags.
+        #
+        # For reference, see:
+        # https://github.com/rpm-software-management/rpm/blob/master/docs/manual/format_v4.md#signature
+        #
+        # In order to check presence of the signature whatever the RPM package
+        # format, we look at all three tags.
+        self.is_signed = (
+            hdr[rpm.RPMTAG_SIGPGP] is not None
+            or hdr[rpm.RPMTAG_RSAHEADER] is not None
+            or hdr[rpm.RPMTAG_DSAHEADER] is not None
+        )
         self.is_source = hdr.isSource()
         self._srcfiles.extend(_header_values(hdr[rpm.RPMTAG_SOURCE]))
         self._srcfiles.extend(_header_values(hdr[rpm.RPMTAG_PATCH]))

--- a/lib/rift/Repository.py
+++ b/lib/rift/Repository.py
@@ -77,6 +77,13 @@ class ConsumableRepository():
             return self.url[len(self.FILE_SCHEME):]
         return self.url
 
+    def generic_url(self, arch):
+        """
+        Return the URL with all occurrences of the given architecture replaced
+        by generic $basearch placeholder.
+        """
+        return self.url.replace(arch, "$basearch")
+
     def exists(self):
         """
         Return true if path the local (aka. file) consumable repository actually

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -73,7 +73,7 @@ def is_virtiofs_qemu(virtiofsd=_DEFAULT_VIRTIOFSD):
     This function checks if virtiofsd is from qemu package or a standalone rust
     version
     """
-    output = ""
+    output = b''
     try:
         output = check_output(f"{virtiofsd} --version",
                               stderr=STDOUT,

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -41,7 +41,6 @@ import sys
 import time
 import datetime
 import shlex
-import pipes
 import platform
 import logging
 import tempfile
@@ -568,7 +567,7 @@ class VM():
         cmd = ''
         for func, code in funcs.items():
             cmd += '%s() { %s;}; export -f %s; ' % (func, code, func)
-        cmd += pipes.quote(test.command)
+        cmd += shlex.quote(test.command)
 
         logging.debug("Running command outside VM: %s", cmd)
         popen = Popen(cmd, shell=True) #, stdout=PIPE, stderr=STDOUT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.pytest.ini_options]
+pythonpath = "lib"
+testpaths = "tests"
+python_files = "*.py"
+# required to catch exception in main()
+log_level = "DEBUG"
+addopts = "-v --cov=rift --cov-report=term-missing"
+
+[tool.pylint.main]
+# Specify a score threshold under which the program will exit with error.
+fail-under = 9.07
+
+# Minimum Python version to use for version dependent checks. Will default to the
+# version used to run pylint.
+py-version = "3.6"
+
+[tool.pylint."messages control"]
+# Disable the message, report, category or checker with the given id(s). You can
+# either give multiple identifiers separated by comma (,) or put this option
+# multiple times (only on the command line, not in the configuration file where
+# it should appear only once). You can also use "--disable=all" to disable
+# everything first and then re-enable specific checks. For example, if you want
+# to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable = ["E1101", "W0511"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+pythonpath = lib
+testpaths = tests
+python_files = *.py
+# required to catch exception in main()
+log_level = DEBUG
+addopts = -v --cov=rift --cov-report=term-missing

--- a/tests/Annex.py
+++ b/tests/Annex.py
@@ -205,7 +205,8 @@ class AnnexTest(RiftTestCase):
         for filename, size, insertion_time, names in self.annex.list():
             self.assertEqual(get_digest_from_path(self.source.name), filename)
             self.assertEqual(source_size, size)
-            self.assertEqual(source_insertion_time, insertion_time)
+            # As tests can take time to run, accept less or equal 1 second shift
+            self.assertAlmostEqual(source_insertion_time, insertion_time, delta=1)
             self.assertTrue(os.path.basename(self.source.name) in names.keys())
 
     def test_push(self):

--- a/tests/Config.py
+++ b/tests/Config.py
@@ -402,10 +402,10 @@ class ConfigTest(RiftTestCase):
         self.assertTrue('os' in repos)
         self.assertTrue('update' in repos)
         self.assertTrue('extra' in repos)
-        self.assertEquals(repos['os']['url'], 'https://os/url/file2')
+        self.assertEqual(repos['os']['url'], 'https://os/url/file2')
         self.assertTrue('module_hotfixes' in repos['os'])
-        self.assertEquals(repos['update']['url'], 'https://update/url/file2')
-        self.assertEquals(repos['extra']['url'], 'https://extra/url/file1')
+        self.assertEqual(repos['update']['url'], 'https://update/url/file2')
+        self.assertEqual(repos['extra']['url'], 'https://extra/url/file1')
 
     def test_load_port_partial_port_range(self):
         """Load partial port range dict"""
@@ -1056,8 +1056,8 @@ class ConfigTestSyntax(RiftTestCase):
         param0 = config.get('param0')
         self.assertTrue('key1' in param0)
         self.assertTrue('key2' in param0)
-        self.assertEquals(param0['key1'], 'value2')
-        self.assertEquals(param0['key2'], 1)
+        self.assertEqual(param0['key1'], 'value2')
+        self.assertEqual(param0['key2'], 1)
 
     def test_load_record(self):
         """Load record without content"""
@@ -1242,9 +1242,9 @@ class ConfigTestSyntax(RiftTestCase):
         self.assertTrue('value1' in record0)
         self.assertTrue('value2' in record0)
         self.assertTrue('value3' in record0)
-        self.assertEquals(record0['value1'], 1)
-        self.assertEquals(record0['value2'], 20)
-        self.assertEquals(record0['value3'], 3)
+        self.assertEqual(record0['value1'], 1)
+        self.assertEqual(record0['value2'], 20)
+        self.assertEqual(record0['value3'], 3)
 
 
 class ProjectConfigTest(RiftTestCase):

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -998,15 +998,15 @@ class ControllerArgumentsTest(RiftTestCase):
 
         args = ['vm', '--arch', 'x86_64']
         opts = parser.parse_args(args)
-        self.assertEquals(opts.command, 'vm')
+        self.assertEqual(opts.command, 'vm')
 
         args = ['vm', 'connect']
         opts = parser.parse_args(args)
-        self.assertEquals(opts.vm_cmd, 'connect')
+        self.assertEqual(opts.vm_cmd, 'connect')
 
         args = ['vm', '--arch', 'x86_64', 'connect']
         opts = parser.parse_args(args)
-        self.assertEquals(opts.vm_cmd, 'connect')
+        self.assertEqual(opts.vm_cmd, 'connect')
 
         args = ['vm', 'build']
         # This must fail due to missing image URL
@@ -1015,8 +1015,8 @@ class ControllerArgumentsTest(RiftTestCase):
 
         args = ['vm', 'build', 'http://image']
         opts = parser.parse_args(args)
-        self.assertEquals(opts.vm_cmd, 'build')
-        self.assertEquals(opts.url, 'http://image')
+        self.assertEqual(opts.vm_cmd, 'build')
+        self.assertEqual(opts.url, 'http://image')
         self.assertFalse(opts.force)
 
         args = ['vm', 'build', 'http://image', '--force']
@@ -1031,11 +1031,11 @@ class ControllerArgumentsTest(RiftTestCase):
 
         args = ['vm', 'build', 'http://image', '-o', OUTPUT_IMG]
         opts = parser.parse_args(args)
-        self.assertEquals(opts.output, OUTPUT_IMG)
+        self.assertEqual(opts.output, OUTPUT_IMG)
 
         args = ['vm', 'build', 'http://image', '--output', OUTPUT_IMG]
         opts = parser.parse_args(args)
-        self.assertEquals(opts.output, OUTPUT_IMG)
+        self.assertEqual(opts.output, OUTPUT_IMG)
 
         # This must fail due to missing output filename
         args = ['vm', 'build', 'http://image', '--output']

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -42,7 +42,7 @@ class MockTest(RiftProjectTestCase):
         repos_ctx = context['repos'][0]
         self.assertEqual(repos_ctx['name'], 'tmp')
         self.assertEqual(repos_ctx['priority'], 999)
-        self.assertEqual(repos_ctx['url'], 'file:///tmp/{}'.format(arch))
+        self.assertEqual(repos_ctx['url'], 'file:///tmp/$basearch')
         self.assertEqual(repos_ctx['module_hotfixes'], True)
         self.assertEqual(repos_ctx['excludepkgs'], 'somepkg')
         self.assertEqual(repos_ctx['proxy'], 'myproxy')

--- a/tests/RPM.py
+++ b/tests/RPM.py
@@ -204,15 +204,15 @@ class RPMTest(RiftProjectTestCase):
         """RPM initializer works with bin/src RPM with/without conf."""
         # test load bin RPM without config
         rpm = RPM(self.bin_rpm)
-        self.assertEquals(rpm.name, 'pkg')
-        self.assertEquals(rpm.arch, 'noarch')
-        self.assertEquals(rpm.is_source, False)
+        self.assertEqual(rpm.name, 'pkg')
+        self.assertEqual(rpm.arch, 'noarch')
+        self.assertEqual(rpm.is_source, False)
 
         # test load src RPM with config
         rpm = RPM(self.src_rpm, self.config)
-        self.assertEquals(rpm.name, 'pkg')
-        self.assertEquals(rpm.arch, 'noarch')
-        self.assertEquals(rpm.is_source, True)
+        self.assertEqual(rpm.name, 'pkg')
+        self.assertEqual(rpm.arch, 'noarch')
+        self.assertEqual(rpm.is_source, True)
 
     def test_extract_srpm(self):
         """RPM.extract_srpm() extracts files from source RPM."""

--- a/tests/RPM.py
+++ b/tests/RPM.py
@@ -14,7 +14,7 @@ from TestUtils import (
     RiftProjectTestCase,
 )
 from rift import RiftError
-from rift.RPM import Spec, Variable, RPMLINT_CONFIG, RPM
+from rift.RPM import Spec, Variable, RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2, RPM, rpmlint_v2
 
 class SpecTest(RiftTestCase):
     """
@@ -77,21 +77,39 @@ class SpecTest(RiftTestCase):
         self.assertIsNone(Spec(self.spec).check())
 
 
-    def test_specfile_check_with_rpmlint(self):
-        """ Test specfile check function with a custom rpmlint file"""
+    def test_specfile_check_with_rpmlint_v1(self):
+        """ Test specfile check function with a custom rpmlint v1 file"""
         # Make an errorneous specfile with hardcoded /lib
+        if rpmlint_v2():
+            self.skipTest("This test requires rpmlint v1")
         self.files = "/lib/test"
         self.update_spec()
         with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
             Spec(self.spec).check()
 
-        # Create rpmlintfile to ignore hardcoded library path
-        rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG])
+        # Create rpmlint config to ignore hardcoded library path
+        rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V1])
         with open(rpmlintfile, "w") as rpmlint:
             rpmlint.write('addFilter("E: hardcoded-library-path")')
         self.assertIsNone(Spec(self.spec).check())
         os.unlink(rpmlintfile)
 
+    def test_specfile_check_with_rpmlint_v2(self):
+        """ Test specfile check function with a custom rpmlint v2 file"""
+        if not rpmlint_v2():
+            self.skipTest("This test requires rpmlint v2")
+        self.buildsteps = "$RPM_BUILD_ROOT"
+        self.update_spec()
+
+        with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
+            Spec(self.spec).check()
+
+        # Create rpmlint config file to ignore rpm-buildroot-usage
+        rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V2])
+        with open(rpmlintfile, "w") as rpmlint:
+            rpmlint.write('Filters = ["rpm-buildroot-usage"]')
+        self.assertIsNone(Spec(self.spec).check())
+        os.unlink(rpmlintfile)
 
     def test_bump_release(self):
         """ Test bump_release """

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -330,6 +330,13 @@ class ConsumableRepositoryTest(RiftTestCase):
         ):
             repo.exists()
 
+    def test_generic_url(self):
+        directory = '/some/where/there'
+        repo =  ConsumableRepository('http:/{}'.format(directory))
+        self.assertEqual(repo.generic_url('x86_64'), 'http:/{}'.format(directory))
+        repo =  ConsumableRepository('http://some/where/x86_64')
+        self.assertEqual(repo.generic_url('x86_64'), 'http://some/where/$basearch')
+
 class ProjectArchRepositoriesTest(RiftTestCase):
     """
     Tests class for ProjectArchRepositories

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -218,11 +218,10 @@ class VMTest(RiftTestCase):
         """
         Check drive command line generation for virtiofs
         """
-        vm = VM(self.config, None)
+        vm = VM(self.config, platform.machine())
         # Test virtiofs configuration without any repos
         vm.shared_fs_type = 'virtiofs'
         vm._project_dir = '/somewhere/else'
-        vm.arch = platform.processor()
         args, helper_args = vm._make_drive_cmd()
         virtiofs_same_arch = ['-object',
                               f'memory-backend-file,id=mem,size={str(vm.memory)}M,'
@@ -287,8 +286,7 @@ class VMTest(RiftTestCase):
         """
         Check qemu args generator
         """
-        vm = VM(self.config, None)
-        vm.arch = platform.processor()
+        vm = VM(self.config, platform.machine())
         vm.consolesock = '/console'
         image_path = '/my_image'
         # Test without seed iso path

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -112,20 +112,20 @@ class VMTest(RiftTestCase):
         # 2 successive calls to id property with same object must return the
         # same value.
         vm1 = VM(self.config, 'x86_64')
-        self.assertEquals(vm1.vmid, vm1.vmid)
+        self.assertEqual(vm1.vmid, vm1.vmid)
         vm2 = VM(self.config, 'aarch64')
-        self.assertEquals(vm2.vmid, vm2.vmid)
+        self.assertEqual(vm2.vmid, vm2.vmid)
         # Verify vm1 and vm2 ID are different due because of their different
         # architecture.
-        self.assertNotEquals(vm1.vmid, vm2.vmid)
+        self.assertNotEqual(vm1.vmid, vm2.vmid)
         # Get another vm object with the same architecture (and user/version)
         # than vm1 and check it has the same ID.
         vm3 = VM(self.config, 'x86_64')
-        self.assertEquals(vm1.vmid, vm3.vmid)
+        self.assertEqual(vm1.vmid, vm3.vmid)
         # Change version for vm3 and check ID is now different of vm1.
         self.config.set('version', '2.0')
         vm3 = VM(self.config, 'x86_64')
-        self.assertNotEquals(vm1.vmid, vm3.vmid)
+        self.assertNotEqual(vm1.vmid, vm3.vmid)
 
     def test_default_port(self):
         """Check VM default port uniqueness and range conformity"""
@@ -137,13 +137,13 @@ class VMTest(RiftTestCase):
         port_range = {'min': 2000,  'max': 3000}
         # Verify vm1 and vm2 default are different because of their different
         # architecture.
-        self.assertNotEquals(
+        self.assertNotEqual(
             vm1.default_port(port_range),
             vm2.default_port(port_range)
         )
         # Verify vm1 and vm3 have the same default port because they share the
         # same combination of user/arch/version.
-        self.assertEquals(
+        self.assertEqual(
             vm1.default_port(port_range),
             vm3.default_port(port_range)
         )
@@ -399,14 +399,14 @@ class VMBuildTest(RiftProjectTestCase):
         self._check_qemuimg()
         vm = VM(self.config, 'x86_64')
         vm.build(self.valid_url, False, False, vm._image)
-        self.assertEquals(os.path.exists(vm._image), True)
+        self.assertEqual(os.path.exists(vm._image), True)
 
     def test_build_ok_copymode(self):
         """Test VM build OK with copymode enabled"""
         vm = VM(self.config, 'x86_64')
         vm.copymode = 1
         vm.build(self.valid_url, False, False, vm._image)
-        self.assertEquals(os.path.exists(vm._image), True)
+        self.assertEqual(os.path.exists(vm._image), True)
 
     @patch('rift.VM.input')
     def test_build_overwrite(self, mock_input):
@@ -417,7 +417,7 @@ class VMBuildTest(RiftProjectTestCase):
         open(vm._image, 'w').close()
         mock_input.side_effect = 'yes'
         vm.build(self.valid_url, False, False, vm._image)
-        self.assertEquals(os.path.exists(vm._image), True)
+        self.assertEqual(os.path.exists(vm._image), True)
         mock_input.assert_called_once()
 
     def test_build_with_build_script(self):
@@ -427,7 +427,7 @@ class VMBuildTest(RiftProjectTestCase):
         with open(vm.build_post_script, 'w') as fh:
             fh.write("#!/bin/bash\n/bin/true\n")
         vm.build(self.valid_url, False, False, vm._image)
-        self.assertEquals(os.path.exists(vm._image), True)
+        self.assertEqual(os.path.exists(vm._image), True)
 
     def test_build_with_build_script_error(self):
         """Test VM build with build script error"""


### PR DESCRIPTION
This pull request adds two GitHub Actions workflows to run unit tests and static lint over the code in contributors pull requests and pushes in master branch.

The pull request also includes some commits to port Rift on latest version of Fedora, with Python 3.13, rpmlint v2, RPM package format >= 3 and mock multi-arch configuration fix.