### PR TITLE
utils: move message() and banner() helpers

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -58,19 +58,8 @@ from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
 from rift.VM import VM
 from rift.sync import RepoSyncFactory
+from rift.utils import message, banner
 
-
-def message(msg):
-    """
-    helper function to print a log message
-    """
-    print(f"> {msg}")
-
-def banner(title):
-    """
-    helper function to print a banner
-    """
-    print(f"** {title} **")
 
 def make_parser():
     """Create command line parser"""

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -38,6 +38,18 @@ import urllib
 
 from rift import RiftError
 
+def message(msg):
+    """
+    helper function to print a log message
+    """
+    print(f"> {msg}")
+
+def banner(title):
+    """
+    helper function to print a banner
+    """
+    print(f"** {title} **")
+
 def download_file(url, output):
     """
     Download file pointed by url and save it in output path. Convert

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2025 CEA
+#
+
+from io import StringIO
+from unittest.mock import patch
+
+from TestUtils import RiftTestCase
+from rift.utils import message, banner
+
+class UtilsTest(RiftTestCase):
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_message(self, mock_stdout):
+        message("foo")
+        self.assertEqual(mock_stdout.getvalue(), "> foo\n")
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_banner(self, mock_stdout):
+        banner("bar")
+        self.assertEqual(mock_stdout.getvalue(), "** bar **\n")


### PR DESCRIPTION
Move message() and banner() helpers function in utils module in order to lighten the Controller module and make these helpers available to other modules.

Also add minimal tests to cover these functions specifically.