### PR TITLE
RPM: Fix changelog --bump option

### DIFF
--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -46,6 +46,7 @@ import rpm
 
 from rift import RiftError
 from rift.Annex import Annex, is_binary
+import rift.utils
 
 RPMLINT_CONFIG_V1 = 'rpmlint'
 RPMLINT_CONFIG_V2 = 'rpmlint.toml'
@@ -296,7 +297,9 @@ class Spec():
         """
         Update epoch:version-release
         """
-        self.evr = f"{self.epoch}{self.version}-{self.release.rstrip(self.dist)}"
+        self.evr = "{}{}-{}".format(self.epoch,
+                                    self.version,
+                                    rift.utils.removesuffix(self.release, self.dist))
 
     def _inc_release(self, release):
         dist = self.dist

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -75,3 +75,14 @@ def setup_dl_opener(proxy, no_proxy, fake_user_agent=True):
     if fake_user_agent:
         opener.addheaders = [('User-agent', 'Mozilla/5.0')]
     urllib.request.install_opener(opener)
+
+def removesuffix(input_string, suffix):
+    """
+    The removesuffix method was introduced in python 3.9,
+    to preserve compatibility with older version, this is
+    a reimplementation
+    """
+    if suffix and input_string.endswith(suffix):
+        return input_string[:-len(suffix)]
+    return input_string
+


### PR DESCRIPTION
To compute the bumped release version of a Specfile, the rstrip method was used to remove the dist tag before computing the bump (We don't want to bump the dist tag, el9 to el10 for instance). However, the rstrip version remove a set of character in the totality of the string instead of only the suffix. The removesuffix method is more suitable.

Further documentation : https://docs.python.org/3/library/stdtypes.html#str.rstrip