### PR TITLE
VM: fix regression in vm connect display

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -581,7 +581,7 @@ def action_vm(args, config):
         raise RiftError(f"Project does not support architecture '{args.arch}'")
     vm = VM(config, args.arch)
     if args.vm_cmd == 'connect':
-        ret = vm.cmd(options=None).returncode
+        ret = vm.cmd(options=None, manage_output=False).returncode
     elif args.vm_cmd == 'console':
         ret = vm.console()
     elif args.vm_cmd == 'cmd':

--- a/lib/rift/run.py
+++ b/lib/rift/run.py
@@ -109,6 +109,7 @@ def run_command(
         live_output=True,
         capture_output=False,
         merge_out_err=False,
+        manage_output=True,
         **kwargs
     ):
     """
@@ -122,7 +123,9 @@ def run_command(
     Initially based on:
     https://gist.github.com/nawatts/e2cdca610463200c12eac2a14efc0bfb
     """
-    if capture_output or live_output:
+    if not manage_output:
+        channel = None
+    elif capture_output or live_output:
         channel = subprocess.PIPE
     else:
         channel = subprocess.DEVNULL
@@ -139,7 +142,7 @@ def run_command(
         **kwargs
     ) as process:
 
-        if capture_output or live_output:
+        if manage_output and (capture_output or live_output):
             # Handle process output
             buf_out, buf_err = _handle_process_output(
                 process, capture_output, live_output, merge_out_err

--- a/tests/run.py
+++ b/tests/run.py
@@ -40,6 +40,18 @@ class RunTest(RiftTestCase):
         # Standard output must also be streamed into current process stdout.
         self.assertEqual(mock_stdout.getvalue(), "output_data\n")
 
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_run_command_stdout(self, mock_stdout):
+        """ Test run_command() with standard output. """
+        proc = run_command(["/bin/echo", "output_data"])
+        # Standard output must be available in out attribute of RunResult named
+        # tuple.
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNone(proc.out)
+        self.assertIsNone(proc.err)
+        # Standard output must also be streamed into current process stdout.
+        self.assertEqual(mock_stdout.getvalue(), "output_data\n")
+
     @patch('sys.stderr', new_callable=StringIO)
     def test_run_command_capture_stderr(self, mock_stderr):
         """ Test run_command() with captured standard error. """
@@ -82,6 +94,16 @@ class RunTest(RiftTestCase):
         """ Test run_command() without live output. """
         # With live_output disabled, standard output and standard error must not
         # be redirected in current process stdout.
-        proc = run_command(["/bin/echo", "output_data"], live_output=False)
+        run_command(["/bin/echo", "output_data"], live_output=False)
         self.assertEqual(mock_stdout.getvalue(), "")
         self.assertEqual(mock_stderr.getvalue(), "")
+
+    def test_run_command_dont_manage_output(self):
+        """ Test run_command() with manage_output disabled. """
+        proc = run_command(["/bin/echo", "output_data"], manage_output=False)
+        self.assertEqual(proc.returncode, 0)
+        # Child stdout/stderr inherit OS fds 1 and 2; that is not the same as
+        # Python's sys.stdout/sys.stderr, so stream content cannot be asserted
+        # here.
+        self.assertIsNone(proc.out)
+        self.assertIsNone(proc.err)


### PR DESCRIPTION
Fix regression introduced 1826f46 that breaks display in vm connect due to default handling of SSH subcommand stdout/stderr streams. This is fixed by introducing manage_output boolean flag (True by default) on run_command() to disable handling of subcommand output when False. This new option is explicitely set to False for vm connect.