### PR TITLE
Build architectures in parallel threads

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -51,12 +51,12 @@ from rift.package import ProjectPackages
 from rift.repository import ProjectArchRepositories, StagingRepository
 from rift.graph import PackagesDependencyGraph
 from rift.RPM import RPM, Spec
-from rift.TempDir import TempDir
 from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
 from rift.VM import VM
 from rift.sync import RepoSyncFactory
 from rift.patches import get_packages_from_patch
+from rift.threads import RiftThread
 from rift.utils import message, banner
 
 
@@ -643,6 +643,28 @@ def build_pkgs(args, pkgs, arch, staging):
 
     return results
 
+def build_architecture(config, args, pkgs, arch):
+    """Build pkgs for a specific architecture and return results."""
+
+    results = TestResults(f"build-{arch}")
+
+    # Create temporary staging repository to hold dependencies unless
+    # dependency tracking is disabled in project configuration or user set
+    # --skip-deps argument.
+    staging = None
+    if config.get('dependency_tracking') and not args.skip_deps:
+        staging = StagingRepository(config)
+
+    results.extend(build_pkgs(args, pkgs, arch, staging))
+
+    if staging:
+        staging.delete()
+
+    banner(f"All packages processed for architecture {arch}")
+
+    return results
+
+
 def action_build(args, config):
     """Action for 'build' command."""
 
@@ -664,30 +686,38 @@ def action_build(args, config):
         str([pkg.name for pkg in pkgs])
     )
 
-    # Build all packages for all project supported architectures
+    # List of build threads
+    threads = []
+
+    # Create parallel threads to build all packages for all project supported
+    # architectures.
     for arch in config.get('arch'):
+        threads.append(
+            RiftThread(
+                build_architecture, f"build-{arch}", args=(config, args, pkgs, arch)
+            )
+        )
 
-        # Create temporary staging repository to hold dependencies unless
-        # dependency tracking is disabled in project configuration or user set
-        # --skip-deps argument.
-        staging = None
-        if config.get('dependency_tracking') and not args.skip_deps:
-            staging = StagingRepository(config)
+    # Start all threads
+    for thread in threads:
+        message(f"Starting build thread {thread.name}")
+        thread.start()
 
-        results.extend(build_pkgs(args, pkgs, arch, staging))
-
-        if getattr(args, 'junit', False):
-            logging.info('Writing test results in %s', args.junit)
-            results.junit(args.junit)
-
-        if staging:
-            staging.delete()
-        banner(f"All packages processed for architecture {arch}")
+    # Wait for all threads to finish
+    for thread in threads:
+        thread.join()
+        results.extend(thread.results)
+        banner(f"Build thread {thread.name} output:")
+        print(thread.output.getvalue(), end='')
 
     banner('All architectures processed')
 
     if len(results) > 1:
         print(results.summary())
+
+    if getattr(args, 'junit', False):
+        logging.info('Writing test results in %s', args.junit)
+        results.junit(args.junit)
 
     if not results.global_result:
         return 2
@@ -765,16 +795,31 @@ def action_validate(args, config):
         "Ordered list of packages to validate: %s",
         str([pkg.name for pkg in pkgs])
     )
-    # Validate packages on all project supported architectures
+
+    # List of validate threads
+    threads = []
+
+    # Create parallel threads to validate packages on all project supported
+    # architectures.
     for arch in config.get('arch'):
