### PR TITLE
RPM: evaluate spec file in Mock's chroot

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -38,6 +38,7 @@ import argparse
 import logging
 from operator import attrgetter
 import time
+import platform
 # Since pylint can not found rpm.error, disable this check
 from rpm import error as RpmError # pylint: disable=no-name-in-module
 from unidiff import parse_unidiff
@@ -51,6 +52,7 @@ from rift.package import RIFT_SUPPORTED_FORMATS, ProjectPackages
 from rift.repository import ProjectArchRepositories, StagingRepository
 from rift.graph import PackagesDependencyGraph
 from rift.RPM import RPM, Spec
+from rift.Mock import Mock
 from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
 from rift.VM import VM
@@ -345,7 +347,9 @@ def action_check(args, config):
         if args.file is None:
             raise RiftError("You must specifiy a file path (-f)")
 
-        spec = Spec(args.file, config=config)
+        mock = Mock(config, platform.machine())
+        repos = ProjectArchRepositories(config, platform.machine()).for_format('rpm')
+        spec = Spec(args.file, mock, repos.all, config=config)
         spec.check()
         logging.info('Spec file is OK.')
 

--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -164,7 +164,7 @@ class Mock():
             f"--configdir={self._tmpdir.path}"
         ] + self._build_macro_args()
 
-    def _exec(self, cmd):
+    def _exec(self, cmd, merge_out_err=True):
         """
         Execute mock command in argument, check its return code and raise
         RiftError with its output in case of error.
@@ -175,11 +175,13 @@ class Mock():
             cmd,
             live_output=logging.getLogger().isEnabledFor(logging.INFO),
             capture_output=True,
-            merge_out_err=True,
+            merge_out_err=merge_out_err,
             cwd='/'
         )
         if proc.returncode != 0:
-            raise RiftError(proc.out)
+            raise RiftError(proc.out if merge_out_err else proc.err)
+
+        return proc
 
     def init(self, repolist):
         """
@@ -189,6 +191,37 @@ class Mock():
         """
         self._init_tmp_conf(repolist)
         self._exec(['--init'])
+
+    def read_spec(self, filepath):
+        """
+        Interpret RPM spec file in chroot by running rpmspec command. Return output of
+        rpmspec command with some prefixed messages filtered out to make it parsable
+        by RPM library.
+        """
+        proc = self._exec(
+            [
+                f"--plugin-option=bind_mount:dirs=[('{filepath}', '{filepath}')]",
+                'chroot',
+                'rpmspec',
+                '--parse',
+                filepath
+            ],
+            merge_out_err=False
+        )
+
+        lines = []
+
+        rpmspec_ignore_prefixes = ("error: ", "warning: ", "rpm: ", "sh: ")
+        for line in proc.out.splitlines():
+            # filter out rpmspec errors and warings
+            ignore_line = False
+            for prefix in rpmspec_ignore_prefixes:
+                if line.startswith(prefix):
+                    ignore_line = True
+            if not ignore_line:
+                lines.append(line)
+
+        return "\n".join(lines)
 
     def resultrpms(self, pattern='*.rpm', sources=True):
         """

--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -43,6 +43,8 @@ import time
 import itertools
 import datetime
 import locale
+import tempfile
+import threading
 
 import rpm
 
@@ -55,6 +57,9 @@ import rift.utils
 
 RPMLINT_CONFIG_V1 = 'rpmlint'
 RPMLINT_CONFIG_V2 = 'rpmlint.toml'
+
+mock_lock = threading.Lock()
+
 
 def _header_values(values):
     """ Convert values from header specfile to strings """
@@ -207,8 +212,10 @@ class RPM():
 class Spec():
     """Access information from a Specfile and build SRPMS."""
 
-    def __init__(self, filepath=None, config=None, variant=None):
+    def __init__(self, filepath, mock, repos, config=None, variant=None):
         self.filepath = filepath
+        self.mock = mock
+        self.repos = repos
         self.srpmname = None
         self.pkgnames = []
         self.provides = []
@@ -240,6 +247,10 @@ class Spec():
                 rpm.addMacro(macro, value)
         if self.variant is not None and self.variant != _DEFAULT_VARIANT:
             rpm.addMacro(f"with_{self.variant}", "1")
+        # Disable automatic expansion of debug_package macro to avoid double
+        # expansion when parsing output of `rpmspec --parse` leading to
+        # "package *-debuginfo already exists" error eventually.
+        rpm.addMacro("debug_package", "%{nil}")
 
     def _parse_vars(self):
         self.variables = {}
@@ -261,18 +272,30 @@ class Spec():
         if not os.path.exists(self.filepath):
             raise RiftError(f"{self.filepath} does not exist")
         try:
