### PR TITLE
RPM: run rpmlint in Mock chroot

### DIFF
--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -42,6 +42,8 @@ import getpass
 import logging
 import threading
 from contextlib import contextmanager
+import shlex
+from textwrap import dedent
 from jinja2 import Template
 
 from rift import RiftError
@@ -54,6 +56,50 @@ from rift.Config import _DEFAULT_VARIANT
 _mock_chroot_locks = {}
 # Mutex to serialize access to _mock_chroot_locks dictionary.
 _mock_chroot_global_mutex = threading.Lock()
+
+RPMLINT_CONFIG_V1 = 'rpmlint'
+RPMLINT_CONFIG_V2 = 'rpmlint.toml'
+
+
+def rpmlint_env(configdir=None):
+    """
+    Return a copy of the process environment with XDG_CONFIG_HOME set when
+    configdir is set (rpmlint config next to the spec uses that layout).
+    Otherwise return None (caller inherits the current environment).
+    """
+    if not configdir:
+        return None
+    env = os.environ.copy()
+    env['XDG_CONFIG_HOME'] = os.path.realpath(configdir)
+    return env
+
+
+def rpmlint_chroot_script(spec_filepath):
+    """
+    Return a shell script for ``bash -c`` that runs rpmlint with v1- or v2-style
+    argv depending on whether ``rpmlint --version`` looks like major version 2.
+    """
+    spec_dir = os.path.dirname(spec_filepath)
+    q_spec = shlex.quote(spec_filepath)
+    q_run_v1 = (
+        f"rpmlint -o 'NetworkEnabled False' -f "
+        f"{shlex.quote(os.path.join(spec_dir, RPMLINT_CONFIG_V1))} {q_spec}"
+    )
+    config_v2 = os.path.join(spec_dir, RPMLINT_CONFIG_V2)
+    if os.path.exists(config_v2):
+        q_run_v2 = f"rpmlint -c {shlex.quote(config_v2)} {q_spec}"
+    else:
+        q_run_v2 = f"rpmlint {q_spec}"
+    return dedent(f"""
+        set +e
+        VERLINE=$(rpmlint --version 2>/dev/null | head -1)
+        if echo "$VERLINE" | grep -q '^2'; then
+            {q_run_v2}
+        else
+            {q_run_v1}
+        fi
+        exit $?
+    """).strip()
 
 
 class Mock():
