### PR TITLE
Controller: add build --formats CLI argument

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -47,7 +47,7 @@ from rift.annex import Annex, is_binary, is_pointer
 from rift.Config import Config, Staff, Modules, _DEFAULT_VARIANT
 from rift.Gerrit import Review
 from rift.auth import Auth
-from rift.package import ProjectPackages
+from rift.package import RIFT_SUPPORTED_FORMATS, ProjectPackages
 from rift.repository import ProjectArchRepositories, StagingRepository
 from rift.graph import PackagesDependencyGraph
 from rift.RPM import RPM, Spec
@@ -134,6 +134,9 @@ def make_parser():
                         help='write junit result file')
     subprs.add_argument('--dont-update-repo', dest='updaterepo', action='store_false',
                         help='do not update repository metadata when publishing a package')
+    subprs.add_argument('-F', '--formats', nargs='+',
+                        choices=RIFT_SUPPORTED_FORMATS,
+                        help='restrict build to specific package formats')
 
     # Sign options
     subprs = subparsers.add_parser('sign', help='Sign RPM package with GPG key.')
@@ -596,6 +599,16 @@ def build_pkgs(args, pkgs, arch, staging):
     results = TestResults()
 
     for pkg in pkgs:
+
+        # Skip package if format is not selected by user
+        if args.formats and pkg.format not in args.formats:
+            logging.info(
+                "Skipping build of %s package %s due to restriction on package "
+                "formats",
+                pkg.format, pkg.name
+            )
+            continue
+
         # Load package and report possible failure
         case = TestCase('build', pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
         now = time.time()

--- a/lib/rift/package/__init__.py
+++ b/lib/rift/package/__init__.py
@@ -31,5 +31,5 @@
 #
 
 """Module to handle packages in different formats."""
-from rift.package._base import Package, Test
+from rift.package._base import RIFT_SUPPORTED_FORMATS, Package, Test
 from rift.package._project import ProjectPackages

--- a/lib/rift/package/_base.py
+++ b/lib/rift/package/_base.py
@@ -55,7 +55,7 @@ _DOC_FILES = ['README', 'README.md', 'README.rst', 'README.txt']
 
 
 # Rift supported package formats
-RIFT_SUPPORTED_FORMATS = ('_virtual', 'rpm',)
+RIFT_SUPPORTED_FORMATS = ('rpm',)
 
 
 class Package(ABC):
@@ -70,8 +70,9 @@ class Package(ABC):
         self._staff = staff
         self._modules = modules
         self.name = name
-        # check package format
-        if _format not in RIFT_SUPPORTED_FORMATS:
+        # Check package format. Allow special _virtual format to handle
+        # unexisting package (typically package being removed).
+        if _format not in RIFT_SUPPORTED_FORMATS + ('_virtual',):
             raise RiftError(f"Unsupported package format {_format}")
         self.format = _format
 

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -474,6 +474,42 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         shutil.rmtree(working_repo)
         atexit.unregister(shutil.rmtree)
 
+    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    def test_action_build_formats(self, mock_pkg_rpm):
+
+        # Declare supported archs.
+        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.update_project_conf()
+
+        # Create fake package without build requirement
+        self.make_pkg(build_requires=[])
+
+        # Get PackageRPM instances mock
+        mock_pkg_rpm_objs = mock_pkg_rpm.return_value
+        # Initialize PackageRPM object attributes
+        PackageRPM.__init__(
+            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+        # Make PackageRPM.supports_arch() return True for all archs
+        mock_pkg_rpm_objs.supports_arch.return_value = True
+
+        # Mock ActionableArchPackageRPM objects
+        mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
+        mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
+
+        self.assertEqual(
+            main(['build', 'pkg', '--formats', 'rpm']), 0)
+
+        # Check RPM package supports_arch() method is called for all supported
+        # archs.
+        for arch in self.config.get('arch'):
+            mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
+
+        # Check actionable RPM package build(), publish() and clean() methods
+        # are called for all supported arch (ie. twice).
+        mock_act_arch_pkg_rpm.build.assert_has_calls(
+            [call(sign=False, staging=None), call(sign=False, staging=None)])
+        mock_act_arch_pkg_rpm.clean.assert_has_calls([call(), call()])
+
     def test_action_build_publish_functional(self):
         """Functional RPM build and publish test"""
         # Declare supported archs and check qemu-user-static is available for
@@ -2093,6 +2129,22 @@ class ControllerArgumentsTest(RiftTestCase):
         parser = make_parser()
         opts = parser.parse_args(args)
         self.assertFalse(opts.updaterepo)
+
+    def test_parse_args_build(self):
+        """ Test build command options parsing """
+        parser = make_parser()
+
+        args = ['build']
+        opts = parser.parse_args(args)
+        self.assertIsNone(opts.formats)
+
+        args = ['build', '--formats', 'rpm']
+        opts = parser.parse_args(args)
+        self.assertCountEqual(opts.formats, ['rpm'])
+
+        args = ['build', '--formats', 'fail']
+        with self.assertRaises(SystemExit):
+            opts = parser.parse_args(args)
 
     def test_make_parser_vm(self):
         """ Test vm command options parsing """


### PR DESCRIPTION
This new command line option allows restricting build action to specific package formats, which could be useful when packages supports multiple formats.