### PR TITLE
Controller: add query --formats CLI argument

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -270,6 +270,9 @@ def make_parser():
                         action='store_false', help="Don't load specfile info")
     subprs.add_argument('-H', '--no-header', dest='headers',
                         action='store_false', help='Hide table headers')
+    subprs.add_argument('-F', '--formats', nargs='+',
+                        choices=RIFT_SUPPORTED_FORMATS,
+                        help='Restrict query to specific package formats')
 
     # Add changelog entry
     subprs = subparsers.add_parser('changelog',
@@ -1169,6 +1172,16 @@ def action_query(args, config):
                         f"(supported keys are: {', '.join(supported_keys)})")
 
     for pkg in pkglist:
+
+        # Skip package if format is not selected by user
+        if args.formats and pkg.format not in args.formats:
+            logging.info(
+                "Skipping query %s package %s due to restriction on "
+                "package formats",
+                pkg.format, pkg.name
+            )
+            continue
+
         logging.debug('Loading package %s', pkg.name)
         try:
             pkg.load()

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -213,6 +213,11 @@ class ControllerProjectActionQueryTest(RiftProjectTestCase):
         mock_mock.return_value.read_spec = read_file
         self.assertEqual(main(['query', 'pkg']), 0)
 
+    def test_action_query_formats(self):
+        """ Test query with format filter """
+        self.make_pkg()
+        self.assertEqual(main(['query', '--formats', 'rpm']), 0)
+
     @patch('rift.package.rpm.Mock')
     def test_action_query_on_bad_pkg(self, mock_mock):
         """ Test query on multiple packages with one errorneous package """
@@ -2323,6 +2328,20 @@ class ControllerArgumentsTest(RiftTestCase):
         self.assertCountEqual(opts.formats, ['rpm'])
 
         args = ['validate', '--formats', 'fail']
+
+    def test_parse_args_query(self):
+        """ Test query command options parsing """
+        parser = make_parser()
+
+        args = ['query']
+        opts = parser.parse_args(args)
+        self.assertIsNone(opts.formats)
+
+        args = ['query', '--formats', 'rpm']
+        opts = parser.parse_args(args)
+        self.assertCountEqual(opts.formats, ['rpm'])
+
+        args = ['query', '--formats', 'fail']
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 


### PR DESCRIPTION
This new command line option allows restricting query action to specific package formats, which could be useful when packages supports multiple formats.