-            rpm.reloadConfig()
-            self._set_macros()
-            # Get current timezone, so it can be restored after parsing the spec
-            # file.
-            current_timezone = str(datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
-            spec = rpm.TransactionSet().parseSpec(self.filepath)
-            # As a workaround RPM library bug
-            # https://github.com/rpm-software-management/rpm/issues/1821,
-            # restore timezone after it has been changed to parse changelog.
-            # Note this is fixed in RPM >= 4.19.
-            os.environ['TZ'] = str(current_timezone)
-            time.tzset()
+            # Run rpmspec in mock's chroot.
+            #
+            # All architectures threads use the same host native mock
+            # environment to load spec file. Add lock to avoid concurrent access
+            # on the same mock build root.
+            with mock_lock:
+                self.mock.init(self.repos)
+                content = self.mock.read_spec(self.filepath)
+                self.mock.clean()
+            with tempfile.NamedTemporaryFile(mode='w+') as fp:
+                fp.write(content)
+                fp.seek(0)
+                rpm.reloadConfig()
+                self._set_macros()
+                # Get current timezone, so it can be restored after parsing the spec
+                # file.
+                current_timezone = str(datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
+                spec = rpm.TransactionSet().parseSpec(fp.name)
+                # As a workaround RPM library bug
+                # https://github.com/rpm-software-management/rpm/issues/1821,
+                # restore timezone after it has been changed to parse changelog.
+                # Note this is fixed in RPM >= 4.19.
+                os.environ['TZ'] = str(current_timezone)
+                time.tzset()
         except ValueError as exp:
             raise RiftError(f"{self.filepath}: {str(exp).strip()}") from exp
         self.pkgnames = [_header_values(pkg.header['name']) for pkg in spec.packages]

--- a/lib/rift/package/rpm.py
+++ b/lib/rift/package/rpm.py
@@ -38,6 +38,7 @@ import shutil
 import textwrap
 import time
 import re
+import platform
 
 from rift import RiftError
 from rift.package._base import Package, ActionableArchPackage, Test
@@ -94,7 +95,8 @@ class PackageRPM(Package):
         its main attributes."""
         # load infos.yaml with parent class
         super().load(infopath)
-        self.spec = Spec(self.buildfile, config=self._config)
+        arch_pkg = self.for_arch(platform.machine())
+        self.spec = Spec(self.buildfile, arch_pkg.mock, arch_pkg.repos.all, config=self._config)
         self.version = self.spec.version
         self.release = self.spec.release
         self.arch = self.spec.arch
@@ -272,7 +274,16 @@ class ActionableArchPackageRPM(ActionableArchPackage):
 
             tests = list(self.package.tests())
             if not kwargs.get('noauto', False):
-                tests.insert(0, BasicTest(self.package, variant, config=self.config))
+                tests.insert(
+                    0,
+                    BasicTest(
+                        self.package,
+                        self.mock,
+                        self.repos.all,
+                        variant,
+                        config=self.config
+                    )
+                )
             for test in tests:
                 case = TestCase(
                     test.name, self.name, variant, self.arch, self.package.format
@@ -358,11 +369,11 @@ class BasicTest(Test):
         - config: rift configuration
     """
 
-    def __init__(self, pkg, variant, config=None):
+    def __init__(self, pkg, mock, repos, variant, config=None):
         if pkg.rpmnames:
             rpmnames = pkg.rpmnames
         else:
-            rpmnames = Spec(pkg.buildfile, config=config, variant=variant).pkgnames
+            rpmnames = Spec(pkg.buildfile, mock, repos, config=config, variant=variant).pkgnames
 
         try:
             for name in pkg.ignore_rpms:

--- a/lib/rift/repository/rpm.py
+++ b/lib/rift/repository/rpm.py
@@ -39,11 +39,13 @@ import logging
 import shutil
 import glob
 import threading
+import platform
 from subprocess import Popen, PIPE, STDOUT, run, CalledProcessError
 
 from rift import RiftError
 from rift.repository._base import ArchRepositoriesBase, StagingRepositoryBase
 from rift.RPM import RPM, Spec
+from rift.Mock import Mock
 from rift.TempDir import TempDir
 from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS
 
@@ -225,9 +227,11 @@ class LocalRepository:
             except CalledProcessError as err:
                 raise RiftError(err) from err
             # Parse spec file
-            spec = Spec(os.path.join(tmp_dir.path,
-                                     'SPECS',
-                                     f"{src_rpm.name}.spec"))
+            spec = Spec(
+                os.path.join(tmp_dir.path, 'SPECS', f"{src_rpm.name}.spec"),
+                Mock(self.config, platform.machine()),
+                ArchRepositoriesRPM(self.config, None, platform.machine()).all,
+            )
             # Remove tmp directory
             tmp_dir.delete()
             # Merge list of bin package names into bin_rpm_names (and avoid

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -11,7 +11,7 @@ import textwrap
 from io import StringIO
 
 from .TestUtils import (
-    make_temp_file, make_temp_dir, gen_rpm_spec, RiftTestCase, RiftProjectTestCase, SubPackage
+    make_temp_file, make_temp_dir, gen_rpm_spec, read_file, RiftTestCase, RiftProjectTestCase, SubPackage
 )
 
 from .VM import GLOBAL_CACHE, VALID_IMAGE_URL, PROXY
@@ -124,20 +124,21 @@ class ControllerProjectActionImportTest(RiftProjectTestCase):
             main(['import', self.bin_rpm, '-m', 'Great module',
                   '-r', 'Good reason', '--maintainer', 'Myself'])
 
-    def test_import(self):
+    @patch('rift.package.rpm.Mock')
+    def test_import(self, mock_mock):
         """simple import"""
         main(['import', self.src_rpm, '-m', 'Great module', '-r', 'Good reason',
               '--maintainer', 'Myself'])
         pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         pkg.load()
         self.assertEqual(pkg.module, 'Great module')
         self.assertEqual(pkg.reason, 'Good reason')
         self.assertCountEqual(pkg.maintainers, ['Myself'])
-        spec = Spec(filepath=pkg.buildfile)
-        spec.load()
-        self.assertEqual(spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(spec.version, '1.0')
-        self.assertEqual(spec.release, '1')
+        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
+        self.assertEqual(pkg.spec.version, '1.0')
+        self.assertEqual(pkg.spec.release, '1')
         self.assertTrue(os.path.exists(f"{pkg.buildfile}.orig"))
         shutil.rmtree(os.path.dirname(pkg.metafile))
 
@@ -170,20 +171,21 @@ class ControllerProjectActionReimportTest(RiftProjectTestCase):
         with self.assertRaisesRegex(RiftError, "You must specify a maintainer"):
             main(['reimport', self.src_rpm, '-m', 'Great module', '-r', 'Good reason'])
 
-    def test_reimport(self):
+    @patch('rift.package.rpm.Mock')
+    def test_reimport(self, mock_mock):
         """simple reimport"""
         self.make_pkg(name='pkg')
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         main(['reimport', self.src_rpm, '--maintainer', 'Myself'])
         pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
         pkg.load()
         self.assertEqual(pkg.module, 'Great module')
         self.assertEqual(pkg.reason, 'Missing feature')
         self.assertCountEqual(pkg.maintainers, ['Myself'])
-        spec = Spec(filepath=pkg.buildfile)
-        spec.load()
-        self.assertEqual(spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(spec.version, '1.0')
-        self.assertEqual(spec.release, '1')
+        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
+        self.assertEqual(pkg.spec.version, '1.0')
+        self.assertEqual(pkg.spec.release, '1')
         self.assertTrue(os.path.exists(f"{pkg.buildfile}.orig"))
         os.unlink(f"{pkg.buildfile}.orig")
 
@@ -196,22 +198,30 @@ class ControllerProjectActionQueryTest(RiftProjectTestCase):
         """simple 'rift query' is ok """
         self.assertEqual(main(['query']), 0)
 
-    def test_action_query_on_pkg(self):
+    @patch('rift.package.rpm.Mock')
+    def test_action_query_on_pkg(self, mock_mock):
         """ Test query on one package """
         self.make_pkg()
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         self.assertEqual(main(['query', 'pkg']), 0)
 
-    def test_action_query_on_bad_pkg(self):
+    @patch('rift.package.rpm.Mock')
+    def test_action_query_on_bad_pkg(self, mock_mock):
         """ Test query on multiple packages with one errorneous package """
         self.make_pkg()
         ## A package with no name should be wrong but the command should not fail
         self.make_pkg(name='pkg2', metadata={})
+        mock_mock.return_value.read_spec = read_file
         self.assertEqual(main(['query']), 0)
 
+    @patch('rift.package.rpm.Mock')
     @patch('sys.stdout', new_callable=StringIO)
-    def test_action_query_output_default(self, mock_stdout):
+    def test_action_query_output_default(self, mock_stdout, mock_mock):
         self.make_pkg(name="pkg1")
         self.make_pkg(name="pkg2", version='2.1', release='3')
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         self.assertEqual(main(['query']), 0)
         self.assertIn(
             "NAME MODULE       MAINTAINERS FORMAT VERSION RELEASE MODULEMANAGER",
@@ -223,10 +233,13 @@ class ControllerProjectActionQueryTest(RiftProjectTestCase):
             """),
             mock_stdout.getvalue())
 
+    @patch('rift.package.rpm.Mock')
     @patch('sys.stdout', new_callable=StringIO)
-    def test_action_query_output_format(self, mock_stdout):
+    def test_action_query_output_format(self, mock_stdout, mock_mock):
         self.make_pkg(name="pkg1")
         self.make_pkg(name="pkg2", version='2.1', release='3')
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         self.assertEqual(
             main([
                 'query', '--format',
@@ -325,9 +338,12 @@ class ControllerProjectActionCheckTest(RiftProjectTestCase):
             exit_code = main(['check', 'spec'])
             self.assertEqual(exit_code, 1)
 
-    def test_check_spec(self):
+    @patch('rift.Controller.Mock')
+    def test_check_spec(self, mock_mock):
         """simple check spec"""
         self.make_pkg()
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         with self.assertLogs(level='INFO') as log:
             exit_code = main(
                 ['check', 'spec', '-f', self.buildfiles['pkg:rpm']]
@@ -991,7 +1007,8 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # return an empty list.
         self.assertEqual(pkgs, [])
 
-    def test_get_packages_to_build_package_order(self):
+    @patch('rift.package.rpm.Mock')
+    def test_get_packages_to_build_package_order(self, mock_mock):
         """ Test get_packages_to_build() returns correctly ordered list of reverse dependencies. """
         self.make_pkg(
             name='libone',
@@ -1017,6 +1034,8 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         args = Mock()
         args.skip_deps = False
         args.packages = ['libone']
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         pkgs = get_packages_to_build(
             self.config, self.staff, self.modules, args
         )
@@ -1035,7 +1054,8 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
             [pkg.name for pkg in pkgs], ['libtwo', 'libone', 'my-software']
         )
 
-    def test_get_packages_to_build_cyclic_deps(self):
+    @patch('rift.package.rpm.Mock')
+    def test_get_packages_to_build_cyclic_deps(self, mock_mock):
         """ Test get_packages_to_build() returns correctly ordered list of reverse dependencies. """
         self.make_pkg(
             name='libone',
@@ -1060,6 +1080,8 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         args = Mock()
         args.skip_deps = False
         args.packages = ['libone']
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         with self.assertLogs(level="DEBUG") as cm:
             pkgs = get_packages_to_build(
                 self.config, self.staff, self.modules, args
@@ -1875,7 +1897,8 @@ class ControllerProjectActionGraphTest(RiftProjectTestCase):
     Tests class for Controller action graph
     """
 
-    def test_get_packages_in_graph(self):
+    @patch('rift.package.rpm.Mock')
+    def test_get_packages_in_graph(self, mock_mock):
         """ Test get_packages_in_graph(). """
         self.make_pkg(
             name='libone',
@@ -1892,6 +1915,8 @@ class ControllerProjectActionGraphTest(RiftProjectTestCase):
         args = Mock()
         args.module = 'Great module'
         args.packages = []
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         self.assertCountEqual(
             get_packages_in_graph(args, self.config, self.staff, self.modules),
             ['libone', 'libtwo']
@@ -1929,7 +1954,8 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
         with self.assertRaisesRegex(SystemExit, "2"):
             main(cmd)
 
-    def test_gitlab(self):
+    @patch('rift.package.rpm.Mock')
+    def test_gitlab(self, mock_mock):
         """simple gitlab"""
         self.make_pkg()
         patch = make_temp_file(
@@ -1947,10 +1973,13 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
                  Group:          System Environment/Base
                  License:        GPL
                 """))
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         # Test no error is raised
         main(['gitlab', patch.name])
 
-    def test_gitlab_check_failed(self):
+    @patch('rift.package.rpm.Mock')
+    def test_gitlab_check_failed(self, mock_mock):
         """gitlab check error"""
         # Make package and inject rpmlint error ($RPM_BUILD_ROOT and
         # RPM_SOURCE_DIR in buildsteps) in RPM spec file, with both rpmlint v1
@@ -1981,6 +2010,8 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
                  Group:          System Environment/Base
                  License:        GPL
                 """))
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         # Test error is raised
         with self.assertRaisesRegex(RiftError, "rpmlint reported errors"):
             main(['gitlab', patch.name])
@@ -1999,8 +2030,9 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
             with self.assertRaisesRegex(SystemExit, "2"):
                 main(cmd)
 
+    @patch('rift.package.rpm.Mock')
     @patch('rift.Controller.Review')
-    def test_gerrit(self, mock_review):
+    def test_gerrit(self, mock_review, mock_mock):
         """simple gerrit"""
         self.make_pkg()
         patch = make_temp_file(
@@ -2018,13 +2050,16 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                  Group:          System Environment/Base
                  License:        GPL
                 """))
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         main(['gerrit', '--change', '1', '--patchset', '2', patch.name])
         # Check review has not been invalidated and pushed
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
+    @patch('rift.package.rpm.Mock')
     @patch('rift.Controller.Review')
-    def test_gerrit_review_invalidated(self, mock_review):
+    def test_gerrit_review_invalidated(self, mock_review, mock_mock):
         """gerrit review invalidated"""
         # Make package and inject rpmlint error ($RPM_BUILD_ROOT and
         # RPM_SOURCE_DIR in buildsteps) in RPM spec file, with both rpmlint v1
@@ -2055,6 +2090,8 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                  Group:          System Environment/Base
                  License:        GPL
                 """))
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         main(['gerrit', '--change', '1', '--patchset', '2', patch.name])
         # Check review has been invalidated and pushed
         mock_review.return_value.invalidate.assert_called_once()
@@ -2088,32 +2125,40 @@ class ControllerProjectActionChangelogTest(RiftProjectTestCase):
             "Package 'pkg' directory does not exist"):
             main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself'])
 
-    def test_action_changelog(self):
+    @patch('rift.package.rpm.Mock')
+    def test_action_changelog(self, mock_mock):
         """simple changelog"""
         self.make_pkg()
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         self.assertEqual(
             main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself']), 0)
-        spec = Spec(filepath=self.buildfiles['pkg:rpm'])
-        spec.load()
-        self.assertEqual(spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(spec.version, '1.0')
-        self.assertEqual(spec.release, '1')
+        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg.load()
+        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
+        self.assertEqual(pkg.spec.version, '1.0')
+        self.assertEqual(pkg.spec.release, '1')
 
-    def test_action_changelog_bump(self):
+    @patch('rift.package.rpm.Mock')
+    def test_action_changelog_bump(self, mock_mock):
         """simple changelog with bump"""
         self.make_pkg()
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
         self.assertEqual(
             main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself', '--bump']),
             0)
-        spec = Spec(filepath=self.buildfiles['pkg:rpm'])
-        spec.load()
-        self.assertEqual(spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-2')
-        self.assertEqual(spec.version, '1.0')
-        self.assertEqual(spec.release, '2')
+        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg.load()
+        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-2')
+        self.assertEqual(pkg.spec.version, '1.0')
+        self.assertEqual(pkg.spec.release, '2')
 
-    def test_action_changelog_unknown_maintainer(self):
+    @patch('rift.package.rpm.Mock')
+    def test_action_changelog_unknown_maintainer(self, mock_mock):
         """changelog with unknown maintainer"""
         self.make_pkg()
+        mock_mock.return_value.read_spec = read_file
         with self.assertRaisesRegex(
             RiftError, "Unknown maintainer Fail, cannot be found in staff"
         ):

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -195,3 +195,56 @@ class MockTest(RiftProjectTestCase):
             merge_out_err=True,
             cwd='/'
         )
+
+    @patch('rift.Mock.run_command')
+    def test_read_spec(self, mock_run_command):
+        mock_run_command.return_value = RunResult(
+            0, "standard output", "standard error"
+        )
+        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock.init([])
+        result = mock.read_spec('/dev/package.spec')
+        mock_run_command.assert_called_with(
+            [
+                'mock', '--config-opts', 'print_main_output=yes',
+                f"--configdir={mock._tmpdir.path}",
+                "--plugin-option=bind_mount:dirs="
+                "[('/dev/package.spec', '/dev/package.spec')]",
+                'chroot',
+                'rpmspec',
+                '--parse',
+                '/dev/package.spec'
+            ],
+            live_output=True,
+            capture_output=True,
+            merge_out_err=False,
+            cwd='/'
+        )
+        mock.clean()
+        self.assertEqual(result, "standard output")
+
+    @patch('rift.Mock.run_command')
+    def test_read_spec_exec_error(self, mock_run_command):
+        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        # First run_command call for init OK
+        mock_run_command.return_value = RunResult(
+            0, "standard output", "standard error"
+        )
+        mock.init([])
+        # Second run_command call for rpmspec with non-zero return code
+        mock_run_command.return_value = RunResult(
+            1, "standard output", "standard error"
+        )
+        with self.assertRaisesRegex(RiftError, "standard error"):
+            mock.read_spec('/dev/package.spec')
+        mock.clean()
+
+    @patch('rift.Mock.run_command')
+    def test_read_spec_filter_output(self, mock_run_command):
+        output = "error: foo\nwarning: bar\nstandard output\nsh: baz\nrpm: qux\n"
+        mock_run_command.return_value = RunResult(0, output, "standard error")
+        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock.init([])
+        result = mock.read_spec('/dev/package.spec')
+        mock.clean()
+        self.assertEqual(result, "standard output")

--- a/tests/RPM.py
+++ b/tests/RPM.py
@@ -6,15 +6,18 @@ import time
 import rpm
 import shutil
 import subprocess
+from unittest.mock import MagicMock
 
 from .TestUtils import (
     make_temp_dir,
     gen_rpm_spec,
+    read_file,
     RiftTestCase,
     RiftProjectTestCase,
 )
 from rift import RiftError
 from rift.RPM import Spec, Variable, RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2, RPM, rpmlint_v2
+from rift.Mock import Mock
 
 class SpecTest(RiftTestCase):
     """
@@ -35,8 +38,10 @@ class SpecTest(RiftTestCase):
         self.files = ""
         self.exclusive_arch = None
         self.variants = None
+        self.mock = MagicMock(autospec=Mock)
+        # mock Mock.read_spec to return spec file content directly read on host
+        self.mock.read_spec.side_effect = read_file
         self.update_spec()
-
 
     def update_spec(self):
         with open(self.spec, "w") as spec:
@@ -59,10 +64,9 @@ class SpecTest(RiftTestCase):
         os.unlink(self.spec)
         os.rmdir(self.directory)
 
-
     def test_init(self):
         """ Test Spec instanciation """
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         self.assertIn(self.name, spec.pkgnames)
         self.assertEqual(len(spec.pkgnames), 1)
         self.assertIn(self.name, spec.provides)
@@ -72,16 +76,18 @@ class SpecTest(RiftTestCase):
         self.assertEqual(spec.arch, self.arch)
         self.assertIn("{0}-{1}.tar.gz".format(self.name, self.version), spec.sources)
         self.assertEqual(len(spec.lines), 50)
+        # Check Mock.read_spec() has been called to load spec file.
+        self.mock.read_spec.assert_called_once_with(self.spec)
 
     def test_init_variant(self):
         """ Test Spec instanciation """
         self.variants = ['variant1', 'variant2']
         self.update_spec()
-        spec = Spec(self.spec, variant='variant1')
+        spec = Spec(self.spec, self.mock, None, variant='variant1')
         self.assertIn(self.name, spec.pkgnames)
         self.assertEqual(len(spec.pkgnames), 2)
         self.assertCountEqual(spec.pkgnames, ['pkg', 'pkg-variant1'])
-        spec = Spec(self.spec, variant='variant2')
+        spec = Spec(self.spec, self.mock, None, variant='variant2')
         self.assertIn(self.name, spec.pkgnames)
         self.assertEqual(len(spec.pkgnames), 2)
         self.assertCountEqual(spec.pkgnames, ['pkg', 'pkg-variant2'])
@@ -89,12 +95,12 @@ class SpecTest(RiftTestCase):
     def test_init_fails(self):
         """ Test Spec instanciation with error """
         path = '/nowhere.spec'
-        self.assert_except(RiftError, "{0} does not exist".format(path), Spec, path)
+        self.assert_except(RiftError, "{0} does not exist".format(path), Spec, path, self.mock, None)
 
 
     def test_specfile_check(self):
         """ Test specfile check function """
-        self.assertIsNone(Spec(self.spec).check())
+        self.assertIsNone(Spec(self.spec, self.mock, None).check())
 
 
     def test_specfile_check_with_rpmlint_v1(self):
@@ -105,13 +111,13 @@ class SpecTest(RiftTestCase):
         self.files = "/lib/test"
         self.update_spec()
         with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
-            Spec(self.spec).check()
+            Spec(self.spec, self.mock, None).check()
 
         # Create rpmlint config to ignore hardcoded library path
         rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V1])
         with open(rpmlintfile, "w") as rpmlint:
             rpmlint.write('addFilter("E: hardcoded-library-path")')
-        self.assertIsNone(Spec(self.spec).check())
+        self.assertIsNone(Spec(self.spec, self.mock, None).check())
         os.unlink(rpmlintfile)
 
     def test_specfile_check_with_rpmlint_v2(self):
@@ -122,18 +128,18 @@ class SpecTest(RiftTestCase):
         self.update_spec()
 
         with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
-            Spec(self.spec).check()
+            Spec(self.spec, self.mock, None).check()
 
         # Create rpmlint config file to ignore rpm-buildroot-usage
         rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V2])
         with open(rpmlintfile, "w") as rpmlint:
             rpmlint.write('Filters = ["rpm-buildroot-usage"]')
-        self.assertIsNone(Spec(self.spec).check())
+        self.assertIsNone(Spec(self.spec, self.mock, None).check())
         os.unlink(rpmlintfile)
 
     def test_bump_release(self):
         """ Test bump_release """
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         spec.release = '1'
         spec.bump_release()
         self.assertEqual(spec.release, '2')
@@ -154,7 +160,7 @@ class SpecTest(RiftTestCase):
 
     def test_add_changelog_entry(self):
         """ Test add_changelog_entry """
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         comment = "- New feature"
         userstr = "John Doe"
         date = time.strftime("%a %b %d %Y", time.gmtime())
@@ -168,7 +174,7 @@ class SpecTest(RiftTestCase):
 
     def test_add_changelog_entry_bump(self):
         """ Test add_changelog_entry with bump release"""
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         comment = "- New feature (Bumped)"
         userstr = "John Doe"
         date = time.strftime("%a %b %d %Y", time.gmtime())
@@ -183,7 +189,7 @@ class SpecTest(RiftTestCase):
 
     def test_parse_vars(self):
         """ Test spec variables parsing """
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         self.assertTrue(str(spec.variables['foo']) == '1.%{bar}')
         self.assertTrue(spec.variables['foo'].value == '1.%{bar}')
         self.assertTrue(spec.variables['foo'].name == 'foo')
@@ -195,7 +201,7 @@ class SpecTest(RiftTestCase):
 
     def test_match_var(self):
         """ Tests variable detection in pattern """
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         foo = spec.variables['foo']
         bar = spec.variables['bar']
         self.assertTrue(spec._match_var('%{foo}', r'^1') == foo)
@@ -213,13 +219,13 @@ class SpecTest(RiftTestCase):
         """ Test supports_arch() with ExclusiveArch"""
         self.exclusive_arch = "x86_64"
         self.update_spec()
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         self.assertTrue(spec.supports_arch('x86_64'))
         self.assertFalse(spec.supports_arch('aarch64'))
 
     def test_supports_arch_wo_exclusive_arch(self):
         """ Test supports_arch() without ExclusiveArch"""
-        spec = Spec(self.spec)
+        spec = Spec(self.spec, self.mock, None)
         self.assertTrue(spec.supports_arch('x86_64'))
         self.assertTrue(spec.supports_arch('aarch64'))
 

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -458,6 +458,10 @@ class RiftProjectTestCase(RiftTestCase):
 def gen_rpm_spec(**kwargs):
     return jinja2.Template(SPEC_TPL).render(**kwargs)
 
+def read_file(filepath):
+    """Read a text file and return its content."""
+    return open(filepath).read()
+
 
 #
 # Temp files

--- a/tests/graph.py
+++ b/tests/graph.py
@@ -8,7 +8,8 @@ from unittest.mock import patch
 
 from rift.graph import PackagesDependencyGraph
 from rift.package.rpm import PackageRPM
-from .TestUtils import RiftProjectTestCase, SubPackage
+from .TestUtils import RiftProjectTestCase, SubPackage, read_file
+
 
 class GraphTest(RiftProjectTestCase):
     """
@@ -19,11 +20,14 @@ class GraphTest(RiftProjectTestCase):
         pkg_name = 'fake'
         self.make_pkg(name=pkg_name)
         package = PackageRPM(pkg_name, self.config, self.staff, self.modules)
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         self.assertEqual(len(graph.nodes), 1)
         build_requirements = graph.solve(package)
         self.assertEqual(len(build_requirements), 1)
@@ -44,11 +48,14 @@ class GraphTest(RiftProjectTestCase):
         os.unlink(packages['failed'].metafile)
         # Build packages graph
         with self.assertLogs(level='WARNING') as cm:
-            graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
-            )
+            # mock Mock.read_spec to return spec file content directly read on host
+            with patch('rift.package.rpm.Mock') as mock_mock:
+                mock_mock.return_value.read_spec = read_file
+                graph = PackagesDependencyGraph.from_project(
+                    self.config,
+                    self.staff,
+                    self.modules
+                )
         # Check warning message has been emitted
         self.assertEqual(
             cm.output,
@@ -76,11 +83,14 @@ class GraphTest(RiftProjectTestCase):
             fh.write("invalid content")
         # Build packages graph
         with self.assertLogs(level='WARNING') as cm:
-            graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
-            )
+            # mock Mock.read_spec to return spec file content directly read on host
+            with patch('rift.package.rpm.Mock') as mock_mock:
+                mock_mock.return_value.read_spec = read_file
+                graph = PackagesDependencyGraph.from_project(
+                    self.config,
+                    self.staff,
+                    self.modules
+                )
         # Check warning message has been emitted
         self.assertEqual(
             cm.output,
@@ -98,11 +108,14 @@ class GraphTest(RiftProjectTestCase):
         """ Test graph dump """
         pkg_name = 'fake'
         self.make_pkg(name=pkg_name)
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         with self.assertLogs(level='INFO') as cm:
             graph.dump()
         self.assertEqual(
@@ -119,11 +132,14 @@ class GraphTest(RiftProjectTestCase):
         """ Test solve with package not in graph """
         pkg_name = 'one'
         self.make_pkg(name=pkg_name)
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         package = PackageRPM('another', self.config, self.staff, self.modules)
         build_requirements = graph.solve(package)
         self.assertEqual(len(build_requirements), 0)
@@ -149,11 +165,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         # Load graph
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         self.assertEqual(len(graph.nodes), 3)
 
         # Rebuild of my-software does not trigger rebuild of other packages.
@@ -228,11 +247,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         def load_graph():
-            graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
-            )
+            # mock Mock.read_spec to return spec file content directly read on host
+            with patch('rift.package.rpm.Mock') as mock_mock:
+                mock_mock.return_value.read_spec = read_file
+                graph = PackagesDependencyGraph.from_project(
+                    self.config,
+                    self.staff,
+                    self.modules
+                )
             self.assertEqual(len(graph.nodes), 3)
             return graph
 
@@ -328,11 +350,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         def load_graph():
-            graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
-            )
+            # mock Mock.read_spec to return spec file content directly read on host
+            with patch('rift.package.rpm.Mock') as mock_mock:
+                mock_mock.return_value.read_spec = read_file
+                graph = PackagesDependencyGraph.from_project(
+                    self.config,
+                    self.staff,
+                    self.modules
+                )
             self.assertEqual(len(graph.nodes), 2)
             return graph
 
@@ -377,11 +402,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         # Load graph
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         self.assertEqual(len(graph.nodes), 3)
 
         # For all three package, the resolution should return all three
@@ -416,11 +444,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         # Load graph
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         graph.draw(False, [])  # w/o external deps
         output = mock_stdout.getvalue()
 
@@ -456,11 +487,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         # Load graph
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         graph.draw(False, ['libone'])  # only libone and its deps
         output = mock_stdout.getvalue()
 
@@ -501,11 +535,14 @@ class GraphTest(RiftProjectTestCase):
         )
 
         # Load graph
-        graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules
-        )
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            graph = PackagesDependencyGraph.from_project(
+                self.config,
+                self.staff,
+                self.modules
+            )
         graph.draw(True, [])  # w/ external deps
         output = mock_stdout.getvalue()
 

--- a/tests/package/rpm.py
+++ b/tests/package/rpm.py
@@ -13,7 +13,9 @@ from rift.TestResults import TestResults
 from rift.Config import _DEFAULT_VARIANT
 from rift.Gerrit import Review
 
-from ..TestUtils import RiftProjectTestCase, PackageTestDef, make_temp_file, gen_rpm_spec
+from ..TestUtils import (
+    RiftProjectTestCase, PackageTestDef, make_temp_file, gen_rpm_spec, read_file
+)
 
 
 class PackageRPMTest(RiftProjectTestCase):
@@ -60,7 +62,10 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         self.assertEqual(pkg.rpmnames, [ 'pkg', 'pkg-devel' ])
         self.assertEqual(pkg.ignore_rpms, [ 'pkg-debuginfos' ])
         self.assertCountEqual(pkg.variants, ['variant1', 'variant2'])
@@ -92,7 +97,9 @@ class PackageRPMTest(RiftProjectTestCase):
         with open(os.path.join(sources_dir, "pkg-1.0.tar.gz"), 'w+') as fh:
             fh.write("data")
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec.return_value = open(spec_file.name).read()
+            pkg.load(infopath = pkgfile.name)
         pkg.check()
 
     def test_check_missing_source(self):
@@ -117,7 +124,10 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         with self.assertRaisesRegex(RiftError,
             r'Missing source file\(s\): pkg-1.0.tar.gz'):
             pkg.check()
@@ -151,7 +161,10 @@ class PackageRPMTest(RiftProjectTestCase):
         with open(os.path.join(sources_dir, 'unused-1.0.tar.gz'), 'w+') as fh:
             fh.write("data")
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         with self.assertRaisesRegex(RiftError,
             r'Unused source file\(s\): unused-1.0.tar.gz'):
             pkg.check()
@@ -160,14 +173,20 @@ class PackageRPMTest(RiftProjectTestCase):
         """ Test PackageRPM.subpackages() returns list of provides """
         self.make_pkg()
         pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
-        pkg.load()
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load()
         self.assertCountEqual(pkg.subpackages(), ['pkg', 'pkg-provide'])
 
     def test_build_requires(self):
         """ Test PackageRPM.build_requires() returns list of build requirements """
         self.make_pkg()
         pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
-        pkg.load()
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load()
         self.assertCountEqual(pkg.build_requires(), ['br-package'])
 
     def test_build_requires_explicit_versions(self):
@@ -179,7 +198,10 @@ class PackageRPMTest(RiftProjectTestCase):
             build_requires=['lib1-devel', 'lib2-devel >= 3.4', 'lib3-devel < 6.0.0']
         )
         pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
-        pkg.load()
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load()
         self.assertCountEqual(
             pkg.build_requires(), ['lib1-devel', 'lib2-devel', 'lib3-devel']
         )
@@ -206,9 +228,14 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         pkg.add_changelog_entry("Myself", "Package modification", False)
-        pkg.spec.load()
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         self.assertEqual(pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1")
 
     def test_add_changelog_entry_bump(self):
@@ -233,9 +260,14 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         pkg.add_changelog_entry("Myself", "Package modification", True)
-        pkg.spec.load()
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         self.assertEqual(pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-2")
 
     def test_add_changelog_entry_unknown_maintainer(self):
@@ -260,7 +292,10 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         with self.assertRaisesRegex(
             RiftError, "Unknown maintainer Unknown, cannot be found in staff"
         ):
@@ -302,7 +337,10 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         self.assertTrue(pkg.supports_arch('x86_64'))
         self.assertFalse(pkg.supports_arch('aarch64'))
 
@@ -327,7 +365,10 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         self.assertTrue(pkg.supports_arch('x86_64'))
         self.assertTrue(pkg.supports_arch('aarch64'))
 
@@ -353,7 +394,10 @@ class PackageRPMTest(RiftProjectTestCase):
             suffix='.spec'
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         review = Mock(spec=Review)
         pkg.analyze(review, pkg.dir)
         review.invalidate.assert_not_called()
@@ -383,7 +427,10 @@ class PackageRPMTest(RiftProjectTestCase):
             suffix='.spec'
         )
         pkg.buildfile = spec_file.name
-        pkg.load(infopath = pkgfile.name)
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            pkg.load(infopath = pkgfile.name)
         review = Mock(spec=Review)
         pkg.analyze(review, pkg.dir)
         review.invalidate.assert_called_once()
@@ -408,8 +455,12 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
     def setup_package(self, variants=None, tests=None):
         self.make_pkg(variants=variants, tests=tests)
         _pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
-        _pkg.load()
+        # mock Mock.read_spec to return spec file content directly read on host
+        with patch('rift.package.rpm.Mock') as mock_mock:
+            mock_mock.return_value.read_spec = read_file
+            _pkg.load()
         self.pkg = ActionableArchPackageRPM(_pkg, 'x86_64')
+        self.pkg.mock.read_spec = read_file
 
     @patch('rift.package.rpm.message')
     @patch('rift.package.rpm.Mock.build_rpms')
@@ -490,9 +541,13 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
             )
             mock_message.assert_any_call(f"Building RPMS variant {variant}...")
 
+    @patch('rift.package.rpm.Mock.clean')
+    @patch('rift.package.rpm.Mock.init')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
-    def test_test_local(self, mock_vm, mock_time_sleep):
+    def test_test_local(
+        self, mock_vm, mock_time_sleep, mock_mock_init, mock_mock_clean
+    ):
         """ Test ActionableArchPackageRPM local test """
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
@@ -512,11 +567,15 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # Check VM is stopped after the tests
         mock_vm_obj.stop.assert_called_once()
 
+    @patch('rift.package.rpm.Mock.clean')
+    @patch('rift.package.rpm.Mock.init')
     @patch('rift.package.rpm.banner')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
-    def test_test_vm(self, mock_vm, mock_time_sleep, mock_banner):
-        """ Test ActionableArchPackageRPM test in VM"""
+    def test_test_vm(
+        self, mock_vm, mock_time_sleep, mock_banner, mock_mock_init, mock_mock_clean
+    ):
+        """ Test ActionableArchPackageRPM test in VM """
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -539,11 +598,15 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
             'Starting tests of package pkg on architecture x86_64'
         )
 
+    @patch('rift.package.rpm.Mock.clean')
+    @patch('rift.package.rpm.Mock.init')
     @patch('rift.package.rpm.banner')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
-    def test_test_staging(self, mock_vm, mock_time_sleep, mock_banner):
-        """ Test ActionableArchPackageRPM test """
+    def test_test_staging(
+        self, mock_vm, mock_time_sleep, mock_banner, mock_mock_init, mock_mock_clean
+    ):
+        """ Test ActionableArchPackageRPM test with staging repository """
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -567,6 +630,8 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
             'Starting tests of package pkg on architecture x86_64'
         )
 
