### PR TITLE
Controller: add changelog --formats CLI argument

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -285,6 +285,9 @@ def make_parser():
                         help='maintainer name from staff.yaml')
     subprs.add_argument('--bump', dest='bump', action='store_true',
                         help='also bump the release number')
+    subprs.add_argument('-F', '--formats', nargs='+',
+                        choices=RIFT_SUPPORTED_FORMATS,
+                        help='restrict command to specific package formats')
 
     # GitLab review
     subprs = subparsers.add_parser('gitlab', add_help=False,
@@ -1057,6 +1060,16 @@ def action_changelog(args, config):
     pkgs = ProjectPackages.get(args.package, config, staff, modules)
     package_found = False
     for pkg in pkgs:
+
+        # Skip package if format is not selected by user
+        if args.formats and pkg.format not in args.formats:
+            logging.info(
+                "Skipping changelog update on %s package %s due to restriction "
+                "on package formats",
+                pkg.format, pkg.name
+            )
+            continue
+
         pkg.load()
         try:
             pkg.add_changelog_entry(args.maintainer, args.comment, args.bump)

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -2211,16 +2211,6 @@ class ControllerProjectActionChangelogTest(RiftProjectTestCase):
     Tests class for Controller action changelog
     """
 
-    def test_action_changelog_without_pkg(self):
-        """changelog without package fails """
-        with self.assertRaisesRegex(SystemExit, "2"):
-            main(['changelog'])
-
-    def test_action_changelog_without_comment(self):
-        """changelog without comment fails """
-        with self.assertRaisesRegex(SystemExit, "2"):
-            main(['changelog', 'pkg'])
-
     def test_action_changelog_without_maintainer(self):
         """changelog without maintainer """
         with self.assertRaisesRegex(RiftError, "You must specify a maintainer"):
@@ -2241,6 +2231,23 @@ class ControllerProjectActionChangelogTest(RiftProjectTestCase):
         mock_mock.return_value.read_spec = read_file
         self.assertEqual(
             main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself']), 0)
+        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg.load()
+        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
+        self.assertEqual(pkg.spec.version, '1.0')
+        self.assertEqual(pkg.spec.release, '1')
+
+    @patch('rift.package.rpm.Mock')
+    def test_action_changelog_formats(self, mock_mock):
+        """simple changelog"""
+        self.make_pkg()
+        # mock Mock.read_spec to return spec file content directly read on host
+        mock_mock.return_value.read_spec = read_file
+        self.assertEqual(
+            main(
+                ['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself',
+                 '--formats', 'rpm']
+            ), 0)
         pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
         pkg.load()
         self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
@@ -2342,6 +2349,28 @@ class ControllerArgumentsTest(RiftTestCase):
         self.assertCountEqual(opts.formats, ['rpm'])
 
         args = ['query', '--formats', 'fail']
+
+    def test_parse_args_changelog(self):
+        """ Test changelog command options parsing """
+        parser = make_parser()
+
+        args = ['changelog']
+        with self.assertRaises(SystemExit):
+            opts = parser.parse_args(args)
+
+        args = ['changelog', 'pkg']
+        with self.assertRaises(SystemExit):
+            opts = parser.parse_args(args)
+
+        args = ['changelog', 'pkg', '-c', 'comment']
+        opts = parser.parse_args(args)
+        self.assertIsNone(opts.formats)
+
+        args = ['changelog', 'pkg', '-c', 'comment', '--formats', 'rpm']
+        opts = parser.parse_args(args)
+        self.assertCountEqual(opts.formats, ['rpm'])
+
+        args = ['changelog', 'pkg', '-c', 'comment', '--formats', 'fail']
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 


### PR DESCRIPTION
This new command line option allows restricting changelog action to specific package formats, which could be useful when packages supports multiple formats.