### PR TITLE
Threaded proxy for token protected HTTP repos

### DIFF
--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -209,6 +209,10 @@ class Config():
                 'variants': {
                     'check': 'list',
                     'default': _DEFAULT_REPOS_VARIANTS,
+                },
+                'auth': {
+                    'check': 'enum',
+                    'values': ['idp_token'],
                 }
             }
         },

--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -51,6 +51,7 @@ from rift.TempDir import TempDir
 from rift.RPM import RPM
 from rift.run import run_command
 from rift.Config import _DEFAULT_VARIANT
+from rift.proxy import AuthenticatedRepositoryProxyRuntime
 
 # Global dictionary of re-entrant locks for each mock name.
 _mock_chroot_locks = {}
@@ -117,6 +118,7 @@ class Mock():
         self._config = config
         self._arch = arch
         self._tmpdir = None
+        self._repo_proxy = None
         self._mockname = f"rift-{self._arch}-{getpass.getuser()}"
         if proj_vers:
             self._mockname = f"{self._mockname}-{proj_vers}"
@@ -148,11 +150,15 @@ class Mock():
         for idx, repo in enumerate(repolist, start=1):
             assert repo.url is not None
             prio = repo.priority or (prio - 1)
+            repo_url = repo.generic_url(self._arch)
+            if self._repo_proxy and repo.authenticated():
+                repo_url = self._repo_proxy.repo_url(repo, "127.0.0.1")
             repo_ctx = {
                 'name': repo.name or f"repo{idx}",
                 'priority': prio,
-                'url': repo.generic_url(self._arch),
+                'url': repo_url,
                 'variants': repo.variants,
+                'authenticated': repo.authenticated(),
                 }
             if repo.module_hotfixes:
                 repo_ctx['module_hotfixes'] = repo.module_hotfixes
@@ -259,6 +265,8 @@ class Mock():
 
         This should be cleaned with clean().
         """
+        self._repo_proxy = AuthenticatedRepositoryProxyRuntime(self._config, repolist)
+        self._repo_proxy.start()
         self._init_tmp_conf(repolist)
         self._exec(['--init'])
 
@@ -366,6 +374,7 @@ class Mock():
             # Clear handle to avoid later init() skipping _init_tmp_conf()
             # and mock seeing --configdir=None.
             self._tmpdir = None
+        self._stop_repo_proxy()
         for rpm in self.resultrpms():
             os.unlink(rpm.filepath)
 
@@ -374,6 +383,13 @@ class Mock():
         with self.lock():
             self._init_tmp_conf()
             self._exec(['--scrub=all'])
+
+    def _stop_repo_proxy(self):
+        """Stop repository proxy runtime if currently active."""
+        if self._repo_proxy is None:
+            return
+        self._repo_proxy.stop()
+        self._repo_proxy = None
 
     def build_srpm(self, specpath, sourcedir, sign):
         """

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -64,6 +64,7 @@ from rift.repository import ProjectArchRepositories
 from rift.TempDir import TempDir
 from rift.utils import last_modified, download_file, setup_dl_opener, message
 from rift.run import run_command
+from rift.proxy import AuthenticatedRepositoryProxyRuntime
 
 __all__ = ['VM']
 
@@ -118,6 +119,8 @@ class VM():
 
     _PROJ_MOUNTPOINT = '/rift.project'
     NAME = 'rift1.domain'
+    # Host IP address for QEMU user-mode networking available inside the guest.
+    QEMU_USERNET_HOST = "10.0.2.2"
     SUPPORTED_FS = ('9p', 'virtiofs')
 
     def __init__(self, config, arch, tmpmode=True, extra_repos=None):
@@ -139,6 +142,7 @@ class VM():
         self._repos = ProjectArchRepositories(
             config, arch
         ).for_format('rpm').all + extra_repos
+        self._auth_proxy = AuthenticatedRepositoryProxyRuntime(config, self._repos)
 
         self.address = vm_config.get('address')
         self.port = self.default_port(vm_config.get('port_range'))
@@ -382,6 +386,27 @@ class VM():
 
         return cmd
 
