### PR TITLE
Restructure vm and gerrit configuration parameters

### DIFF
--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -181,49 +181,88 @@ class Config():
                 }
             }
         },
-        'vm_image':    {
-            'required': True,
-            # XXX?: default value?
-        },
-        'vm_image_copy':    {
-            'check':    'digit',
-            'default': 0,
-        },
-        'vm_port_range': {
+        'vm': {
             'check':    'dict',
+            'required': True,
             'syntax': {
-                'min': {
-                    'check': 'digit',
-                    'default': _DEFAULT_VM_PORT_RANGE_MIN,
+                'image':    {
+                    'required': True,
+                    # XXX?: default value?
                 },
-                'max': {
-                    'check': 'digit',
-                    'default': _DEFAULT_VM_PORT_RANGE_MAX,
-                }
+                'image_copy':    {
+                    'check':    'digit',
+                    'default': 0,
+                },
+                'port_range': {
+                    'check':    'dict',
+                    'syntax': {
+                        'min': {
+                            'check': 'digit',
+                            'default': _DEFAULT_VM_PORT_RANGE_MIN,
+                        },
+                        'max': {
+                            'check': 'digit',
+                            'default': _DEFAULT_VM_PORT_RANGE_MAX,
+                        }
+                    }
+                },
+                'cpu': {},
+                'cpus': {
+                    'check':    'digit',
+                    'default':  _DEFAULT_VM_CPUS,
+                },
+                'memory': {
+                    'check':    'digit',
+                    'default':   _DEFAULT_VM_MEMORY,
+                },
+                'address': {
+                    'default':  _DEFAULT_VM_ADDRESS,
+                },
+                'images_cache': {},
+                'additional_rpms': {
+                    'check':    'list',
+                    'default':  _DEFAULT_VM_ADDITIONAL_RPMS,
+                },
+                'cloud_init_tpl': {
+                    'default': _DEFAULT_VM_CLOUD_INIT_TPL,
+                },
+                'build_post_script': {
+                    'default': _DEFAULT_VM_BUILD_POST_SCRIPT,
+                },
             }
         },
-        'vm_cpu': {},
+        'vm_image':    {
+            'deprecated': 'vm.image'
+        },
+        'vm_image_copy':    {
+            'deprecated': 'vm.image_copy'
+        },
+        'vm_port_range': {
+            'deprecated': 'vm.port_range'
+        },
+        'vm_cpu': {
+            'deprecated': 'vm.cpu'
+        },
         'vm_cpus': {
-            'check':    'digit',
-            'default':  _DEFAULT_VM_CPUS,
+            'deprecated': 'vm.cpus'
         },
         'vm_memory': {
-            'check':    'digit',
-            'default':   _DEFAULT_VM_MEMORY,
+            'deprecated': 'vm.memory'
         },
         'vm_address': {
-            'default':  _DEFAULT_VM_ADDRESS,
+            'deprecated': 'vm.address'
         },
-        'vm_images_cache': {},
+        'vm_images_cache': {
+            'deprecated': 'vm.images_cache'
+        },
         'vm_additional_rpms': {
-            'check':    'list',
-            'default':  _DEFAULT_VM_ADDITIONAL_RPMS,
+            'deprecated': 'vm.additional_rpms'
         },
         'vm_cloud_init_tpl': {
-            'default': _DEFAULT_VM_CLOUD_INIT_TPL,
+            'deprecated': 'vm.cloud_init_tpl'
         },
         'vm_build_post_script': {
-            'default': _DEFAULT_VM_BUILD_POST_SCRIPT,
+            'deprecated': 'vm.build_post_script'
         },
         'gerrit_realm': {},
         'gerrit_server': {},

--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -264,11 +264,31 @@ class Config():
         'vm_build_post_script': {
             'deprecated': 'vm.build_post_script'
         },
-        'gerrit_realm': {},
-        'gerrit_server': {},
-        'gerrit_url': {},
-        'gerrit_username': {},
-        'gerrit_password': {},
+        'gerrit': {
+            'check': 'dict',
+            'syntax': {
+                'realm': {},
+                'server': {},
+                'url': {},
+                'username': {},
+                'password': {},
+            }
+        },
+        'gerrit_realm': {
+            'deprecated': 'gerrit.realm'
+        },
+        'gerrit_server': {
+            'deprecated': 'gerrit.server'
+        },
+        'gerrit_url': {
+            'deprecated': 'gerrit.url'
+        },
+        'gerrit_username': {
+            'deprecated': 'gerrit.username'
+        },
+        'gerrit_password': {
+            'deprecated': 'gerrit.password'
+        },
         'rpm_macros': {
             'check':    'dict',
         },

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -677,7 +677,7 @@ def vm_build(vm, args, config):
             "Both --deploy and -o,--output options cannot be used together"
         )
     if args.deploy:
-        output = config.get('vm_image')
+        output = config.get('vm').get('image')
     else:
         output = args.output
     message(f"Building new vm image {output}")

--- a/lib/rift/Gerrit.py
+++ b/lib/rift/Gerrit.py
@@ -80,15 +80,20 @@ class Review():
     def push(self, config, changeid, revid):
         """Send REST request to Gerrit server from config"""
         auth_methods = ('digest', 'basic')
-        realm = config.get('gerrit_realm')
-        server = config.get('gerrit_server')
-        username = config.get('gerrit_username')
-        password = config.get('gerrit_password')
-        auth_method = config.get('gerrit_auth_method', 'basic')
+
+        gerrit_config = config.get('gerrit')
+        if gerrit_config is None:
+            raise RiftError("Gerrit configuration is not defined")
+
+        realm = gerrit_config.get('realm')
+        server = gerrit_config.get('server')
+        username = gerrit_config.get('username')
+        password = gerrit_config.get('password')
+        auth_method = gerrit_config.get('auth_method', 'basic')
 
         if realm is None:
             raise RiftError("Gerrit realm is not defined")
-        if server is None and config.get('gerrit_url') is None:
+        if server is None and gerrit_config.get('url') is None:
             raise RiftError("Gerrit url is not defined")
         if username is None:
             raise RiftError("Gerrit username is not defined")
@@ -98,7 +103,7 @@ class Review():
             raise RiftError(f"Gerrit auth_method is not correct (supported {auth_methods})")
 
         # Set a default url if only gerrit_server was defined
-        url = config.get('gerrit_url', f"https://{server}")
+        url = gerrit_config.get('url', f"https://{server}")
 
         # FIXME: Don't check certificate
         ctx = ssl.create_default_context()

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -123,7 +123,8 @@ class VM():
         self.version = config.get('version', '0')
         self.arch = arch
 
-        self._image = config.get('vm_image', arch=arch)
+        vm_config = config.get('vm', arch=arch)
+        self._image = vm_config.get('image')
         self._project_dir = config.project_dir
 
         if extra_repos is None:
@@ -131,17 +132,17 @@ class VM():
 
         self._repos = ProjectArchRepositories(config, arch).all + extra_repos
 
-        self.address = config.get('vm_address')
-        self.port = self.default_port(config.get('vm_port_range'))
-        self.cpus = config.get('vm_cpus', 1)
-        self.memory = config.get('vm_memory')
+        self.address = vm_config.get('address')
+        self.port = self.default_port(vm_config.get('port_range'))
+        self.cpus = vm_config.get('cpus', 1)
+        self.memory = vm_config.get('memory')
         self.qemu = config.get('qemu', arch=arch)
 
         # default emulated cpu architecture
         if self.arch == 'aarch64':
-            self.cpu_type = config.get('vm_cpu', 'cortex-a72')
+            self.cpu_type = vm_config.get('cpu', 'cortex-a72')
         else:
-            self.cpu_type = config.get('vm_cpu', 'host')
+            self.cpu_type = vm_config.get('cpu', 'host')
 
         # Specific aarch64 options
         self.arch_efi_bios = config.get('arch_efi_bios', ARCH_EFI_BIOS)
@@ -156,21 +157,21 @@ class VM():
 
 
         self.tmpmode = tmpmode
-        self.copymode = config.get('vm_image_copy')
+        self.copymode = vm_config.get('image_copy')
         self._vm = None
         self._helpers = []
         self._tmpimg = None
         self.consolesock = f"/tmp/rift-vm-console-{self.vmid}.sock"
         self.proxy = config.get('proxy')
         self.no_proxy = config.get('no_proxy')
-        self.additional_rpms = config.get('vm_additional_rpms')
+        self.additional_rpms = vm_config.get('additional_rpms')
         self.cloud_init_tpl = config.project_path(
-            config.get('vm_cloud_init_tpl')
+            vm_config.get('cloud_init_tpl')
         )
         self.build_post_script = config.project_path(
-            config.get('vm_build_post_script')
+            vm_config.get('build_post_script')
         )
-        self.images_cache = config.get('vm_images_cache')
+        self.images_cache = vm_config.get('images_cache')
 
     @property
     def vmid(self):

--- a/template/project.conf
+++ b/template/project.conf
@@ -15,16 +15,6 @@ annex: /somewhere/
 #
 # no_proxy: localhost,.intranet.company.ltd
 
-# VM options
-vm_image: images/default.qcow
-# full copy of image
-vm_image_copy: False
-
-# TCP port range Rift can select for SSH server in the VMs
-# vm_port_range:
-#   min: 10000
-#   max: 15000
-
 # Build architectures
 arch:
 - x86_64
@@ -39,37 +29,51 @@ arch:
 #rpm_macros:
 #  kernel_version: 1.2.4.4
 
-# Optional VM settings
-#
-# Path to directory where downloaded cloud images are stored locally. This
-# directory serves as a cache: when images are already present in this directory
-# (ie. same filename), download is skipped. If this parameter is not defined,
-# images are downloaded in a temporary directory.
-#
-# vm_images_cache: /path/to/images/cache
-#
-# List of paths to RPM packages that are copied into the VM before execution of
-# build post script. This script is then responsible of their installation in VM
-# image.
-#
-# vm_additional_rpms:
-# - /path/to/first-rpm-1.el8.x86_64.rpm
-# - /path/to/second-rpm-1.el8.x86_64.rpm
-#
-# Path to alternative cloud-init template file. By default, Rift uses
-# cloud-init.tpl file located in project top folder.
-#
-# vm_cloud_init_tpl: /path/to/cloud-init.tpl
-#
-# Path to alternative VM build post script. By default, Rift executes
-# build-post.sh script located in project top folder.
-#
-# vm_build_post_script: /path/to/build-post.sh
+# VM options
+vm:
+  image: images/default.qcow
+
+  # Optional VM settings
+  #
+  # Make a full copy of the image before using it.
+  # image_copy: False
+  #
+  # TCP port range Rift can select for SSH server for its VMs.
+  # port_range:
+  #   min: 10000
+  #   max: 15000
+  #
+  # Path to directory where downloaded cloud images are stored locally. This
+  # directory serves as a cache: when images are already present in this directory
+  # (ie. same filename), download is skipped. If this parameter is not defined,
+  # images are downloaded in a temporary directory.
+  #
+  # images_cache: /path/to/images/cache
+  #
+  # List of paths to RPM packages that are copied into the VM before execution of
+  # build post script. This script is then responsible of their installation in VM
+  # image.
+  #
+  # additional_rpms:
+  # - /path/to/first-rpm-1.el8.x86_64.rpm
+  # - /path/to/second-rpm-1.el8.x86_64.rpm
+  #
+  # Path to alternative cloud-init template file. By default, Rift uses
+  # cloud-init.tpl file located in project top folder.
+  #
+  # cloud_init_tpl: /path/to/cloud-init.tpl
+  #
+  # Path to alternative VM build post script. By default, Rift executes
+  # build-post.sh script located in project top folder.
+  #
+  # Emulated CPU model for the VM. The default value is 'cortex-a72' for aarch64
+  # architecture or 'host' for other architectures.
+  # cpu: "cortex-a72"
+  # build_post_script: /path/to/build-post.sh
 
 # Dedicated options for aarch64 builds
 #arch: "aarch64"
 #arch_efi_bios: "/ccc/home/cont001/ocre/cedeyna/Ocean/rift/vendor/QEMU_EFI.fd"
-#vm_cpu: "cortex-a72"
 
 # Example GPG settings for package cryptographic signing
 #gpg:
@@ -83,7 +87,8 @@ arch:
 # It is possible to declare architecture specific options with a mapping under
 # the key named after this architectur.
 # x86_64:
-#   vm_image: images/image-x86_64.qcow2
+#   vm:
+#     image: images/image-x86_64.qcow2
 
 # External repositories
 #

--- a/tests/Config.py
+++ b/tests/Config.py
@@ -501,7 +501,6 @@ class ConfigTest(RiftTestCase):
                     '^Key (key|keyring) is required in dict parameter gpg$'
                 ):
                 config.load(cfgfile.name)