@@ -137,9 +183,8 @@ class Mock():
         already initialized.
         """
 
-        # If _tmpdir is already defined (ie. _init_tmp_conf() has already been
-        # called), do nothing.
-        if self._tmpdir is not None:
+        # Skip only when tmpdir exists and still has a path (not after clean()).
+        if self._tmpdir is not None and self._tmpdir.path is not None:
             return
 
         # Set empty repolist by default.
@@ -217,19 +262,26 @@ class Mock():
         self._init_tmp_conf(repolist)
         self._exec(['--init'])
 
+    def _bind_mount_dirs_opt(self, paths):
+        """Return mock bind_mount plugin option for dirs (host path = chroot path)."""
+        unique = sorted({os.path.realpath(p) for p in paths})
+        pairs = ",".join(f"('{p}', '{p}')" for p in unique)
+        return f'--plugin-option=bind_mount:dirs=[{pairs}]'
+
     def read_spec(self, filepath):
         """
         Interpret RPM spec file in chroot by running rpmspec command. Return output of
         rpmspec command with some prefixed messages filtered out to make it parsable
         by RPM library.
         """
+        filepath_rp = os.path.realpath(filepath)
         proc = self._exec(
             [
-                f"--plugin-option=bind_mount:dirs=[('{filepath}', '{filepath}')]",
+                self._bind_mount_dirs_opt([filepath_rp]),
                 'chroot',
                 'rpmspec',
                 '--parse',
-                filepath
+                filepath_rp
             ],
             merge_out_err=False
         )
@@ -248,6 +300,55 @@ class Mock():
 
         return "\n".join(lines)
 
+    def rpmlint(self, spec_filepath, configdir=None):
+        """
+        Install rpmlint in the chroot, run rpmlint on spec file in chroot, then
+        clean the chroot. Return RunResult of rpmlint command.
+        """
+        spec_fp = os.path.realpath(spec_filepath)
+        spec_dir = os.path.dirname(spec_fp)
+        mount_paths = {spec_dir}
+        if configdir:
+            mount_paths.add(os.path.realpath(configdir))
+        bind_opt = self._bind_mount_dirs_opt(mount_paths)
+
+        # Install rpmlint in the chroot.
+        self._exec(
+            [
+                '--no-clean',
+                '--no-cleanup-after',
+                '--quiet',
+                '--pm-cmd',
+                'install',
+                '-y',
+                'rpmlint',
+            ]
+        )
+
+        # Run rpmlint in the chroot. The self._exec() method is not used here
+        # because callers need return code and output of rpmlint command.
+        cmd = self._mock_base() + [
+            bind_opt,
+            '--quiet',
+            'chroot',
+            '--',
+            'bash',
+            '-c',
+            rpmlint_chroot_script(spec_fp),
+        ]
+        logging.debug('Running mock rpmlint chroot: %s', ' '.join(cmd[:8]))
+        try:
+            return run_command(
+                cmd,
+                capture_output=True,
+                merge_out_err=False,
+                cwd='/',
+                env=rpmlint_env(configdir),
+            )
+        finally:
+            # Clean the chroot to remove rpmlint.
+            self._exec(['--quiet', '--clean'])
+
     def resultrpms(self, pattern='*.rpm', sources=True):
         """
         Iterate over built RPMS matching `pattern' in mock result directory.
@@ -260,7 +361,11 @@ class Mock():
 
     def clean(self):
         """Clean temporary files and RPMS created for this instance."""
-        self._tmpdir.delete()
+        if self._tmpdir:
+            self._tmpdir.delete()
+            # Clear handle to avoid later init() skipping _init_tmp_conf()
+            # and mock seeing --configdir=None.
+            self._tmpdir = None
         for rpm in self.resultrpms():
             os.unlink(rpm.filepath)
 

--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -51,11 +51,7 @@ import rpm
 from rift import RiftError
 from rift.annex import Annex, is_binary
 from rift.Config import _DEFAULT_VARIANT
-from rift.run import run_command
 import rift.utils
-
-RPMLINT_CONFIG_V1 = 'rpmlint'
-RPMLINT_CONFIG_V2 = 'rpmlint.toml'
 
 
 def _header_values(values):
@@ -65,18 +61,6 @@ def _header_values(values):
     if isinstance(values, bytes):
         return values.decode("utf8")
     return str(values)
-
-
-def rpmlint_v2():
-    """Return True if rpmlint major version is 2."""
-    # check --version output
-    try:
-        proc = run(['rpmlint', '--version'], stdout=PIPE, check=True)
-    except CalledProcessError as err:
-        raise RiftError(
-            f"Unable to get rpmlint version: {str(err)}"
-        ) from err
-    return proc.stdout.decode().startswith("2")
 
 
 class RPM():
@@ -466,26 +450,6 @@ class Spec():
 
         return RPM(os.path.join(destdir, self.srpmname))
 
-    def _check(self, configdir=None):
-        if configdir:
-            env = os.environ.copy()
-            env['XDG_CONFIG_HOME'] = configdir
-        else:
-            env = None
-
-        if rpmlint_v2():
-            cmd = ['rpmlint', self.filepath]
-            config = os.path.join(os.path.dirname(self.filepath), RPMLINT_CONFIG_V2)
-            if os.path.exists(config):
-                cmd[1:1] = ['-c', config]
-        else:
-            # rpmlint v1. Does not fail when config file is missing.
-            cmd = ['rpmlint', '-o', 'NetworkEnabled False', '-f',
-                os.path.join(os.path.dirname(self.filepath), RPMLINT_CONFIG_V1),
-                self.filepath]
-        logging.debug('Running rpmlint: %s', ' '.join(cmd))
-        return cmd, env
-
     def check(self, pkg=None):
         """
         Check specfile content using `rpmlint' tool and check missing items