+    def _repo_url_for_guest(self, repo, host):
+        """Return effective URL for a repository consumed inside the VM."""
+        if repo.is_file():
+            return f"file:///rift.{repo.name}/"
+        # If repository is authenticated, use URL to authenticated repository proxy
+        # instead of the repository URL.
+        if repo.authenticated():
+            return self._auth_proxy.repo_url(repo, host)
+        return repo.url
+
+    def _guest_no_proxy(self):
+        """
+        Value for no_proxy inside the guest (libcurl / dnf).
+
+        Always include the QEMU user-net host so requests to the host-side Rift
+        repository proxy are not sent through http_proxy.
+        """
+        if not self.no_proxy:
+            return self.QEMU_USERNET_HOST
+        return f"{self.no_proxy},{self.QEMU_USERNET_HOST}"
+
     def _download(self, force: bool):
         """
         Download local copy of VM image if it is remote URL. Download is skipped if
@@ -498,9 +523,7 @@ class VM():
                 mkdirs.append(f"/rift.{repo.name}")
                 fstab.append(f"{repo.name} /rift.{repo.name} {self.shared_fs_type} "
                              f"{options} 0 0")
-                url = f"file:///rift.{repo.name}/"
-            else:
-                url = repo.url
+            url = self._repo_url_for_guest(repo, self.QEMU_USERNET_HOST)
             prio = repo.priority or (prio - 1)
             repos.append(textwrap.dedent(f"""\
                 [{repo.name}]
@@ -514,7 +537,9 @@ class VM():
                 repos.append(f"excludepkgs={repo.excludepkgs}\n")
             if repo.module_hotfixes:
                 repos.append(f"module_hotfixes={repo.module_hotfixes}\n")
-            if repo.proxy:
+            # Set proxy for this repo if set in configuration and is not
+            # authenticated.
+            if repo.proxy and not repo.authenticated():
                 repos.append(f"proxy={repo.proxy}\n")
 
         # Build the full command line