-            self.assertEqual(config.get('gpg'), None)
 
     def test_load_gpg_unknown_key(self):
         """Load gpg parameters raise DeclError if unknown key"""
@@ -1056,6 +1055,35 @@ class ConfigTestSyntax(RiftTestCase):
         self.assertTrue('key1' in param0)
         self.assertTrue('key2' in param0)
         self.assertEqual(param0['key1'], 'value2')
+        self.assertEqual(param0['key2'], 1)
+
+    def test_load_dict_merged_syntax_missing_required(self):
+        """load() merges dict from multiple files with syntax and required param missing in one file"""
+        self._add_fake_params()
+        conf_files = [
+            make_temp_file(
+                textwrap.dedent(
+                    """
+                    param0:
+                      key1: value1
+                    """
+                )
+            ),
+            make_temp_file(
+                textwrap.dedent(
+                    """
+                    param0:
+                      key2: 1
+                    """
+                )
+            ),
+        ]
+        config = Config()
+        config.load([conf_file.name for conf_file in conf_files])
+        param0 = config.get('param0')
+        self.assertTrue('key1' in param0)
+        self.assertTrue('key2' in param0)
+        self.assertEqual(param0['key1'], 'value1')
         self.assertEqual(param0['key2'], 1)
 
     def test_load_record(self):