@@ -510,19 +474,27 @@ class Spec():
                 msg = f"Missing source file(s): {' '.join(set(self.sources) - pkg.sources)}"
                 raise RiftError(msg)
 
-        cmd, env = self._check(configdir)
-        proc = run_command(cmd, capture_output=True)
+        with self.mock.lock():
+            try:
+                self.mock.init(self.repos)
+                proc = self.mock.rpmlint(self.filepath, configdir)
+            finally:
+                self.mock.clean()
         if proc.returncode:
             raise RiftError(proc.err or 'rpmlint reported errors')
 
     def analyze(self, review, configdir=None):
         """Run `rpmlint' for this specfile and fill provided `review'."""
-        cmd, env = self._check(configdir)
-        with Popen(cmd, stdout=PIPE, stderr=PIPE, env=env, universal_newlines=True) as popen:
-            stdout, stderr = popen.communicate()
-            if popen.returncode not in (0, 64, 66):
-                raise RiftError(stderr or f"rpmlint returned {popen.returncode}")
+        with self.mock.lock():
+            try:
+                self.mock.init(self.repos)
+                proc = self.mock.rpmlint(self.filepath, configdir)
+            finally:
+                self.mock.clean()
+        if proc.returncode not in (0, 64, 66):
+            raise RiftError(proc.err or f"rpmlint returned {proc.returncode}")
 
+        stdout = proc.out or ''
         for line in stdout.splitlines():
             if line.startswith(self.filepath + ':'):
                 line = line[len(self.filepath + ':'):]
@@ -537,7 +509,7 @@ class Spec():
                 except (ValueError, KeyError):
                     pass
 
-        if popen.returncode != 0:
+        if proc.returncode != 0:
             review.invalidate()
 
     def supports_arch(self, arch):

--- a/lib/rift/patches.py
+++ b/lib/rift/patches.py
@@ -39,7 +39,7 @@ import logging
 from unidiff import parse_unidiff
 from rift import RiftError
 from rift.package import ProjectPackages
-from rift.RPM import RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2
+from rift.Mock import RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2
 from rift.Config import Staff, Modules
 
 

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -11,7 +11,14 @@ import textwrap
 from io import StringIO
 
 from .TestUtils import (
-    make_temp_file, make_temp_dir, gen_rpm_spec, read_file, RiftTestCase, RiftProjectTestCase, SubPackage
+    make_temp_file,
+    make_temp_dir,
+    gen_rpm_spec,
+    read_file,
+    host_rpmlint,
+    RiftTestCase,
+    RiftProjectTestCase,
+    SubPackage,
 )
 
 from .VM import GLOBAL_CACHE, VALID_IMAGE_URL, PROXY
@@ -344,10 +351,11 @@ class ControllerProjectActionCheckTest(RiftProjectTestCase):
         self.make_pkg()
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with self.assertLogs(level='INFO') as log:
-            exit_code = main(
-                ['check', 'spec', '-f', self.buildfiles['pkg:rpm']]
-            )
+        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
+            with self.assertLogs(level='INFO') as log:
+                exit_code = main(
+                    ['check', 'spec', '-f', self.buildfiles['pkg:rpm']]
+                )
         self.assertEqual(exit_code, 0)
         self.assertIn(
             'INFO:root:Spec file is OK.',
@@ -1996,7 +2004,7 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
     def test_gitlab(self, mock_mock):
         """simple gitlab"""
         self.make_pkg()
-        patch = make_temp_file(
+        patch_file = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkg/pkg.spec
                 index d1a0d0e7..b3e36379 100644
@@ -2014,7 +2022,8 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         # Test no error is raised
-        main(['gitlab', patch.name])
+        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
+            main(['gitlab', patch_file.name])
 
     @patch('rift.package.rpm.Mock')
     def test_gitlab_check_failed(self, mock_mock):
@@ -2033,7 +2042,7 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
                     buildsteps="$RPM_SOURCE_DIR\n$RPM_BUILD_ROOT",
                 )
             )
