### PR TITLE
Package: move local test logic out of VM class

### DIFF
--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -629,49 +629,47 @@ class VM():
         termios.tcsetattr(self_stdin, termios.TCSANOW, old)
         return retcode
 
+    def local_test_funcs(self):
+        """
+        Return dict of shell functions that could be useful for local tests
+        running on hosts for handling this VM.
+        """
+        return {
+            'cm_cmd': (
+                "ssh -oUserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no "
+                f"-oLogLevel=ERROR -T -p {self.port} root@127.0.0.1 \"$@\""
+            ),
+            'vm_wait': textwrap.dedent("""\
+                rc=1
+                for i in {1..7}
+                do
+                sleep 5
+                echo -n .
+                vm_cmd echo -e '\\\\nConnection is OK' && rc=0 && break
+                done
+                return $rc\
+                """
+            ),
+            'vm_reboot': textwrap.dedent("""\
+                echo -n 'Restarting VM...'
+                vm_cmd 'reboot' || true; sleep 5 && vm_wait || return 1\
+                """
+            )
+        }
 
     def run_test(self, test, variant):
         """
-        Run specified test using this VM.
-
-        If test is local, it is run on local host, if not, it is run inside the
-        VM.
+        Run specified test inside the VM.
         """
-        funcs = {}
-        funcs['vm_cmd'] = (
-            "ssh -oUserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no "
-            f"-oLogLevel=ERROR -T -p {self.port} root@127.0.0.1 \"$@\""
-        )
-        funcs['vm_wait'] = textwrap.dedent("""\
-            rc=1
-            for i in {1..7}
-            do
-              sleep 5
-              echo -n .
-              vm_cmd echo -e '\\\\nConnection is OK' && rc=0 && break
-            done
-            return $rc""")
-        funcs['vm_reboot'] = textwrap.dedent("""\
-            echo -n 'Restarting VM...'
-            vm_cmd 'reboot' || true; sleep 5 && vm_wait || return 1""")
-
         # Set environment variable for package variant to allow conditionals
         # in test scripts.
         cmd = f"export RIFT_VARIANT={variant}; "
-        if not test.local:
-            if test.command.startswith(self._project_dir):
-                testcmd = test.command[len(self._project_dir) + 1:]
-            else:
-                testcmd = test.command
-            cmd += f"cd {self._PROJ_MOUNTPOINT}; {testcmd}"
-            return self.cmd(cmd, capture_output=True)
-
-        for func, code in funcs.items():
-            cmd += f"{func}() {{ {code}; }}; export -f {func}; "
-        cmd += shlex.quote(test.command)
-
-        logging.debug("Running command outside VM: %s", cmd)
-        return run_command(cmd, capture_output=True, shell=True)
+        if test.command.startswith(self._project_dir):
+            testcmd = test.command[len(self._project_dir) + 1:]
+        else:
+            testcmd = test.command
+        cmd += f"cd {self._PROJ_MOUNTPOINT}; {testcmd}"
+        return self.cmd(cmd, capture_output=True)
 
     def running(self):
         """Check if VM is already running."""

--- a/lib/rift/package/_base.py
+++ b/lib/rift/package/_base.py
@@ -39,11 +39,13 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
+import shlex
 import yaml
 
 from rift import RiftError
 from rift.Config import OrderedLoader
 from rift.utils import message
+from rift.run import run_command
 from rift.repository import ProjectArchRepositories
 
 _META_FILE = 'info.yaml'
@@ -310,6 +312,22 @@ class ActionableArchPackage(ABC):
     @abstractmethod
     def test(self, **kwargs):
         """Test package. Must be overriden in concrete format classes."""
+
+    def run_local_test(self, test, funcs=None):
+        """
+        Run a test command on local host. Dict of shell functions can be
+        provided. Shell will be initialized with these functions before running
+        the test.
+        """
+        cmd = ''
+        if not funcs:
+            funcs = {}
+        for func, code in funcs.items():
+            cmd += f"{func}() {{ {code}; }}; export -f {func}; "
+        cmd += shlex.quote(test.command)
+
+        logging.debug("Running local test command %s", cmd)
+        return run_command(cmd, capture_output=True, shell=True)
 
     @abstractmethod
     def publish(self, **kwargs):