--- a/tests/Config.py
+++ b/tests/Config.py
@@ -677,6 +677,27 @@ class ConfigTest(RiftTestCase):
         self.assertEqual(config.get('vm').get('cpus'), 42)
         self.assertEqual(config.get('vm').get('memory'), 1234)
 
+    def test_load_deprecated_gerrit_parameters(self):
+        """load() deprecated gerrit_* parameters."""
+        cfgfile = make_temp_file(
+            textwrap.dedent(
+                """
+                annex: /a/dir
+                vm:
+                  image: /a/image.img
+                gerrit_realm: Rift
+                gerrit_url: https://localhost
+                gerrit_username: rift
+                """
+            )
+        )
+        config = Config()
+        with self.assertWarns(RiftDeprecatedConfWarning):
+            config.load(cfgfile.name)
+        self.assertEqual(config.get('gerrit').get('realm'), 'Rift')
+        self.assertEqual(config.get('gerrit').get('url'), 'https://localhost')
+        self.assertEqual(config.get('gerrit').get('username'), 'rift')
+
 
 class ConfigTestSyntax(RiftTestCase):
     """Test Config with modified syntax."""

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -601,17 +601,17 @@ rename to packages/pkgnew/sources/pkgnew-1.0.tar.gz
         mock_vm_class.assert_called()
 
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', False, False, self.config.get('vm_image')
+            'http://image', False, False, self.config.get('vm').get('image')
         )
         mock_vm_objects.build.reset_mock()
         main(['vm', 'build', 'http://image', '--deploy', '--force'])
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', True, False, self.config.get('vm_image')
+            'http://image', True, False, self.config.get('vm').get('image')
         )
         mock_vm_objects.build.reset_mock()
         main(['vm', 'build', 'http://image', '--deploy', '--keep'])
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', False, True, self.config.get('vm_image')
+            'http://image', False, True, self.config.get('vm').get('image')
         )
         mock_vm_objects.build.reset_mock()
         main(
@@ -645,12 +645,12 @@ rename to packages/pkgnew/sources/pkgnew-1.0.tar.gz
         self.skipTest("Too much instability")
         if not os.path.exists("/usr/bin/qemu-img"):
             self.skipTest("qemu-img is not available")
-        self.config.options['vm_images_cache'] = GLOBAL_CACHE
+        self.config.options['vm']['images_cache'] = GLOBAL_CACHE
         # Reduce memory size from default 8GB to 2GB because it is sufficient to
         # run this VM and it largely reduces storage required by virtiofs memory
         # backend file which is the same size as the VM memory, thus reducing
         # the risk to fill up small partitions when running the tests.
-        self.config.options['vm_memory'] = 2048
+        self.config.options['vm']['memory'] = 2048
         self.config.options['proxy'] = PROXY
         self.config.options['repos'] = {
             'os': {

--- a/tests/Gerrit.py
+++ b/tests/Gerrit.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2024 CEA
+#
+from unittest import mock
+
+from TestUtils import RiftTestCase
+from rift.Config import Config
+from rift.Gerrit import Review
+from rift import RiftError
+
+class GerritTest(RiftTestCase):
+    def setUp(self):
+        self.config = Config()
+        self.config.set(
+            'gerrit',
+            {
+                'realm': 'Rift',
+                'server': 'localhost',
+                'username': 'rift',
+                'password': 'SECR3T',
+            }
+        )
+        self.review = Review()
+        self.review.add_comment('/path/to/file', 42, 'E', 'test error message')
+
+    def test_invalidate(self):
+        """ Test Review.invalidate() method"""
+        self.assertEqual(self.review.validated, True)
+        self.review.invalidate()
+        self.assertEqual(self.review.validated, False)
+
+    @mock.patch("rift.Gerrit.urllib.urlopen")
+    def test_push(self, mock_urlopen):
+        """ Test Review push """
+        self.review.push(self.config, 4242, 42)
+        # Check push successfully send HTTP request with urllib.urlopen() and
+        # reads its result.
+        mock_urlopen.assert_called_once()
+        mock_urlopen.return_value.read.assert_called_once()
+
+    def test_push_no_config(self):
+        """ Test Review push w/o gerrit config error """
+        del self.config.options['gerrit']
+        with self.assertRaisesRegex(RiftError, "Gerrit configuration is not defined"):
+            self.review.push(self.config, 4242, 42)
+
+    def test_push_missing_conf_param(self):
+        """ Test Review push with missing parameter error """
+        gerrit_conf = self.config.get('gerrit')
+        for parameter, value in gerrit_conf.copy().items():
+            # temporary remove parameter
+            del gerrit_conf[parameter]
+            with self.assertRaisesRegex(RiftError, "Gerrit .* is not defined"):
+                self.review.push(self.config, 4242, 42)
+            # restore value
+            gerrit_conf[parameter] = value

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -162,7 +162,8 @@ class RiftProjectTestCase(RiftTestCase):
         self.projectconf = os.path.join(self.projdir, Config._DEFAULT_FILES[0])
         with open(self.projectconf, "w") as conf:
             conf.write("annex:           %s\n" % self.annexdir)
-            conf.write("vm_image:        test.img\n")
+            conf.write("vm:\n")
+            conf.write("  image:         test.img\n")
             conf.write("repos:           {}\n")
         os.chdir(self.projdir)
         # Dict of created packages
@@ -198,9 +199,13 @@ class RiftProjectTestCase(RiftTestCase):
             os.rmdir(pkgdir)
         # Remove potentially generated files for VM related tests
         for path in [
-            self.config.project_path(self.config.get('vm_cloud_init_tpl')),
-            self.config.project_path(self.config.get('vm_build_post_script')),
-            self.config.project_path(self.config.get('vm_image')),
+            self.config.project_path(
+                self.config.get('vm').get('cloud_init_tpl')
+            ),
+            self.config.project_path(
+                self.config.get('vm').get('build_post_script')
+            ),
+            self.config.project_path(self.config.get('vm').get('image')),
         ]:
             if os.path.exists(path):
                 os.unlink(path)
@@ -318,7 +323,9 @@ class RiftProjectTestCase(RiftTestCase):
                 'template',
                 'cloud-init.tpl',
             ),
-            self.config.project_path(self.config.get('vm_cloud_init_tpl')),
+            self.config.project_path(
+                self.config.get('vm').get('cloud_init_tpl')
+            ),
         )
 
     def copy_build_post_script(self):
@@ -330,13 +337,15 @@ class RiftProjectTestCase(RiftTestCase):
                 'template',
                 'build-post.sh',
             ),