-        patch = make_temp_file(
+        patch_file = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkg/pkg.spec
                 index d1a0d0e7..b3e36379 100644
@@ -2051,8 +2060,9 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         # Test error is raised
-        with self.assertRaisesRegex(RiftError, "rpmlint reported errors"):
-            main(['gitlab', patch.name])
+        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
+            with self.assertRaisesRegex(RiftError, "rpmlint reported errors"):
+                main(['gitlab', patch_file.name])
 
 
 class ControllerProjectActionGerritTest(RiftProjectTestCase):
@@ -2073,7 +2083,7 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
     def test_gerrit(self, mock_review, mock_mock):
         """simple gerrit"""
         self.make_pkg()
-        patch = make_temp_file(
+        patch_file = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkg/pkg.spec
                 index d1a0d0e7..b3e36379 100644
@@ -2090,7 +2100,8 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                 """))
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        main(['gerrit', '--change', '1', '--patchset', '2', patch.name])
+        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
+            main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
         # Check review has not been invalidated and pushed
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
@@ -2113,7 +2124,7 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                     buildsteps="$RPM_SOURCE_DIR\n$RPM_BUILD_ROOT",
                 )
             )
-        patch = make_temp_file(
+        patch_file = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkg/pkg.spec
                 index d1a0d0e7..b3e36379 100644
@@ -2130,7 +2141,8 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                 """))
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        main(['gerrit', '--change', '1', '--patchset', '2', patch.name])
+        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
+            main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
         # Check review has been invalidated and pushed
         mock_review.return_value.invalidate.assert_called_once()
         mock_review.return_value.push.assert_called_once()

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -4,10 +4,12 @@
 
 import os
 import getpass
-from unittest.mock import patch, MagicMock
+import tempfile
+from textwrap import dedent
+from unittest.mock import patch, MagicMock, ANY
 
 from .TestUtils import RiftProjectTestCase
-from rift.Mock import Mock
+from rift.Mock import Mock, rpmlint_chroot_script, rpmlint_env
 from rift.repository import ProjectArchRepositories
 from rift.repository.rpm import ConsumableRepository
 from rift.RPM import RPM
@@ -248,3 +250,135 @@ class MockTest(RiftProjectTestCase):
         result = mock.read_spec('/dev/package.spec')
         mock.clean()
         self.assertEqual(result, "standard output")