--- a/lib/rift/package/rpm.py
+++ b/lib/rift/package/rpm.py
@@ -279,7 +279,10 @@ class ActionableArchPackageRPM(ActionableArchPackage):
                 )
                 now = time.time()
                 message(f"Running test '{case.fullname}' on architecture '{self.arch}'")
-                proc = vm.run_test(test, variant)
+                if test.local:
+                    proc = self.run_local_test(test, vm.local_test_funcs())
+                else:
+                    proc = vm.run_test(test, variant)
                 if proc.returncode == 0:
                     results.add_success(
                         case, time.time() - now, out=proc.out, err=proc.err

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -621,6 +621,12 @@ class VMTest(RiftTestCase):
         vm.ready.assert_not_called()
         vm.prepare.assert_not_called()
 
+    def test_local_test_funcs(self):
+        vm = VM(self.config, platform.machine())
+        funcs = vm.local_test_funcs()
+        self.assertIsInstance(funcs, dict)
+        self.assertCountEqual(funcs.keys(), ['cm_cmd', 'vm_wait', 'vm_reboot'])
+
     @patch('rift.VM.run_command')
     def test_run_test(self, mock_run_command):
         vm = VM(self.config, platform.machine())

--- a/tests/package/base.py
+++ b/tests/package/base.py
@@ -3,6 +3,7 @@
 #
 import os
 import textwrap
+from unittest.mock import patch
 
 from rift import RiftError
 from rift.package import Package
@@ -173,6 +174,42 @@ class ActionableArchPackageTest(RiftProjectTestCase):
 
     def test_init_concrete(self):
         ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+
+    @patch('rift.package._base.run_command')
+    def test_run_local_test(self, mock_run_command):
+        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        command = make_temp_file(
+            textwrap.dedent("""\
+                #!/bin/sh
+                /bin/true
+                """),
+            suffix='.sh'
+        )
+        test = Test(command.name)
+        actionable_pkg.run_local_test(test)
+        mock_run_command.assert_called_once_with(
+            command.name, capture_output=True, shell=True)
+
+    @patch('rift.package._base.run_command')
+    def test_run_local_test_with_funcs(self, mock_run_command):
+        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        command = make_temp_file(
+            textwrap.dedent("""\
+                #!/bin/sh
+                /bin/true
+                """),
+            suffix='.sh'
+        )
+        test = Test(command.name)
+        actionable_pkg.run_local_test(test, { 'hey': 'echo hey!'})
+        mock_run_command.assert_called_once_with(
+            f"hey() {{ echo hey!; }}; export -f hey; {command.name}",
+            capture_output=True, shell=True)
+
+    def test_clean(self):
+        """ Test clean method no-op on abstract class """
+        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        actionable_pkg.clean()
 
 
 class TestTest(RiftProjectTestCase):

--- a/tests/package/rpm.py
+++ b/tests/package/rpm.py
@@ -1,7 +1,7 @@
 #
 # Copyright (C) 2025 CEA
 #
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, ANY
 import os
 import textwrap
 
@@ -490,27 +490,48 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
             )
             mock_message.assert_any_call(f"Building RPMS variant {variant}...")
 
