### PR TITLE
Test: marker to restrict to specific formats

### DIFF
--- a/lib/rift/package/_base.py
+++ b/lib/rift/package/_base.py
@@ -40,6 +40,7 @@ import os
 from abc import ABC, abstractmethod
 
 import shlex
+import re
 import yaml
 
 from rift import RiftError
@@ -264,7 +265,10 @@ class Package(ABC):
         """An iterator over Test objects for each test files."""
         testspattern = os.path.join(self.testsdir, '*.sh')
         for testpath in glob.glob(testspattern):
-            yield Test(testpath)
+            test = Test(testpath)
+            # Skip the test if restricted to other specific package formats.
+            if not test.formats or self.format in test.formats:
+                yield test
 
     def add_changelog_entry(self, maintainer, comment, bump):
         """Must be implemented in concrete children classes when supported."""
@@ -344,15 +348,17 @@ class Test():
     """
     Wrapper around test scripts or test commands.
 
-    It analyzes if test script is flagged as local one or if it should be run
-    inside the VM.
+    It analyzes if test script is flagged as local one or restricted to
+    specific package formats.
     """
 
     _LOCAL_PATTERN = '*** RIFT LOCAL ***'
+    _FORMAT_PATTERN = r'\*\*\* RIFT FORMAT (\S+) \*\*\*'
 
     def __init__(self, command, name=None):
         self.command = command
         self.local = False
+        self.formats = []
         self.name = name
         if os.path.exists(self.command):
             self.name = name or os.path.splitext(os.path.basename(command))[0]
@@ -360,11 +366,19 @@ class Test():
 
     def _analyze(self, blocksize=4096):
         """
-        Look for special LOCAL PATTERN in file header and flag the file
-        accordingly.
+        Look for special patterns (local or format restrictions) in file header
+        and flag the test accordingly.
         """
         with open(self.command, 'rt', encoding='utf-8') as ftest:
             data = ftest.read(blocksize)
             if self._LOCAL_PATTERN in data:
                 logging.debug("Test '%s' detected as local", self.name)
                 self.local = True