+    @patch('rift.package.rpm.Mock.clean')
+    @patch('rift.package.rpm.Mock.init')
     @patch('rift.package.rpm.banner')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
@@ -574,9 +639,11 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         self,
         mock_vm,
         mock_time_sleep,
-        mock_banner
+        mock_banner,
+        mock_mock_init,
+        mock_mock_clean,
     ):
-        """ Test ActionableArchPackageRPM test """
+        """ Test ActionableArchPackageRPM test with multiple variants """
         variants = ['variant1', 'variant2']
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
@@ -622,6 +689,9 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         mock_vm_obj.running.return_value = False
         mock_vm_obj.run_test.return_value = RunResult(1, None, None)
         self.setup_package()
+        # mock Mock.read_spec() so BasicTest can extract rpm packages from spec file
+        self.pkg.mock = Mock()
+        self.pkg.mock.read_spec.return_value = open(self.buildfiles['pkg:rpm']).read()
         results = self.pkg.test()
         self.assertIsInstance(results, TestResults)
         self.assertEqual(len(results), 2)
@@ -648,6 +718,9 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         mock_vm_obj.running.return_value = False
         mock_vm_obj.run_test.return_value = RunResult(0, None, None)
         self.setup_package()
+        # mock Mock.read_spec() so BasicTest can extract rpm packages from spec file
+        self.pkg.mock = Mock()
+        self.pkg.mock.read_spec.return_value = open(self.buildfiles['pkg:rpm']).read()
         self.pkg.test(noquit=True)
         # Check VM is NOT stopped after the tests
         mock_vm_obj.stop.assert_not_called()