+
+    def test_rpmlint_env_returns_none_without_configdir(self):
+        """Test rpmlint_env() returns None without configdir."""
+        self.assertIsNone(rpmlint_env())
+        self.assertIsNone(rpmlint_env(None))
+        self.assertIsNone(rpmlint_env(''))
+
+    def test_rpmlint_env_sets_xdg_config_home_realpath(self):
+        """Test rpmlint_env() sets XDG_CONFIG_HOME to realpath of configdir."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = os.path.join(tmp, 'nested')
+            os.mkdir(cfg)
+            env = rpmlint_env(cfg)
+            self.assertIsNotNone(env)
+            self.assertEqual(env['XDG_CONFIG_HOME'], os.path.realpath(cfg))
+            self.assertIsNot(env, os.environ)
+
+    def test_rpmlint_env_is_copy_of_environ(self):
+        """Test rpmlint_env() is a copy of os.environ."""
+        with patch.dict(os.environ, {'RIFT_RPMLINT_ENV_TEST': 'orig'}, clear=False):
+            env = rpmlint_env('/tmp')
+            self.assertEqual(env['RIFT_RPMLINT_ENV_TEST'], 'orig')
+            env['RIFT_RPMLINT_ENV_TEST'] = 'changed'
+            self.assertEqual(os.environ['RIFT_RPMLINT_ENV_TEST'], 'orig')
+
+    def test_rpmlint_chroot_script(self):
+        """Test rpmlint_chroot_script() returns shell script for rpmlint."""
+        # Generate spec file in temporary directory and generate script.
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = os.path.join(tmp, 'pkg.spec')
+            with open(spec, 'w', encoding='utf-8'):
+                pass
+            script = rpmlint_chroot_script(spec)
+        self.assertEqual(
+            script,
+            dedent(f"""
+                set +e
+                VERLINE=$(rpmlint --version 2>/dev/null | head -1)
+                if echo "$VERLINE" | grep -q '^2'; then
+                    rpmlint {spec}
+                else
+                    rpmlint -o 'NetworkEnabled False' -f {tmp}/rpmlint {spec}
+                fi
+                exit $?
+            """).strip(),
+        )
+
+    def test_rpmlint_chroot_script_v2_branch_inserts_config_when_toml_exists(self):
+        """Test rpmlint_chroot_script() v2 branch inserts config when toml exists."""
+        # Generate spec and toml files in temporary directory and generate script.
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = os.path.join(tmp, 'pkg.spec')
+            with open(spec, 'w', encoding='utf-8'):
+                pass
+            with open(os.path.join(tmp, 'rpmlint.toml'), 'w', encoding='utf-8'):
+                pass
+            script = rpmlint_chroot_script(spec)
+        # Check script contains rpmlint -c <toml> <spec>.
+        self.assertIn(
+            f"rpmlint -c {tmp}/rpmlint.toml {spec}",
+            script,
+        )
+
+    @patch('rift.Mock.run_command')
+    def test_rpmlint(self, mock_run_command):
+        """Test Mock.rpmlint() installs rpmlint, runs it in chroot, cleans, returns result."""
+        spec_path = '/dev/package.spec'
+        expected_script = rpmlint_chroot_script(spec_path)
+
+        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+
+        mock_run_command.side_effect = [
+            RunResult(0, None, None),  # init
+            RunResult(0, None, None),  # install rpmlint
+            RunResult(4, 'rpmlint stdout', 'rpmlint stderr'),  # chroot rpmlint
+            RunResult(0, None, None),  # clean
+        ]
+        mock.init([])
+        result = mock.rpmlint(spec_path)
+
+        # Check return value
+        self.assertEqual(result, RunResult(4, 'rpmlint stdout', 'rpmlint stderr'))
+        self.assertEqual(mock_run_command.call_count, 4)
+
+        # Check mock command calls
+        base = [
+            'mock', '--config-opts', 'print_main_output=yes',
+            f'--configdir={mock._tmpdir.path}',
+        ]
+        mock_run_command.assert_any_call(
+            base + [
+                '--no-clean', '--no-cleanup-after', '--quiet',
+                '--pm-cmd', 'install', '-y', 'rpmlint',
+            ],
+            live_output=ANY,
+            capture_output=True,
+            merge_out_err=True,
+            cwd='/',
+        )
+        mock_run_command.assert_any_call(
+            base + [
+                "--plugin-option=bind_mount:dirs=[('/dev', '/dev')]",
+                '--quiet', 'chroot', '--', 'bash', '-c', expected_script,
+            ],
+            capture_output=True,
+            merge_out_err=False,
+            cwd='/',
+            env=None,
+        )
+        mock_run_command.assert_any_call(
+            base + ['--quiet', '--clean'],
+            live_output=ANY,
+            capture_output=True,
+            merge_out_err=True,
+            cwd='/',
+        )
+        mock.clean()
+
+    @patch('rift.Mock.run_command')
+    def test_rpmlint_install_failure_no_chroot_or_clean(self, mock_run_command):
+        """Test Mock.rpmlint() install failure no chroot or clean."""
+        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock_run_command.side_effect = [
+            RunResult(0, None, None),  # init
+            RunResult(1, 'install failed', None),  # install rpmlint
+        ]
+        mock.init([])
+        with self.assertRaisesRegex(RiftError, 'install failed'):
+            mock.rpmlint('/dev/package.spec')
+        mock.clean()
+        # Check mock called 2 commands: init and install rpmlint.
+        self.assertEqual(mock_run_command.call_count, 2)

--- a/tests/RPM.py
+++ b/tests/RPM.py
@@ -6,18 +6,35 @@ import time
 import rpm
 import shutil
 import subprocess
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from .TestUtils import (
     make_temp_dir,
     gen_rpm_spec,
     read_file,
+    host_rpmlint,
     RiftTestCase,
     RiftProjectTestCase,
 )
 from rift import RiftError
-from rift.RPM import Spec, Variable, RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2, RPM, rpmlint_v2
-from rift.Mock import Mock
+from rift.RPM import Spec, Variable, RPM
+from rift.Mock import Mock, RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2
+
+
+def rpmlint_v2():
+    """Return True if host rpmlint major version is 2."""
+    try:
+        proc = subprocess.run(
+            ['rpmlint', '--version'],
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+    except subprocess.CalledProcessError as err:
+        raise RiftError(
+            f"Unable to get rpmlint version: {str(err)}"
+        ) from err
+    return proc.stdout.decode().startswith("2")
+
 
 class SpecTest(RiftTestCase):
     """
