### PR TITLE
Controller: add test --formats CLI argument

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -153,6 +153,9 @@ def make_parser():
                         help='do not run auto tests')
     subprs.add_argument('--junit', metavar='FILENAME',
                         help='write junit result file')
+    subprs.add_argument('-F', '--formats', nargs='+',
+                        choices=RIFT_SUPPORTED_FORMATS,
+                        help='restrict tests to specific package formats')
 
     # Validate options
     subprs = subparsers.add_parser('validate', help='Fully validate package')
@@ -757,6 +760,15 @@ def action_test(args, config):
 
     for arch in config.get('arch'):
         for pkg in ProjectPackages.list(config, staff, modules, args.packages):
+
+            # Skip package if format is not selected by user
+            if args.formats and pkg.format not in args.formats:
+                logging.info(
+                    "Skipping tests %s package %s due to restriction on "
+                    "package formats",
+                    pkg.format, pkg.name
+                )
+                continue
 
             # Load package and report possible failure
             now = time.time()

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -735,6 +735,44 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
              call(noauto=False, noquit=False)])
 
     @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    def test_action_test_formats(self, mock_pkg_rpm):
+
+        # Declare supported archs.
+        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.update_project_conf()
+
+        # Create fake package without build requirement
+        self.make_pkg(build_requires=[])
+
+        # Get PackageRPM instances mock
+        mock_pkg_rpm_objs = mock_pkg_rpm.return_value
+        # Initialize PackageRPM object attributes
+        PackageRPM.__init__(
+            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+        # Make PackageRPM.supports_arch() return True for all archs
+        mock_pkg_rpm_objs.supports_arch.return_value = True
+        # Mock ActionableArchPackageRPM objects
+        mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
+        mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
+        # Make ActionableArchPackageRPM.test() return empty but successful test
+        # results.
+        mock_act_arch_pkg_rpm.test.return_value = TestResults()
+
+        # Run test on package
+        self.assertEqual(main(['test', 'pkg', '--formats', 'rpm']), 0)
+
+        # Check RPM package supports_arch() method is called for all supported
+        # archs.
+        for arch in self.config.get('arch'):
+            mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
+
+        # Check actionable RPM package test() method is called for all
+        # supported arch (ie. twice).
+        mock_act_arch_pkg_rpm.test.assert_has_calls(
+            [call(noauto=False, noquit=False),
+             call(noauto=False, noquit=False)])
+
+    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
     def test_action_test_load_failure(self, mock_pkg_rpm):
 
         # Create fake package without build requirement
@@ -2143,6 +2181,22 @@ class ControllerArgumentsTest(RiftTestCase):
         self.assertCountEqual(opts.formats, ['rpm'])
 
         args = ['build', '--formats', 'fail']
+        with self.assertRaises(SystemExit):
+            opts = parser.parse_args(args)
+
+    def test_parse_args_test(self):
+        """ Test test command options parsing """
+        parser = make_parser()
+
+        args = ['test']
+        opts = parser.parse_args(args)
+        self.assertIsNone(opts.formats)
+
+        args = ['test', '--formats', 'rpm']
+        opts = parser.parse_args(args)
+        self.assertCountEqual(opts.formats, ['rpm'])
+
+        args = ['test', '--formats', 'fail']
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 


### PR DESCRIPTION
This new command line option allows restricting test action to specific package formats, which could be useful when packages supports multiple formats.