-            self.config.project_path(self.config.get('vm_build_post_script')),
+            self.config.project_path(
+                self.config.get('vm').get('build_post_script')
+            ),
         )
 
     def ensure_vm_images_cache_dir(self):
         """Ensure VM images cache directory exists."""
         cache_dir =  self.config.project_path(
-            self.config.get('vm_images_cache')
+            self.config.get('vm').get('images_cache')
         )
         if not os.path.exists(cache_dir):
             os.mkdir(cache_dir)

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -79,13 +79,18 @@ class VMTest(RiftTestCase):
 
         # custom
         self.config.set('arch', ['aarch64'])
-        self.config.set('vm_cpu', 'custom')
-        self.config.set('vm_cpus', 32)
-        self.config.set('vm_memory', vm_custom_memory)
+        self.config.set(
+            'vm',
+            {
+                'cpu': 'custom',
+                'cpus': 32,
+                'memory': vm_custom_memory,
+                'image_copy': 1,
+                'address': '192.168.0.5',
+                'image': '/my_image',
+            }
+        )
         self.config.set('arch_efi_bios', '/my_bios')
-        self.config.set('vm_image_copy', 1)
-        self.config.set('vm_address', '192.168.0.5')
-        self.config.set('vm_image', '/my_image')
         self.config.set('qemu', '/my_custom_qemu')
 
         vm = VM(self.config, 'aarch64')
@@ -340,7 +345,7 @@ class VMBuildTest(RiftProjectTestCase):
         super().setUp()
         # Override some configuration parameters defined in dummy config from
         # RiftProjectTestCase.
-        self.config.options['vm_images_cache'] = GLOBAL_CACHE
+        self.config.options['vm']['images_cache'] = GLOBAL_CACHE
         self.config.options['proxy'] = PROXY
         self.wrong_url = 'https://127.0.0.1/fail'
         self.valid_url = VALID_IMAGE_URL['x86_64']


### PR DESCRIPTION
The pull requests deprecates all `vm_*` and `gerrit_*` configuration parameters and introduces new `vm` and `gerrit` hashes to hold all related parameters.

2 parents commits are also included to:

- fix a bug with required parameters validation when hashes are merged from multiple configuration files
- introduce generic management of deprecated parameters and raise user warnings