@@ -100,7 +117,8 @@ class SpecTest(RiftTestCase):
 
     def test_specfile_check(self):
         """ Test specfile check function """
-        self.assertIsNone(Spec(self.spec, self.mock, None).check())
+        with patch.object(self.mock, 'rpmlint', host_rpmlint):
+            self.assertIsNone(Spec(self.spec, self.mock, None).check())
 
 
     def test_specfile_check_with_rpmlint_v1(self):
@@ -110,14 +128,15 @@ class SpecTest(RiftTestCase):
             self.skipTest("This test requires rpmlint v1")
         self.files = "/lib/test"
         self.update_spec()
-        with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
-            Spec(self.spec, self.mock, None).check()
+        with patch.object(self.mock, 'rpmlint', host_rpmlint):
+            with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
+                Spec(self.spec, self.mock, None).check()
 
-        # Create rpmlint config to ignore hardcoded library path
-        rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V1])
-        with open(rpmlintfile, "w") as rpmlint:
-            rpmlint.write('addFilter("E: hardcoded-library-path")')
-        self.assertIsNone(Spec(self.spec, self.mock, None).check())
+            # Create rpmlint config to ignore hardcoded library path
+            rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V1])
+            with open(rpmlintfile, "w") as rpmlint:
+                rpmlint.write('addFilter("E: hardcoded-library-path")')
+            self.assertIsNone(Spec(self.spec, self.mock, None).check())
         os.unlink(rpmlintfile)
 
     def test_specfile_check_with_rpmlint_v2(self):
@@ -127,14 +146,15 @@ class SpecTest(RiftTestCase):
         self.buildsteps = "$RPM_BUILD_ROOT"
         self.update_spec()
 
-        with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
-            Spec(self.spec, self.mock, None).check()
+        with patch.object(self.mock, 'rpmlint', host_rpmlint):
+            with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
+                Spec(self.spec, self.mock, None).check()
 