-    @patch('rift.package.rpm.banner')
-    @patch('rift.package.rpm.BasicTest')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
-    def test_test(self, mock_vm, mock_time_sleep, mock_basic_test, mock_banner):
-        """ Test ActionableArchPackageRPM test """
+    def test_test_local(self, mock_vm, mock_time_sleep):
+        """ Test ActionableArchPackageRPM local test """
+        # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
+        mock_vm_obj = mock_vm.return_value
+        mock_vm_obj.running.return_value = False
+        mock_vm_obj.run_test.return_value = RunResult(0, None, None)
+        self.setup_package(tests=[PackageTestDef(name='0_test.sh', local=True)])
+        self.pkg.run_local_test = Mock(return_value=RunResult(0, None, None))
+        results = self.pkg.test()
+        self.assertIsInstance(results, TestResults)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results.global_result, True)
+        # Check run_local_test() has been called once for local dummy test
+        self.pkg.run_local_test.assert_called_once()
+        # Check vm.run_test has been called once for basic test
+        mock_vm_obj.run_test.assert_called_once_with(ANY, _DEFAULT_VARIANT)
+        # Check VM is stopped after the tests
+        mock_vm_obj.stop.assert_called_once()
+
+    @patch('rift.package.rpm.banner')
+    @patch('rift.package.rpm.time.sleep')
+    @patch('rift.package.rpm.VM')
+    def test_test_vm(self, mock_vm, mock_time_sleep, mock_banner):
+        """ Test ActionableArchPackageRPM test in VM"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
         mock_vm_obj.run_test.return_value = RunResult(0, None, None)
         self.setup_package(tests=[])
+        self.pkg.run_local_test = Mock(return_value=RunResult(0, None, None))
         results = self.pkg.test()
         self.assertIsInstance(results, TestResults)
         self.assertEqual(len(results), 1)
         self.assertEqual(results.global_result, True)
+        # Check run_local_test() has not been called.
+        self.pkg.run_local_test.assert_not_called()
         # Check VM initialized (w/o extra repository)
         mock_vm.assert_called_once_with(self.config, 'x86_64', extra_repos=[])
         # Check VM run_test() called once for basic test
-        mock_vm_obj.run_test.assert_called_with(
-            mock_basic_test.return_value, _DEFAULT_VARIANT
-        )
+        mock_vm_obj.run_test.assert_called_once_with(ANY, _DEFAULT_VARIANT)
         # Check VM is stopped after the tests
         mock_vm_obj.stop.assert_called_once()
         mock_banner.assert_called_once_with(
@@ -518,10 +539,9 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         )
 
     @patch('rift.package.rpm.banner')
-    @patch('rift.package.rpm.BasicTest')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
-    def test_test_staging(self, mock_vm, mock_time_sleep, mock_basic_test, mock_banner):
+    def test_test_staging(self, mock_vm, mock_time_sleep, mock_banner):
         """ Test ActionableArchPackageRPM test """
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
@@ -547,14 +567,12 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         )
 
     @patch('rift.package.rpm.banner')
-    @patch('rift.package.rpm.BasicTest')
     @patch('rift.package.rpm.time.sleep')
     @patch('rift.package.rpm.VM')
-    def test_test_multiple_variants(
+    def test_test_vm_multiple_variants(
         self,
         mock_vm,
         mock_time_sleep,
-        mock_basic_test,
         mock_banner
     ):
         """ Test ActionableArchPackageRPM test """
@@ -570,9 +588,12 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # test), ie. 4 results
         self.assertEqual(len(results), 4)
         self.assertEqual(results.global_result, True)
-        # Check VM run_test() called for basic test on all variants
+        # Check VM run_test() has been called 4 times, for autotest + dummy and
+        # 2 variants each.
+        self.assertEqual(mock_vm_obj.run_test.call_count, 4)
+        # Check VM run_test() called test on all variants
         for variant in variants:
-            mock_vm_obj.run_test.assert_any_call(mock_basic_test.return_value, variant)
+            mock_vm_obj.run_test.assert_any_call(ANY, variant)
             mock_banner.assert_any_call(
                 f"Starting tests of package pkg variant {variant} on architecture "
                 "x86_64"


### PR DESCRIPTION
VM.run_test() was responsible of running local tests, designed to be executed on host. The responsability has been transfered to ActionableArchPackage class because this need is shared by all supported packages formats. The VM class is now only responsible to provide the dict of shell functions with utilities to handle the VM in the tests.