@@ -544,6 +569,8 @@ class VM():
             # Uses repos from the Rift configuration
             /bin/rm -f /etc/yum.repos.d/*.repo
             echo "{joinl(repos)}" > /etc/yum.repos.d/rift.repo
+
+            export no_proxy={shlex.quote(self._guest_no_proxy())}
 
             if [ -x /usr/bin/dnf ] ; then
                 dnf -d1 makecache
@@ -726,6 +753,8 @@ class VM():
                 logging.debug("Sending TERM signal to helper process (%d)", pid)
                 helper.terminate()
 
+        # Stop authenticated repositories proxy
+        self._auth_proxy.stop()
 
         # Unlink temp VM image
         if unlink:
@@ -754,6 +783,8 @@ class VM():
         self._download(force)
 
         message('Launching VM ...')
+        # Start authenticated repositories proxy
+        self._auth_proxy.start()
         self.spawn()
         self.ready()
         self.prepare()
@@ -859,8 +890,7 @@ class VM():
             fh_user.write(
                 tpl.render(
                     proxy=self.proxy,
-                    no_proxy=self.no_proxy,
-                    repositories=self._repos
+                    no_proxy=self._guest_no_proxy(),
                 )
             )
 
@@ -942,6 +972,9 @@ class VM():
 
         # Download image if necessary
         base_image_path = self._dl_base_image(url, force)
+
+        # Start authenticated repositories proxy
+        self._auth_proxy.start()
 
         # Build cloud-init seed iso
         seed_iso_file = self._build_seed_iso()

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -200,6 +200,30 @@ class Auth:
 
         return True
 
+    def get_idp_token_noninteractive(self):
+        """
+        Return cached OpenID token from environment or state file without
+        prompting user. Raise RiftError if token is missing or expired.
+        """
+
+        token = os.environ.get("RIFT_AUTH_IDP_TOKEN")
+        if token:
+            return token
+
+        if not os.path.isfile(self.credentials_file):
+            raise RiftError(
+                f"Missing authentication state file {self.credentials_file}. "
+                "Run 'rift auth' first."
+            )
+        self.restore_state()
+        token = self.config.get("idp_token")
+        if not token:
+            raise RiftError(
+                f"Missing idp_token in authentication state file {self.credentials_file}. "
+                "Run 'rift auth' first."
+            )
+        return token
+
     # Step 2: Get S3 credentials using token from (1)
     def get_s3_credentials(self):
         """

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -208,6 +208,7 @@ class Auth:
 
         token = os.environ.get("RIFT_AUTH_IDP_TOKEN")
         if token:
+            logging.debug("fetched idp token from environment")
             return token
 
         if not os.path.isfile(self.credentials_file):

--- a/lib/rift/proxy.py
+++ b/lib/rift/proxy.py
@@ -1,0 +1,336 @@
+#
+# Copyright (C) 2026 CEA
+#
+# This file is part of Rift project.
+#
+# This software is governed by the CeCILL license under French law and
+# abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# "http://www.cecill.info".
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# In this respect, the user's attention is drawn to the risks associated
+# with loading,  using,  modifying and/or developing or reproducing the
+# software by the user in light of its specific status of free software,
+# that may mean  that it is complicated to manipulate,  and  that  also
+# therefore means  that it is reserved for developers  and  experienced
+# professionals having in-depth computer knowledge. Users are therefore
+# encouraged to load and test the software's suitability as regards their
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
+# same conditions as regards security.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+#
+
+"""
+HTTP repository proxy for idp_token protected repositories.
+"""
+
+import logging
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+from rift import RiftError
+from rift.auth import Auth
+
+# Hop-by-hop headers apply only to a single HTTP connection hop
+# (client<->proxy or proxy<->upstream), not to the full end-to-end message.
+# Forwarding them as-is may break framing/connection semantics (for example
+# Connection and Transfer-Encoding), so this proxy strips them on both request
+# forwarding and response forwarding.
+_HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    """
+    Threading HTTP server for repository proxy.
+    """
+    # Handle each request in its own daemon thread so long-running RPM downloads
+    # do not block other clients and do not prevent process exit.
+    daemon_threads = True
+    # Allow fast restart on the same host/port without waiting for TIME_WAIT.
+    allow_reuse_address = True
+
+    def __init__(self, server_address, RequestHandlerClass, runtime):
+        super().__init__(server_address, RequestHandlerClass)
+        self.runtime = runtime
+
+
+class _TokenAuthRepositoryProxyHandler(BaseHTTPRequestHandler):
+    """
+    HTTP repository proxy request handler for bearer token protected repositories.
+    """
+    # Advertise a proxy-specific Server header for troubleshooting.
+    server_version = "RiftAuthRepoProxy/1.0"
+    # Use HTTP/1.1 responses to keep transfer/framing behavior aligned with
+    # modern upstream repository clients.
+    protocol_version = "HTTP/1.1"
+
+    def _log_proxy_request(self, upstream_url, status_code):
+        """Log proxy requests at DEBUG level."""
+        logging.debug(
+            "proxy request %s %s -> %s [%s]",
+            self.command,
+            self.path,
+            upstream_url,
+            status_code,
+        )
+
+    def send_error(self, code, message=None, explain=None):
+        """Override parent class send_error() to log proxy errors at ERROR level."""
+        logging.error(
+            "proxy error %s %s [%s] %s",
+            self.command,
+            self.path,
+            code,
+            message if message is not None else "-",
+        )
+        super().send_error(code, message, explain)
+
+    def _handle(self):
+        # Make sure this handler is running on custom Rift threading HTTP server
+        # with AuthenticatedRepositoryProxyRuntime instance.
+        assert isinstance(self.server, _ThreadingHTTPServer)
+
+        repo_key, relpath, query = self._parse_repo_route()
+        if repo_key is None:
+            return
+
+        repo = self.server.runtime.repositories.get(repo_key)
+        if repo is None:
+            self.send_error(404, "Unknown repository key")
+            return
+
+        upstream_url = self._build_upstream_url(repo.url, relpath, query)
+        headers = self._build_forward_headers(self.server.runtime.token)
+
+        request = urllib.request.Request(
+            upstream_url,
+            headers=headers,
+            method=self.command,
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=self.server.runtime.timeout) as response:
+                self._log_proxy_request(upstream_url, response.getcode())
+                self._send_upstream_response(response)
+        except urllib.error.HTTPError as err:
+            self._log_proxy_request(upstream_url, err.code)
+            self._send_error_response(err)
+        except (urllib.error.URLError, OSError) as err:
+            logging.error("Repository proxy request failed: %s", err)
+            self.send_error(502, "Bad gateway")
+
+    def _parse_repo_route(self):
+        """
+        Extract upstream repository route from request path. Return (repo_key,
+        relpath, query) tuple where:
+        - repo_key is the upstream repository key (ie. the first path component
+          of the request path)
+        - relpath is the relative path to the upstream repository base URL (ie.
+          the remaining path components of the request path)
+        - query is the query string
+        """
+        split = urllib.parse.urlsplit(self.path)
+        route = split.path.lstrip("/")
+        if not route:
+            self.send_error(400, "Missing repository key in URL")
+            return None, None, None
+
+        route_parts = route.split("/", 1)
+        repo_key = urllib.parse.unquote(route_parts[0]).strip()
+        if not repo_key:
+            self.send_error(400, "Invalid repository key")
+            return None, None, None
+
+        if len(route_parts) == 2:
+            relpath = route_parts[1]
+        else:
+            relpath = ""
+
+        return repo_key, relpath, split.query
+
+    @staticmethod
+    def _build_upstream_url(base_url, relpath, query):
+        base = base_url
+        if not base.endswith("/"):
+            base += "/"
+        upstream = urllib.parse.urljoin(base, relpath)
+        if query:
+            upstream = f"{upstream}?{query}"
+        return upstream
+
+    def _build_forward_headers(self, token):
+        headers = {}
+        for key in self.headers.keys():
+            key_lower = key.lower()
+            if key_lower in _HOP_BY_HOP_HEADERS or key_lower == "host":
+                continue
+            headers[key] = self.headers.get(key)
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    def _send_upstream_response(self, response):
+        """
+        Relay a successful upstream urllib response to the client.
+
+        Sends the HTTP status line, forwards upstream headers except hop-by-hop
+        headers, then ends the header block. For GET, streams the body in chunks;
+        for HEAD, sends headers only (no body).
+        """
+        self.send_response(response.getcode())
+        for key, value in response.getheaders():
+            key_lower = key.lower()
+            if key_lower in _HOP_BY_HOP_HEADERS:
+                continue
+            self.send_header(key, value)
+        self.end_headers()
+
+        if self.command == "HEAD":
+            return
+
+        while True:
+            chunk = response.read(64 * 1024)
+            if not chunk:
+                break
+            self.wfile.write(chunk)
+
+    def _send_error_response(self, error):
+        """
+        Relay an urllib HTTPError response to the client.
+
+        Sends the error status code, forwards the error response headers except
+        hop-by-hop headers, then ends the header block. For GET, forwards the
+        error body when present; for HEAD, omits the body.
+        """
+        self.send_response(error.code)
+        for key, value in error.headers.items():
+            key_lower = key.lower()
+            if key_lower in _HOP_BY_HOP_HEADERS:
+                continue
+            self.send_header(key, value)
+        self.end_headers()
+        if self.command != "HEAD":
+            body = error.read()
+            if body:
+                self.wfile.write(body)
+
+    def do_GET(self):  # pylint: disable=invalid-name
+        """Handle GET requests."""
+        self._handle()
+
+    def do_HEAD(self):  # pylint: disable=invalid-name
+        """Handle HEAD requests."""
+        self._handle()
+
+    def log_message(self, format, *args):
+        """
+        Override parent class log_message() to suppress default http.server
+        per-request stderr/INFO logging.
+        """
+
+
+class AuthenticatedRepositoryProxyRuntime:
+    """
+    Runtime helper around a local HTTP proxy for authenticated repos.
+    """
+
+    def __init__(self, config, repositories, timeout=60):
+        self._config = config
+        self._timeout = timeout
+        self.repositories = {
+            repo.name: repo
+            for repo in repositories
+            if repo.authenticated()
+        }
+        self.token = None
+        self.server = None
+        self._thread = None
+
+    @property
+    def timeout(self):
+        """Get repository proxy timeout."""
+        return self._timeout
+
+    @property
+    def active(self):
+        """Check if repository proxy is active."""
+        return self.server is not None
+
+    @property
+    def required(self):
+        """Check if repository proxy is required."""
+        return len(self.repositories) > 0
+
+    def start(self):
+        """Start repository proxy."""
+        if self.server is not None:
+            return
+        if not self.required:
+            logging.debug("No repositories need proxy, skipping proxy startup")
+            return
+
+        # Get IDP token non-interactively.
+        self.token = Auth(self._config).get_idp_token_noninteractive()
+
+        # Start HTTP server in a separate thread.
+        self.server = _ThreadingHTTPServer(
+            ("127.0.0.1", 0), _TokenAuthRepositoryProxyHandler, self
+        )
+        # Make thread daemon to avoid hanging when the main thread finishes (e.g.
+        # after mock build or VM test). Daemon threads are stopped on interpreter
+        # exit.
+        self._thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self._thread.start()
+        logging.info("Started repository proxy on port %s", self.port)
+
+    def stop(self):
+        """Stop repository proxy."""
+        if self.server is None:
+            return
+        self.server.shutdown()
+        self.server.server_close()
+        self.server = None
+        self._thread = None
+        self.token = None
+        logging.debug("Stopped repository proxy")
+
+    @property
+    def port(self):
+        """Get repository proxy port."""
+        if self.server is None:
+            raise RiftError("Repository proxy is not started")
+        return self.server.server_port
+
+    def repo_url(self, repo, host):
+        """Get repository URL for proxy."""
+        if not self.required or not repo.authenticated():
+            return repo.url
+        if self.server is None:
+            raise RiftError("Repository proxy is not started")
+        if repo.name not in self.repositories:
+            raise RiftError(
+                f"Missing repository route for key '{repo.name}' in repository proxy"
+            )
+        return f"http://{host}:{self.port}/{urllib.parse.quote(repo.name)}/"

--- a/lib/rift/repository/rpm.py
+++ b/lib/rift/repository/rpm.py
@@ -71,6 +71,7 @@ class ConsumableRepository:
         self.priority = priority
         if options is None:
             options = {}
+        self.auth = options.get('auth')
         self.module_hotfixes = options.get('module_hotfixes')
         self.excludepkgs = options.get('excludepkgs')
         self.proxy = options.get('proxy', default_proxy)
@@ -82,6 +83,10 @@ class ConsumableRepository:
     def is_file(self):
         """True if repository URL looks like a file URI."""
         return self.url.startswith(self.FILE_SCHEME) or self.url.startswith('/')
+
+    def authenticated(self):
+        """True if repository is remote and uses idp_token auth."""
+        return (not self.is_file()) and self.auth == 'idp_token'
 
     @property
     def path(self):

--- a/template/cloud-init.tpl
+++ b/template/cloud-init.tpl
@@ -61,6 +61,4 @@ write_files:
         export http_proxy="{{ proxy }}"
         export ftp_proxy="{{ proxy }}"
 {%- endif %}
-{%- if no_proxy is not none  %}
         export no_proxy="{{ no_proxy }}"
-{%- endif %}

--- a/template/mock.tpl
+++ b/template/mock.tpl
@@ -26,10 +26,10 @@ name={{ repo.name }}
 baseurl={{ repo.url }}
 priority={{ repo.priority }}
 enabled={% if 'main' in repo.variants %}1{% else %}0{% endif %}
-{%if repo.module_hotfixes %}
+{% if repo.module_hotfixes %}
 module_hotfixes={{ repo.module_hotfixes }}
 {% endif %}
-{%if repo.proxy %}
+{% if repo.proxy and not repo.authenticated %}
 proxy={{ repo.proxy }}
 {% endif %}
 {% endfor %}

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -1,0 +1,86 @@
+import json
+import os
+import re
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from rift import RiftError
+from rift.auth import Auth
+
+from .TestUtils import make_temp_file
+
+
+class AuthTest(unittest.TestCase):
+    """Unit tests for rift.auth.Auth; add new test groups as methods here."""
+
+    def setUp(self):
+        self._cred_tmp = make_temp_file("{}", delete=False, suffix=".json")
+        self._cred_path = self._cred_tmp.name
+        self._cred_tmp.close()
+        self._minimal_config = {
+            "idp_app_token": "app-token",
+            "s3_credential_file": self._cred_path,
+        }
+
+    def tearDown(self):
+        if os.path.isfile(self._cred_path):
+            os.unlink(self._cred_path)
+
+    def _write_state(self, data):
+        with open(self._cred_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def test_get_idp_token_noninteractive_env_token(self):
+        self._write_state({})
+        auth = Auth(self._minimal_config)
+        with patch.dict(os.environ, {"RIFT_AUTH_IDP_TOKEN": "from-env"}):
+            self.assertEqual(auth.get_idp_token_noninteractive(), "from-env")
+
+    def test_get_idp_token_noninteractive_missing_credentials_file(self):
+        missing = self._cred_path + ".missing"
+        self._minimal_config["s3_credential_file"] = missing
+        auth = Auth(self._minimal_config)
+        with self.assertRaisesRegex(
+            RiftError,
+            rf"Missing authentication state file {re.escape(missing)}\. "
+            r"Run 'rift auth' first\.",
+        ):
+            auth.get_idp_token_noninteractive()
+
+    def test_get_idp_token_noninteractive_missing_idp_token(self):
+        self._write_state({})
+        auth = Auth(self._minimal_config)
+        with self.assertRaisesRegex(
+            RiftError,
+            rf"Missing idp_token in authentication state file {re.escape(self._cred_path)}\. "
+            r"Run 'rift auth' first\.",
+        ):
+            auth.get_idp_token_noninteractive()
+
+    def test_get_idp_token_noninteractive_state_file(self):
+        exp = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._write_state(
+            {
+                "idp_token": "tok-from-file",
+                "idp_token_expiration": exp,
+            }
+        )
+        auth = Auth(self._minimal_config)
+        self.assertEqual(auth.get_idp_token_noninteractive(), "tok-from-file")
+
+    def test_get_idp_token_noninteractive_expired_token(self):
+        exp = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._write_state(
+            {
+                "idp_token": "expired",
+                "idp_token_expiration": exp,
+            }
+        )
+        auth = Auth(self._minimal_config)
+        with self.assertRaisesRegex(
+            RiftError,
+            rf"Missing idp_token in authentication state file {re.escape(self._cred_path)}\. "
+            r"Run 'rift auth' first\.",
+        ):
+            auth.get_idp_token_noninteractive()

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -35,7 +35,9 @@ class AuthTest(unittest.TestCase):
         self._write_state({})
         auth = Auth(self._minimal_config)
         with patch.dict(os.environ, {"RIFT_AUTH_IDP_TOKEN": "from-env"}):
-            self.assertEqual(auth.get_idp_token_noninteractive(), "from-env")
+            with self.assertLogs(level="DEBUG") as logs:
+                self.assertEqual(auth.get_idp_token_noninteractive(), "from-env")
+        self.assertIn("fetched idp token from environment", "\n".join(logs.output))
 
     def test_get_idp_token_noninteractive_missing_credentials_file(self):
         missing = self._cred_path + ".missing"

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -1,0 +1,194 @@
+#
+# Copyright (C) 2026 CEA
+#
+
+from unittest.mock import Mock, patch
+
+from rift import RiftError
+from rift.proxy import (
+    AuthenticatedRepositoryProxyRuntime,
+    _TokenAuthRepositoryProxyHandler,
+)
+from .TestUtils import RiftTestCase
+
+
+class _DummyRepo:
+    def __init__(self, name, url, authenticated):
+        self.name = name
+        self.url = url
+        self._authenticated = authenticated
+
+    def authenticated(self):
+        return self._authenticated
+
+
+class TokenAuthRepositoryProxyHandlerTest(RiftTestCase):
+    def test_build_upstream_url(self):
+        url = _TokenAuthRepositoryProxyHandler._build_upstream_url(
+            "https://example.org/repo",
+            "x86_64/repodata/repomd.xml",
+            "a=1&b=2",
+        )
+        self.assertEqual(
+            url,
+            "https://example.org/repo/x86_64/repodata/repomd.xml?a=1&b=2",
+        )
+
+    def test_build_forward_headers(self):
+        handler = _TokenAuthRepositoryProxyHandler.__new__(
+            _TokenAuthRepositoryProxyHandler
+        )
+        handler.headers = {
+            "Host": "127.0.0.1:8080",
+            "Connection": "keep-alive",
+            "Transfer-Encoding": "chunked",
+            "Accept": "application/json",
+            "User-Agent": "curl/8.0",
+        }
+
+        headers = handler._build_forward_headers("token-123")
+        self.assertEqual(
+            headers,
+            {
+                "Accept": "application/json",
+                "User-Agent": "curl/8.0",
+                "Authorization": "Bearer token-123",
+            },
+        )
+
+
+class AuthenticatedRepositoryProxyRuntimeTest(RiftTestCase):
+    @patch("rift.proxy.Auth")
+    def test_init(self, mock_auth):
+        repos = [
+            _DummyRepo("public", "https://repo/public", False),
+            _DummyRepo("private", "https://repo/private", True),
+        ]
+
+        runtime = AuthenticatedRepositoryProxyRuntime({"idp_app_token": "x"}, repos)
+
+        self.assertTrue(runtime.required)
+        self.assertEqual(list(runtime.repositories.keys()), ["private"])
+        mock_auth.assert_not_called()
+
+    @patch("rift.proxy.threading.Thread")
+    @patch("rift.proxy._ThreadingHTTPServer")
+    @patch("rift.proxy.Auth")
+    def test_runtime_start(
+        self,
+        mock_auth_cls,
+        mock_server_cls,
+        mock_thread_cls,
+    ):
+        mock_server = Mock()
+        mock_server.server_port = 51234
+        mock_server_cls.return_value = mock_server
+
+        mock_thread = Mock()
+        mock_thread_cls.return_value = mock_thread
+
+        mock_auth = Mock()
+        mock_auth.get_idp_token_noninteractive.return_value = "idp-token"
+        mock_auth_cls.return_value = mock_auth
+
+        repos = [_DummyRepo("private repo", "https://repo/private", True)]
+        runtime = AuthenticatedRepositoryProxyRuntime({"idp_app_token": "x"}, repos)
+
+        runtime.start()
+
+        mock_auth.get_idp_token_noninteractive.assert_called_once()
+        mock_server_cls.assert_called_once_with(
+            ("127.0.0.1", 0),
+            _TokenAuthRepositoryProxyHandler,
+            runtime,
+        )
+        mock_thread_cls.assert_called_once_with(
+            target=mock_server.serve_forever,
+            daemon=True,
+        )
+        mock_thread.start.assert_called_once()
+        self.assertTrue(runtime.active)
+        self.assertEqual(runtime.token, "idp-token")
+        self.assertEqual(runtime.port, 51234)
+
+    @patch("rift.proxy.Auth")
+    def test_start_skips_when_no_authenticated_repos(self, mock_auth):
+        repos = [_DummyRepo("public", "https://repo/public", False)]
+        runtime = AuthenticatedRepositoryProxyRuntime({"idp_app_token": "x"}, repos)
+
+        runtime.start()
+
+        self.assertFalse(runtime.active)
+        self.assertIsNone(runtime.token)
+        mock_auth.return_value.get_idp_token_noninteractive.assert_not_called()
+        mock_auth.assert_not_called()
+
+    @patch("rift.proxy.Auth")
+    def test_stop(self, mock_auth):
+        runtime = AuthenticatedRepositoryProxyRuntime(
+            {"idp_app_token": "x"},
+            [_DummyRepo("private", "https://repo/private", True)],
+        )
+        server = Mock()
+        runtime.server = server
+        runtime._thread = Mock()
+        runtime.token = "idp-token"
+
+        runtime.stop()
+
+        server.shutdown.assert_called_once()
+        server.server_close.assert_called_once()
+        self.assertIsNone(runtime.server)
+        self.assertIsNone(runtime._thread)
+        self.assertIsNone(runtime.token)
+
+    @patch("rift.proxy.Auth")
+    def test_port_raises_when_not_started(self, mock_auth):
+        runtime = AuthenticatedRepositoryProxyRuntime(
+            {"idp_app_token": "x"},
+            [_DummyRepo("private", "https://repo/private", True)],
+        )
+        with self.assertRaisesRegex(RiftError, "^Repository proxy is not started$"):
+            _ = runtime.port
+
+    @patch("rift.proxy.Auth")
+    def test_repo_url_returns_original_when_not_authenticated(self, mock_auth):
+        repo = _DummyRepo("public", "https://repo/public", False)
+        runtime = AuthenticatedRepositoryProxyRuntime({"idp_app_token": "x"}, [repo])
+
+        self.assertEqual(runtime.repo_url(repo, "127.0.0.1"), repo.url)
+
+    @patch("rift.proxy.Auth")
+    def test_repo_url_raises_when_not_started(self, mock_auth):
+        repo = _DummyRepo("private", "https://repo/private", True)
+        runtime = AuthenticatedRepositoryProxyRuntime({"idp_app_token": "x"}, [repo])
+
+        with self.assertRaisesRegex(RiftError, "^Repository proxy is not started$"):
+            runtime.repo_url(repo, "127.0.0.1")
+
+    @patch("rift.proxy.Auth")
+    def test_repo_url_encoded_repo_name(self, mock_auth):
+        repo = _DummyRepo("private repo", "https://repo/private", True)
+        runtime = AuthenticatedRepositoryProxyRuntime({"idp_app_token": "x"}, [repo])
+        runtime.server = Mock()
+        runtime.server.server_port = 41234
+
+        url = runtime.repo_url(repo, "10.0.2.2")
+
+        self.assertEqual(url, "http://10.0.2.2:41234/private%20repo/")
+
+    @patch("rift.proxy.Auth")
+    def test_repo_url_missing_repo_key(self, mock_auth):
+        runtime = AuthenticatedRepositoryProxyRuntime(
+            {"idp_app_token": "x"},
+            [_DummyRepo("private", "https://repo/private", True)],
+        )
+        runtime.server = Mock()
+        runtime.server.server_port = 41234
+        not_registered = _DummyRepo("other", "https://repo/other", True)
+
+        with self.assertRaisesRegex(
+            RiftError,
+            "^Missing repository route for key 'other' in repository proxy$",
+        ):
+            runtime.repo_url(not_registered, "127.0.0.1")

--- a/tests/repository/rpm.py
+++ b/tests/repository/rpm.py
@@ -378,6 +378,23 @@ class ConsumableRepositoryTest(RiftTestCase):
         repo =  ConsumableRepository('http://some/where/x86_64')
         self.assertEqual(repo.generic_url('x86_64'), 'http://some/where/$basearch')
 
+    def test_authenticated(self):
+        local_repo = ConsumableRepository(
+            "file:///repo/x86_64",
+            options={"auth": "idp_token"},
+        )
+        remote_without_auth_repo = ConsumableRepository(
+            "https://repo.example.org/x86_64",
+        )
+        remote_auth_repo = ConsumableRepository(
+            "https://repo.example.org/private/x86_64",
+            options={"auth": "idp_token"},
+        )
+
+        self.assertFalse(local_repo.authenticated())
+        self.assertFalse(remote_without_auth_repo.authenticated())
+        self.assertTrue(remote_auth_repo.authenticated())
+
 class ArchRepositoriesRPMTest(RiftTestCase):
     """
     Tests class for ArchRepositoriesRPM


### PR DESCRIPTION
Introduce a threaded internal proxy for remote package repositories that require token based authentication.

This kind of authentication is not supported by package managers such as dnf/yum. As soon as a repository is declared with `auth: idp_token` in project's configuration, Rift starts a thread with an HTTP server that acts as a proxy which injects the token in all HTTP requests to remote repos.

The token is either extracted from RIFT_AUTH_IDP_TOKEN environment variable or rift auth state file.

The URL to authenticated remote repositories are modified in Mock config and in testing VM to redirect to Rift's internal proxy. The host IP addresse in testing guest VM is systematically set in no_proxy environment variable to avoid libcurl (used by dnf and many others) sending the requests targeted Rift's internal proxy to IT global proxy.