--- a/tests/repository/rpm.py
+++ b/tests/repository/rpm.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from unittest.mock import Mock, call, patch
 
-from ..TestUtils import make_temp_dir, RiftTestCase
+from ..TestUtils import make_temp_dir, read_file, RiftTestCase
 from rift.repository.rpm import (
     ConsumableRepository,
     LocalRepository,
@@ -17,15 +17,18 @@ from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS, Config
 from rift.RPM import RPM
 from rift import RiftError
 
+
 class LocalRepositoryTest(RiftTestCase):
     """
     Tests class for Repository
     """
+    def setUp(self):
+        self.config = Config()
 
     def test_init(self):
         """ Test LocalRepository instanciation with a specific configuration """
         arch = 'x86_64'
-        _config = { 'arch': [arch], 'createrepo': 'mycustom_create_repo' }
+        self.config.update({ 'arch': [arch], 'createrepo': 'mycustom_create_repo' })
         _options = {
             'module_hotfixes': True,
             'excludepkgs': 'somepkg',
@@ -34,7 +37,7 @@ class LocalRepositoryTest(RiftTestCase):
         repo_name = 'nowhere'
         repo = LocalRepository(
             '/{}'.format(repo_name),
-            _config,
+            self.config,
             options=_options
         )
 
@@ -52,14 +55,14 @@ class LocalRepositoryTest(RiftTestCase):
         self.assertEqual(repo.consumables[arch].module_hotfixes, True)
         self.assertEqual(repo.consumables[arch].excludepkgs, 'somepkg')
         self.assertEqual(repo.consumables[arch].proxy, 'myproxy')
-        self.assertEqual(repo.createrepo, _config['createrepo'])
+        self.assertEqual(repo.createrepo, self.config.get('createrepo'))
 
     def test_init_multiple_archs(self):
         """ Test LocalRepository instanciation with multiple architectures """
         archs = ['x86_64', 'aarch64']
-        _config = { 'arch': archs }
+        self.config.update({ 'arch': archs })
         repo_name = 'nowhere'
-        repo = LocalRepository('/{}'.format(repo_name), _config)
+        repo = LocalRepository('/{}'.format(repo_name), self.config)
 
         self.assertEqual(repo.createrepo, _DEFAULT_REPO_CMD)
         self.assertEqual(list(repo.consumables.keys()), archs)
@@ -75,10 +78,10 @@ class LocalRepositoryTest(RiftTestCase):
     def test_init_rpms_dir(self):
         """ Test LocalRepository rpm_dirs """
         archs = ['x86_64', 'aarch64']
-        _config = { 'arch': archs }
+        self.config.update({ 'arch': archs })
         repo_name = 'nowhere'
         path = f"/{repo_name}"
-        repo = LocalRepository(path, _config)
+        repo = LocalRepository(path, self.config)
 
         self.assertEqual(repo.rpms_dir(archs[0]), os.path.join(path, archs[0]))
         self.assertEqual(repo.rpms_dir(archs[1]), os.path.join(path, archs[1]))
@@ -95,9 +98,9 @@ class LocalRepositoryTest(RiftTestCase):
         # Emulate successful createrepo execution
         mock_popen.return_value.__enter__.return_value.returncode = 0
         arch = 'x86_64'
-        _config = { 'arch': [arch] }
+        self.config.update({ 'arch': [arch] })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
         repo.create()
         self.assertTrue(os.path.exists(repo.srpms_dir))
         self.assertTrue(os.path.exists(repo.rpms_dir(arch)))
@@ -110,9 +113,9 @@ class LocalRepositoryTest(RiftTestCase):
         mock_popen.return_value.__enter__.return_value.returncode = 1
         mock_popen.return_value.__enter__.return_value.communicate.return_value = ["output"]
         arch = 'x86_64'
-        _config = { 'arch': [arch] }
+        self.config.update({ 'arch': [arch] })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
         with self.assertRaisesRegex(RiftError, '^output$'):
             repo.create()
         shutil.rmtree(local_repo_path)
@@ -123,9 +126,9 @@ class LocalRepositoryTest(RiftTestCase):
         # Emulate successful createrepo execution
         mock_popen.return_value.__enter__.return_value.returncode = 0
         arch = 'x86_64'
-        _config = { 'arch': [arch] }
+        self.config.update({ 'arch': [arch] })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
         repo.create()  # create() calls update()
         # createrepo must have been executed twice, one for SRPMS and the other
         # for x86_64.
@@ -142,9 +145,9 @@ class LocalRepositoryTest(RiftTestCase):
         # Emulate createrepo execution failure
         mock_popen.return_value.__enter__.return_value.returncode = 0
         arch = 'x86_64'
-        _config = { 'arch': [arch] }
+        self.config.update({ 'arch': [arch] })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
         repo.create()
         mock_popen.return_value.__enter__.return_value.returncode = 1
         mock_popen.return_value.__enter__.return_value.communicate.return_value = ["output"]
@@ -176,9 +179,9 @@ class LocalRepositoryTest(RiftTestCase):
     def test_add(self):
         """ Test LocalRepository add """
         archs = ['x86_64', 'aarch64']
-        _config = { 'arch': archs }
+        self.config.update({ 'arch': archs })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
 
         # Create repository and add packages
         repo.create()
@@ -205,16 +208,20 @@ class LocalRepositoryTest(RiftTestCase):
 
         shutil.rmtree(local_repo_path)
 
-    def test_search(self):
+    @patch('rift.repository.rpm.Mock')
+    def test_search(self, mock_mock):
         """Test search packages on a repository"""
         archs = ['x86_64', 'aarch64']
-        _config = { 'arch': archs }
+        self.config.update({ 'arch': archs })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
 
         # Create repository and add packages
         repo.create()
         (src_rpm, bin_rpm) = self._add_packages(repo)
+
+        # mock Mock.read_spec() to read spec file on host directly
+        mock_mock.return_value.read_spec = read_file
 
         # Test multiple search in repository
 
@@ -246,16 +253,20 @@ class LocalRepositoryTest(RiftTestCase):
         # Cleanup temporary repository
         shutil.rmtree(local_repo_path)
 
-    def test_delete(self):
+    @patch('rift.repository.rpm.Mock')
+    def test_delete(self, mock_mock):
         """Test delete packages on a repository"""
         archs = ['x86_64', 'aarch64']
-        _config = { 'arch': archs }
+        self.config.update({ 'arch': archs })
         local_repo_path = make_temp_dir()
-        repo = LocalRepository(local_repo_path, _config)
+        repo = LocalRepository(local_repo_path, self.config)
 
         # Create repository and add packages
         repo.create()
         (src_rpm, bin_rpm) = self._add_packages(repo)
+
+        # mock Mock.read_spec() to read spec file on host directly
+        mock_mock.return_value.read_spec = read_file
 
         # Search and retrieve packages from repo
         pkgs = repo.search('pkg')


### PR DESCRIPTION
Instead of loading RPM spec file directly on host with RPM library, run rpmspec in Mock's chroot (with host CPU architecture) to interpret RPM spec file in all targeted environment macros. The interpreted output of rpmspec is then parsed RPM library on host.

This way, macros are expanded in targeted chroot and behavior is consistent in all hosts environments.

The main drawback is execution time. Running rpmspec with mock in the chroot takes order of magnitude more time than reading the file with RPM library. Operations such as graph and query are largely impacted.

For this reason, many tests are updated to skip Mock init + rpmspec execution in order to avoid a surge in unit tests execution time and amount of downloaded data.