-        results.extend(
-            validate_pkgs(
-                config,
-                args,
-                pkgs,
-                arch
+        threads.append(
+            RiftThread(
+                validate_pkgs, f"validate-{arch}", args=(config, args, pkgs, arch)
             )
         )
+
+    # Start all threads
+    for thread in threads:
+        message(f"Starting validate thread {thread.name}")
+        thread.start()
+
+    # Wait for all threads to finish
+    for thread in threads:
+        thread.join()
+        results.extend(thread.results)
+        banner(f"Validate thread {thread.name} output:")
+        print(thread.output.getvalue(), end='')
+
     banner('All packages checked on all architectures')
 
     if getattr(args, 'junit', False):
@@ -803,10 +848,30 @@ def action_validdiff(args, config):
         args.patch, config=config, modules=modules, staff=staff
     )
     results = TestResults('validate')
-    # Re-validate all updated packages for all architectures supported by the
-    # project.
+
+    # List of validate threads
+    threads = []
+
+    # Create parallel threads to re-validate all updated packages for all
+    # architectures supported by the project.
     for arch in config.get('arch'):
-        results.extend(validate_pkgs(config, args, updated, arch))
+        threads.append(
+            RiftThread(
+                validate_pkgs, f"validate-{arch}", args=(config, args, updated, arch)
+            )
+        )
+
+    # Start all threads
+    for thread in threads:
+        message(f"Starting validate thread {thread.name}")
+        thread.start()
+
+    # Wait for all threads to finish
+    for thread in threads:
+        thread.join()
+        results.extend(thread.results)
+        banner(f"Validate thread {thread.name} output:")
+        print(thread.output.getvalue(), end='')
 
     if getattr(args, 'junit', False):
         logging.info('Writing test results in %s', args.junit)

--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -50,6 +50,7 @@ import rpm
 from rift import RiftError
 from rift.annex import Annex, is_binary
 from rift.Config import _DEFAULT_VARIANT
+from rift.run import run_command
 import rift.utils
 
 RPMLINT_CONFIG_V1 = 'rpmlint'
@@ -493,10 +494,9 @@ class Spec():
                 raise RiftError(msg)
 
         cmd, env = self._check(configdir)
-        with Popen(cmd, stderr=PIPE, env=env, universal_newlines=True) as popen:
-            stderr = popen.communicate()[1]
-            if popen.returncode != 0:
-                raise RiftError(stderr or 'rpmlint reported errors')
+        proc = run_command(cmd, capture_output=True)
+        if proc.returncode:
+            raise RiftError(proc.err or 'rpmlint reported errors')
 
     def analyze(self, review, configdir=None):
         """Run `rpmlint' for this specfile and fill provided `review'."""

--- a/lib/rift/repository/rpm.py
+++ b/lib/rift/repository/rpm.py
@@ -38,6 +38,7 @@ import os
 import logging
 import shutil
 import glob
+import threading
 from subprocess import Popen, PIPE, STDOUT, run, CalledProcessError
 
 from rift import RiftError
@@ -45,6 +46,8 @@ from rift.repository._base import ArchRepositoriesBase, StagingRepositoryBase
 from rift.RPM import RPM, Spec
 from rift.TempDir import TempDir
 from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS
+
+repo_lock = threading.Lock()
 
 class ConsumableRepository:
     """
@@ -149,13 +152,19 @@ class LocalRepository:
         """
         # Create main repository directory and the SRPM sub-directory.
         for path in (self.path, self.srpms_dir):
-            if not os.path.exists(path):
-                os.mkdir(path)
+            # Add lock to avoid race condition between arch build threads on
+            # existence test and mkdir().
+            with repo_lock:
+                if not os.path.exists(path):
+                    os.mkdir(path)
         # Create all architectures RPM sub-directories and their repodata.
         for arch in self.config.get('arch'):
             path = self.rpms_dir(arch)
-            if not os.path.exists(path):
-                os.mkdir(path)
+            # Add lock to avoid race condition between arch build threads on
+            # existence test and mkdir().
+            with repo_lock:
+                if not os.path.exists(path):
+                    os.mkdir(path)
         self.update()
 
     def update(self):
@@ -164,15 +173,17 @@ class LocalRepository:
         architectures RPMS repositories.
         """
         def run_update(path):
-            with Popen(
-                [self.createrepo, '-q', '--update', path],
-                stdout=PIPE,
-                stderr=STDOUT,
-                universal_newlines=True,
-            ) as popen:
-                stdout = popen.communicate()[0]
-                if popen.returncode != 0:
-                    raise RiftError(stdout)
+            # Add lock to avoid conflicts between parallel runs of createrepo.
+            with repo_lock:
+                with Popen(
+                    [self.createrepo, '-q', '--update', path],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    universal_newlines=True,
+                ) as popen:
+                    stdout = popen.communicate()[0]
+                    if popen.returncode != 0:
+                        raise RiftError(stdout)
 
         run_update(self.srpms_dir)
         for arch in self.config.get('arch'):

--- a/lib/rift/run.py
+++ b/lib/rift/run.py
@@ -45,16 +45,27 @@ RunResult = collections.namedtuple(
     'RunResult', ['returncode', 'out', 'err']
 )
 
-def _handle_process_output(process, live_output, buf_out, buf_err):
+def _handle_process_output(process, capture_output, live_output, merge_out_err):
     """Handle process output until it is terminated."""
+
+    buf_out = buf_err = None
+    # Initialize string buffers to store process output in memory
+    if capture_output:
+        buf_out = io.StringIO()
+        if merge_out_err:
+            buf_err = buf_out
+        else:
+            buf_err = io.StringIO()
 
     # Process output lines handlers
     def handle_stdout_line(line):
-        buf_out.write(line)
+        if capture_output:
+            buf_out.write(line)
         if live_output:
             sys.stdout.write(line)
     def handle_stderr_line(line):
-        buf_err.write(line)
+        if capture_output:
+            buf_err.write(line)
         if live_output:
             sys.stderr.write(line)
 
@@ -90,6 +101,9 @@ def _handle_process_output(process, live_output, buf_out, buf_err):
     # Ensure process is terminated
     process.wait()
 
+    return buf_out, buf_err
+
+
 def run_command(
         cmd,
         live_output=True,
@@ -108,10 +122,8 @@ def run_command(
     Initially based on:
     https://gist.github.com/nawatts/e2cdca610463200c12eac2a14efc0bfb
     """
-    if capture_output:
+    if capture_output or live_output:
         channel = subprocess.PIPE
-    elif live_output:
-        channel = None
     else:
         channel = subprocess.DEVNULL
 
@@ -127,21 +139,16 @@ def run_command(
         **kwargs
     ) as process:
 
-        # If capture is disabled, just return the command result with the return
-        # code and None values for output.
-        if not capture_output:
-            return RunResult(process.wait(), None, None)
+        if capture_output or live_output:
+            # Handle process output
+            buf_out, buf_err = _handle_process_output(
+                process, capture_output, live_output, merge_out_err
+            )
 
-        # Initialize string buffers to store process output in memory
-        buf_out = io.StringIO()
-        buf_err = None
-        if merge_out_err:
-            buf_err = buf_out
-        else:
-            buf_err = io.StringIO()
-
-        # Handle process output
-        _handle_process_output(process, live_output, buf_out, buf_err)
+    # If capture is disabled, just return the command result with the return
+    # code and None values for output.
+    if not capture_output:
+        return RunResult(process.wait(), None, None)
 
     # Get values for out/err buffers and close them
     out = buf_out.getvalue()

--- a/lib/rift/threads.py
+++ b/lib/rift/threads.py
@@ -1,0 +1,140 @@
+#
+# Copyright (C) 2026 CEA
+#
+# This file is part of Rift project.
+#
+# This software is governed by the CeCILL license under French law and
+# abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# "http://www.cecill.info".
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# In this respect, the user's attention is drawn to the risks associated
+# with loading,  using,  modifying and/or developing or reproducing the
+# software by the user in light of its specific status of free software,
+# that may mean  that it is complicated to manipulate,  and  that  also
+# therefore means  that it is reserved for developers  and  experienced
+# professionals having in-depth computer knowledge. Users are therefore
+# encouraged to load and test the software's suitability as regards their
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
+# same conditions as regards security.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+#
+
+"""Threads classes and utilities to build for architectures in parallel."""
+
+import sys
+import threading
+import contextlib
+import traceback
+import io
+
+from rift.TestResults import TestResults
+
+
+# Python provides standards context managers contextlib.redirect_{stdout,stderr}
+# but they are not thread-safe unfortunately. For redirecting threads
+# stdout/stderr in a buffer, Rift uses a combination of:
+#
+# - stdout/stderr proxy that tries to use thread local stream before fallback to
+#   default process stdout/stderr
+# - thread-safe context manager which sets up a thread local stream.
+
+class _ThreadLocalStream:
+    """Rift stdout/stderr proxies, to support threads local buffering."""
+    def __init__(self, default):
+        # Store the original global stream (real sys.stdout / sys.stderr)
+        self._default = default
+
+        # Thread-local storage: each thread gets its own independent "stream"
+        self.local = threading.local()
+
+    def write(self, data):
+        """
+        Write data to stream. First look up the stream for the current thread.
+        If none is set, fall back to the original global stream.
+        """
+        stream = getattr(self.local, "stream", self._default)
+
+        # Delegate the write to the selected stream
+        stream.write(data)
+
+    def flush(self):
+        """
+        Flush stream. First look up the stream for the current thread. If none
+        is set, fall back to the original global stream.
+        """
+        stream = getattr(self.local, "stream", self._default)
+
+        # Delegate flush to that stream
+        stream.flush()
+
+
+def _install_proxy():
+    """Install stdout/stderr proxies if not installed yet."""
+    if not isinstance(sys.stdout, _ThreadLocalStream):
+        sys.stdout = _ThreadLocalStream(sys.stdout)
+
+    if not isinstance(sys.stderr, _ThreadLocalStream):
+        sys.stderr = _ThreadLocalStream(sys.stderr)
+
+
+# Install stdout/stderr proxies at import time so logging handlers can use them
+# as soon as they are initialized.
+_install_proxy()
+
+
+@contextlib.contextmanager
+def redirect_output_threadsafe(output):
+    """
+    Temporarily redirect stdout and/or stderr for the current thread only.
+
+    Unlike contextlib.redirect_stdout, this does NOT modify global sys.stdout.
+    Instead, it sets a thread-local override used by our proxy streams.
+    """
+
+    # Make sure stdout/stderr proxies are installed
+    _install_proxy()
+
+    # Set provided output stream for local thread
+    sys.stdout.local.stream = sys.stderr.local.stream = output
+
+    try:
+        # Execute the block with redirected output
+        yield
+    finally:
+        # Remove thread local attributes to fall back to default stdout/stderr
+        del sys.stdout.local.stream
+        del sys.stderr.local.stream
+
+
+class RiftThread(threading.Thread):
+    """Base thread for Rift parallel processing"""
+    def __init__(self, target, name, args):
+        # Initializing the Thread class
+        super().__init__(None, target, name, args=args)
+        self.output = io.StringIO()   # output buffer, for stdout/stderr
+        self.results = TestResults()  # build/validate tests results
+
+    def run(self):
+        """
+        Run the thread target and bufferize its stdout/stderr in output attribute.
+        """
+        with redirect_output_threadsafe(self.output):
+            try:
+                self.results = self._target(*self._args)
+            except Exception:
+                # Avoid threading.Thread to catch the Exception and report the
+                # stacktrace out of thread buffered output. Force print of
+                # exception in sys.stderr here to make it land in thread local
+                # buffer.
+                traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
This commit introduces automatic threading of build and validate actions (including validdiff in CI) so various architectures are processed in parallel. This helps reducing whole running time when project supports multiple architectures.

New threads module has been introduced to save threads output into buffer. This way, build output is printed when threads are terminated. This prevents multiplexing of all parallel threads output in the terminal and helps diagnosis on build failure.

The run module has been updated to redirect subcommands output to current process stdin/stdout stream as soon as live output is enabled, not only when output capture is enabled. Some commands that generally produce output have been converted from raw Popen to run_command wrapper to allow buffering.

Some locks have been introduced in repository handling to avoid race conditions when creating directory layout and potential conflict when running createrepo simultanously.