-        # Create rpmlint config file to ignore rpm-buildroot-usage
-        rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V2])
-        with open(rpmlintfile, "w") as rpmlint:
-            rpmlint.write('Filters = ["rpm-buildroot-usage"]')
-        self.assertIsNone(Spec(self.spec, self.mock, None).check())
+            # Create rpmlint config file to ignore rpm-buildroot-usage
+            rpmlintfile = os.sep.join([self.directory, RPMLINT_CONFIG_V2])
+            with open(rpmlintfile, "w") as rpmlint:
+                rpmlint.write('Filters = ["rpm-buildroot-usage"]')
+            self.assertIsNone(Spec(self.spec, self.mock, None).check())
         os.unlink(rpmlintfile)
 
     def test_bump_release(self):

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -23,7 +23,8 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from rift.Config import Config, Staff, Modules
-from rift.Mock import Mock
+from rift.Mock import Mock, rpmlint_env, rpmlint_chroot_script
+from rift.run import run_command
 
 MOCK_CONF = '''\
 config_opts.setdefault('plugin_conf', {})
@@ -462,6 +463,19 @@ def read_file(filepath):
     """Read a text file and return its content."""
     return open(filepath).read()
 
+def host_rpmlint(filepath, configdir=None):
+    """
+    Drop-in replacement for Mock.rpmlint() method that runs host
+    rpmlint.
+    """
+    spec_fp = os.path.realpath(filepath)
+    script = rpmlint_chroot_script(spec_fp)
+    return run_command(
+        ['bash', '-lc', script],
+        capture_output=True,
+        merge_out_err=False,
+        env=rpmlint_env(configdir),
+    )
 
 #
 # Temp files

--- a/tests/package/rpm.py
+++ b/tests/package/rpm.py
@@ -21,6 +21,7 @@ from ..TestUtils import (
     gen_rpm_spec,
     read_file,
     nullcontext,
+    host_rpmlint,
 )
 
 
@@ -106,7 +107,8 @@ class PackageRPMTest(RiftProjectTestCase):
         with patch('rift.package.rpm.Mock') as mock_mock:
             mock_mock.return_value.read_spec.return_value = open(spec_file.name).read()
             pkg.load(infopath = pkgfile.name)
-        pkg.check()
+        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+            pkg.check()
 
     def test_check_missing_source(self):
         """ Test PackageRPM.check() detect missing source """
@@ -134,9 +136,10 @@ class PackageRPMTest(RiftProjectTestCase):
         with patch('rift.package.rpm.Mock') as mock_mock:
             mock_mock.return_value.read_spec = read_file
             pkg.load(infopath = pkgfile.name)
-        with self.assertRaisesRegex(RiftError,
-            r'Missing source file\(s\): pkg-1.0.tar.gz'):
-            pkg.check()
+        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+            with self.assertRaisesRegex(RiftError,
+                r'Missing source file\(s\): pkg-1.0.tar.gz'):
+                pkg.check()
 
     def test_check_unused_source(self):
         """ Test PackageRPM.check() detect unused source """
@@ -171,9 +174,10 @@ class PackageRPMTest(RiftProjectTestCase):
         with patch('rift.package.rpm.Mock') as mock_mock:
             mock_mock.return_value.read_spec = read_file
             pkg.load(infopath = pkgfile.name)
-        with self.assertRaisesRegex(RiftError,
-            r'Unused source file\(s\): unused-1.0.tar.gz'):
-            pkg.check()
+        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+            with self.assertRaisesRegex(RiftError,
+                r'Unused source file\(s\): unused-1.0.tar.gz'):
+                pkg.check()
 
     def test_subpackages(self):
         """ Test PackageRPM.subpackages() returns list of provides """
@@ -405,7 +409,8 @@ class PackageRPMTest(RiftProjectTestCase):
             mock_mock.return_value.read_spec = read_file
             pkg.load(infopath = pkgfile.name)
         review = Mock(spec=Review)
-        pkg.analyze(review, pkg.dir)
+        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+            pkg.analyze(review, pkg.dir)
         review.invalidate.assert_not_called()
 
     def test_analyze_invalidate(self):
@@ -438,7 +443,8 @@ class PackageRPMTest(RiftProjectTestCase):
             mock_mock.return_value.read_spec = read_file
             pkg.load(infopath = pkgfile.name)
         review = Mock(spec=Review)
-        pkg.analyze(review, pkg.dir)
+        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+            pkg.analyze(review, pkg.dir)
         review.invalidate.assert_called_once()
 
     def test_for_arch(self):


### PR DESCRIPTION
In order to have consistent and reproducible results on all hosts, run
rpmlint command for static analysis of RPM spec file in Mock's chroot
and targeted environment, instead of running host's rpmlint.

New method rpmlint() is introduced on Mock class. It installs rpmlint,
runs this command (with a shell wrapper to handle v1 and v2 differences)
and clean the build chroot to restore its state.

Calls of this method must protected by locks to avoid conflicting access
to the same build chroot by parallel validate threads.

Tests are updated to mock this method with a replacement function that
actually runs rpmlint on host and save chroot handling.

[based on #93]