### PR TITLE
Tests: use gen_rpm_spec() in make_pkgs()

### DIFF
--- a/tests/RPM.py
+++ b/tests/RPM.py
@@ -66,7 +66,7 @@ class SpecTest(RiftTestCase):
         self.assertEqual(spec.exclusive_archs, [])
         self.assertEqual(spec.arch, self.arch)
         self.assertTrue("{0}-{1}.tar.gz".format(self.name, self.version) in spec.sources)
-        self.assertEqual(len(spec.lines), 36)
+        self.assertEqual(len(spec.lines), 42)
 
     def test_init_fails(self):
         """ Test Spec instanciation with error """

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -85,12 +85,23 @@ Source0:        https://nowhere.com/sources/%{name}-%{version}.tar.gz
 ExclusiveArch:  {{ exclusive_arch }}
 {% endif -%}
 BuildArch:      {{ arch }}
-BuildRequires:  br-package
-Requires:       another-package
+{% for build_require in build_requires | default(['br-package']) %}
+BuildRequires:  {{ build_require }}
+{% endfor %}
+{% for require in requires | default(['another-package']) %}
+Requires:       {{ require}}
+{% endfor %}
 Provides:       {{ name }}-provide
 
 %description
 A package
+
+{% for subpackage in subpackages | default([]) %}
+%package -n {{ subpackage.name }}
+Summary: Sub-package {{ subpackage.name }}
+%description -n {{ subpackage.name }}
+Description for package {{ subpackage.name }}
+{% endfor %}
 
 %prep
 {{ prepsteps | default("") }}
@@ -259,40 +270,10 @@ class RiftProjectTestCase(RiftTestCase):
         self.pkgspecs[name] = os.path.join(self.pkgdirs[name],
                                            "{0}.spec".format(name))
         with open(self.pkgspecs[name], "w") as spec:
-            spec.write("Name:    {0}\n".format(name))
-            spec.write("Version:        {0}\n".format(version))
-            spec.write("Release:        {0}\n".format(release))
-            spec.write("Summary:        A package\n")
-            spec.write("Group:          System Environment/Base\n")
-            spec.write("License:        GPL\n")
-            spec.write("URL:            http://nowhere.com/projects/%{name}/\n")
-            spec.write("Source0:        %{name}-%{version}.tar.gz\n")
-            spec.write("BuildArch:      noarch\n")
-            for build_require in build_requires:
-                spec.write(f"BuildRequires:  {build_require}\n")
-            for require in requires:
-                spec.write(f"Requires:       {require}\n")
-            spec.write("Provides:       {0}-provide\n".format(name))
-            spec.write("%description\n")
-            spec.write("A package\n")
-            for subpackage in subpackages:
-                spec.write(f"%package -n {subpackage.name}\n")
-                spec.write(f"Summary: Sub-package {subpackage.name}\n")
-                spec.write(f"%description -n {subpackage.name}\n")
-                spec.write(f"Description for package {subpackage.name}\n")
-
-            spec.write("%prep\n")
-            spec.write("%build\n")
-            spec.write("# Nothing to build\n")
-            spec.write("%install\n")
-            spec.write("# Nothing to install\n")
-            spec.write("%files\n")
-            spec.write("# No files\n")
-            spec.write("%changelog\n")
-            spec.write("* Tue Feb 26 2019 Myself <buddy@somewhere.org>"
-                       " - {0}-{1}\n".format(version, release))
-            spec.write("- Update to {0} release\n".format(version))
-
+            spec.write(
+                gen_rpm_spec(name=name, version=version, release=release,
+                             build_requires=build_requires, requires=requires,
+                             arch='noarch', subpackages=subpackages))
         # ./packages/pkg/sources
         srcdir = os.path.join(self.pkgdirs[name], 'sources')
         os.mkdir(srcdir)


### PR DESCRIPTION
Reuse gen_rpm_spec() template in RiftProjectTestCase.make_pkg() method to keep one RPM spec file generation logic.