### PR TITLE
Tests: disable mock bootstrap image

### DIFF
--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -33,7 +33,7 @@ config_opts['dist'] = 'el8'
 config_opts['releasever'] = '8'
 config_opts['priorities.conf'] = "[main]\\nenabled = 1\\n"
 config_opts['package_manager'] = 'dnf'
-config_opts['bootstrap_image'] = 'centos:8'
+config_opts['use_bootstrap_image'] = False
 config_opts['isolation'] = 'simple'
 config_opts['chroot_setup_cmd'] = (
     'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make '


### PR DESCRIPTION
Mock bootstrap image feature leads to some unexplained behavior when running multi-arch builds with podman in docker in GitHub actions. As an example, builds of foreign architecture fail with file:// repository metadata not found during bootstrap when local repository is specified in build environment, despite a valid multi-arch local repository and correct usage of $basearch in repository path to handle architecture difference between bootstrap image and build environment.

This might be related to this issue:
https://github.com/rpm-software-management/mock/issues/1570

Bootstrap feature is not required by tests as testing environment support all expected rpm features so the quick and easy fix is to disable this feature in tests.