+            self.formats = re.findall(self._FORMAT_PATTERN, data)
+            # Log debug message if the test is restricted to specific package
+            # formats.
+            if self.formats:
+                logging.debug(
+                    "Test '%s' restricted to specific formats: %s",
+                    self.name, ', '.join(self.formats)
+                )

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -156,7 +156,7 @@ Description for package {{ name }} variant %{variant}
 """
 
 SubPackage = namedtuple("SubPackage", ["name"])
-PackageTestDef = namedtuple("PackageTestDef", ["name", "local"])
+PackageTestDef = namedtuple("PackageTestDef", ["name", "local", "formats"])
 
 
 class RiftTestCase(unittest.TestCase):
@@ -389,7 +389,7 @@ class RiftProjectTestCase(RiftTestCase):
         # Add dummy test ./tests/0_test.sh by default
         if tests is None:
             tests = [
-                PackageTestDef(name='0_test.sh', local=False)
+                PackageTestDef(name='0_test.sh', local=False, formats=[])
             ]
 
         # ./tests
@@ -406,6 +406,8 @@ class RiftProjectTestCase(RiftTestCase):
                 fh.write('#!/bin/sh\n')
                 if test.local:
                     fh.write('# *** RIFT LOCAL ***\n')
+                for _format in test.formats:
+                    fh.write(f"# *** RIFT FORMAT {_format} ***\n")
                 fh.write('true')
 
     def clean_mock_environments(self):

--- a/tests/package/base.py
+++ b/tests/package/base.py
@@ -14,7 +14,7 @@ from rift.package._base import (
     ActionableArchPackage,
     Test,
 )
-from ..TestUtils import RiftProjectTestCase, make_temp_file
+from ..TestUtils import RiftProjectTestCase, PackageTestDef, make_temp_file
 from rift.Gerrit import Review
 
 
@@ -126,6 +126,28 @@ class PackageTest(RiftProjectTestCase):
         self.assertIsInstance(tests[0], Test)
         self.assertEqual(tests[0].name, '0_test')
 
+    def test_tests_format(self):
+        """ Test Package tests method with formats restriction in tests """
+        self.make_pkg(
+            tests=[
+                PackageTestDef(name='0_test.sh', local=False, formats=[]),
+                PackageTestDef(name='1_test.sh', local=False,
+                    formats=['rpm', 'other']),
+                PackageTestDef(name='2_test.sh', local=False,
+                    formats=['other']),
+            ]
+        )
+        pkg = PackageTestingConcrete(
+            'pkg', self.config, self.staff, self.modules, 'rpm'
+        )
+        pkg.load()
+        tests = [test for test in pkg.tests()]
+        self.assertEqual(len(tests), 2)
+        for test in tests:
+            self.assertIsInstance(test, Test)
+        self.assertCountEqual(
+            [test.name for test in tests], ['0_test', '1_test'])
+
     def test_subpackages(self):
         """ Test Package subpackages (dummy implementation) """
         pkg = PackageTestingConcrete(
@@ -226,6 +248,7 @@ class TestTest(RiftProjectTestCase):
         test = Test(command.name)
         self.assertEqual(test.command, command.name)
         self.assertFalse(test.local)
+        self.assertCountEqual(test.formats, [])
         self.assertEqual(
             test.name, os.path.splitext(os.path.basename(command.name))[0])
 
@@ -244,5 +267,47 @@ class TestTest(RiftProjectTestCase):
         with self.assertLogs(level='DEBUG') as logs:
             test = Test(command.name)
         self.assertTrue(test.local)
+        self.assertCountEqual(test.formats, [])
         self.assertIn(
             f"DEBUG:root:Test '{test.name}' detected as local", logs.output)
+
+    def test_one_format(self):
+        """ Test with analyzed command restricted to one format """
+        command = make_temp_file(
+            textwrap.dedent("""\
+                #!/bin/sh
+                #
+                # *** RIFT FORMAT rpm ***
+                #
+                /bin/true
+                """),
+            suffix='.sh'
+        )
+        with self.assertLogs(level='DEBUG') as logs:
+            test = Test(command.name)
+        self.assertCountEqual(test.formats, ['rpm'])
+        self.assertIn(
+            f"DEBUG:root:Test '{test.name}' restricted to specific formats: "
+            "rpm",
+            logs.output)
+
+    def test_multiple_formats(self):
+        """ Test with analyzed command restricted to multiple formats """
+        command = make_temp_file(
+            textwrap.dedent("""\
+                #!/bin/sh
+                #
+                # *** RIFT FORMAT rpm ***
+                # *** RIFT FORMAT other ***
+                #
+                /bin/true
+                """),
+            suffix='.sh'
+        )
+        with self.assertLogs(level='DEBUG') as logs:
+            test = Test(command.name)
+        self.assertCountEqual(test.formats, ['rpm', 'other'])
+        self.assertIn(
+            f"DEBUG:root:Test '{test.name}' restricted to specific formats:"
+             " rpm, other",
+             logs.output)

--- a/tests/package/rpm.py
+++ b/tests/package/rpm.py
@@ -498,7 +498,8 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
         mock_vm_obj.run_test.return_value = RunResult(0, None, None)
-        self.setup_package(tests=[PackageTestDef(name='0_test.sh', local=True)])
+        self.setup_package(
+            tests=[PackageTestDef(name='0_test.sh', local=True, formats=[])])
         self.pkg.run_local_test = Mock(return_value=RunResult(0, None, None))
         results = self.pkg.test()
         self.assertIsInstance(results, TestResults)


### PR DESCRIPTION
Similarly to local tests, it is now possible to add markers in test headers to restrict the test to specific package formats.