### PR TITLE
Sync: add --retries option and --log-file

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -306,6 +306,8 @@ def make_parser():
     subprs.add_argument('-o', '--output', help='Synchronization output directory')
     subprs.add_argument('-m', '--max-size', type=int,
                         help='Max size authorized for the download of each file, in bytes')
+    subprs.add_argument('-r', '--retries', type=int,
+                        help='Allowed retries when a package download failed')
     subprs.add_argument('repositories', metavar='REPOSITORY', nargs='*',
                         help='repositories to synchronize (default: all)')
 
@@ -998,9 +1000,11 @@ def action_sync(args, config):
     if args.output:
         output = args.output
         max_size = args.max_size
+        retries = args.retries
     else:
         output = config.get('sync_output')
         max_size = None
+        retries = 0
     if output is None:
         raise RiftError(
             "Synchronization output directory must be defined with "
@@ -1042,7 +1046,7 @@ def action_sync(args, config):
                 )
                 sync['source'] = repo.get('url')
             synchronizer = RepoSyncFactory.get(config, name, output, sync,
-                                               max_size, arch)
+                                               max_size, retries, arch)
             if synchronizer.source in synchronized_sources:
                 logging.debug(
                     "Skipping already synchronized source %s",

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -306,9 +306,9 @@ def make_parser():
     subprs.add_argument('-o', '--output', help='Synchronization output directory')
     subprs.add_argument('-m', '--max-size', type=int,
                         help='Max size authorized for the download of each file, in bytes')
-    subprs.add_argument('-r', '--retries', type=int,
+    subprs.add_argument('-r', '--retries', type=int, default=0,
                         help='Allowed retries when a package download failed')
-    subprs.add_argument('-l', '--log-file', type=bool,
+    subprs.add_argument('-l', '--log-file', action='store_true',
                         help='Log the sync process to a log file in the current directory')
     subprs.add_argument('repositories', metavar='REPOSITORY', nargs='*',
                         help='repositories to synchronize (default: all)')

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -308,6 +308,8 @@ def make_parser():
                         help='Max size authorized for the download of each file, in bytes')
     subprs.add_argument('-r', '--retries', type=int,
                         help='Allowed retries when a package download failed')
+    subprs.add_argument('-l', '--log-file', type=bool,
+                        help='Log the sync process to a log file in the current directory')
     subprs.add_argument('repositories', metavar='REPOSITORY', nargs='*',
                         help='repositories to synchronize (default: all)')
 
@@ -1001,10 +1003,12 @@ def action_sync(args, config):
         output = args.output
         max_size = args.max_size
         retries = args.retries
+        enable_log_file = args.log_file
     else:
         output = config.get('sync_output')
         max_size = None
         retries = 0
+        enable_log_file = False
     if output is None:
         raise RiftError(
             "Synchronization output directory must be defined with "
@@ -1046,7 +1050,8 @@ def action_sync(args, config):
                 )
                 sync['source'] = repo.get('url')
             synchronizer = RepoSyncFactory.get(config, name, output, sync,
-                                               max_size, retries, arch)
+                max_size, retries, enable_log_file, arch
+            )
             if synchronizer.source in synchronized_sources:
                 logging.debug(
                     "Skipping already synchronized source %s",

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -142,7 +142,7 @@ class RepoSyncLftp(RepoSyncBase):
     def _run(self):
         """Run repository synchronization with LFTP."""
         log_part = (
-            f"--log {self.logfile} {self.source.path} {self.output}"
+            f"--log {self.logfile}"
             if self.enable_log_file
             else ""
         )
@@ -151,7 +151,8 @@ class RepoSyncLftp(RepoSyncBase):
             self.base_url,
             '-e',
             "set ssl:verify-certificate off; mirror --no-empty-dirs ",
-            f"{log_part} --delete ",
+            f"{self.include_arg} {self.exclude_arg} --delete",
+            f"{log_part} {self.source.path} {self.output} --delete",
             f"; quit"
         ]
         logging.debug(

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -151,7 +151,7 @@ class RepoSyncLftp(RepoSyncBase):
             self.base_url,
             '-e',
             "set ssl:verify-certificate off; mirror --no-empty-dirs ",
-            f"{log_part} --delete "
+            f"{log_part} --delete ",
             f"; quit"
         ]
         logging.debug(

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -73,6 +73,7 @@ class RepoSyncBase:
         self._logfh = None  # Initialized in _log_open()
         self.patterns = SyncPatterns(sync['include'], sync['exclude'])
         self.max_size = max_size
+        self.retries = retries
 
     @property
     def base_url(self):

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -57,7 +57,7 @@ SyncPatterns = collections.namedtuple('SyncPatterns', ['include', 'exclude'])
 
 class RepoSyncBase:
     """Common parent to all RepoSync* classes."""
-    def __init__(self, config, name, output, sync, max_size=None, arch=None):
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
         self.config = config
         self.name = name
         subdir = sync.get('subdir', '').lstrip('/')
@@ -121,8 +121,8 @@ class RepoSyncBase:
 
 class RepoSyncLftp(RepoSyncBase):
     """Synchronize remote repositories with LFTP."""
-    def __init__(self, config, name, output, sync, max_size=None, arch=None):
-        super().__init__(config, name, output, sync, max_size, arch)
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
+        super().__init__(config, name, output, sync, max_size, retries, arch)
         self.include_arg = ' '.join(
             [f"--include={pattern}" for pattern in self.patterns.include]
         )
@@ -164,8 +164,8 @@ class RepoSyncIndexed(RepoSyncBase):
     declared in index.
     """
 
-    def __init__(self, config, name, output, sync, max_size=None, arch=None):
-        super().__init__(config, name, output, sync, max_size, arch)
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
+        super().__init__(config, name, output, sync, max_size, retries, arch)
         self.indexed_files = []
 
     def _relpath_matches(self, relpath):
@@ -228,8 +228,8 @@ class RepoSyncEpel(RepoSyncIndexed):
 
     PUB_ROOT = "/pub/epel"
 
-    def __init__(self, config, name, output, sync, max_size=None, arch=None):
-        super().__init__(config, name, output, sync, max_size, arch)
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
+        super().__init__(config, name, output, sync, max_size, retries, arch)
         self.pub_url = f"{self.base_url}{self.PUB_ROOT}"
 
     def _process_line(self, line):
@@ -295,7 +295,7 @@ class RepoSyncEpel(RepoSyncIndexed):
         self.log_write(f"download {url_file}")
         logging.info("Downloading file %s", url_file)
         try:
-            download_file(url_file, output_file, self.max_size)
+            download_file(url_file, output_file, self.max_size, self.retries)
         except RiftError as err:
             logging.warning("Download failed, skipping entry: %s", str(err))
 
@@ -308,7 +308,7 @@ class RepoSyncEpel(RepoSyncIndexed):
             filelist_url = f"{self.pub_url}/fullfiletimelist-epel"
             logging.debug("Downloading EPEL files index %s", filelist_url)
             try:
-                download_file(filelist_url, tmp_file.name, self.max_size)
+                download_file(filelist_url, tmp_file.name, self.max_size, self.retries)
             except RiftError as err:
                 logging.warning("Download failed, skipping entry: %s", str(err))
 
@@ -360,7 +360,7 @@ class RepoSyncDnf(RepoSyncIndexed):
         self.log_write(f"download {url}")
         logging.info("Downloading file '%s' to '%s'", url, output_directory)
         try:
-            download_file(url, output_file, self.max_size)
+            download_file(url, output_file, self.max_size, self.retries)
         except RiftError as err:
             logging.warning("Download failed, skipping entry: %s", str(err))
 
@@ -443,9 +443,9 @@ class RepoSyncFactory:
             )
 
     @staticmethod
-    def get(config, name, output, sync, max_size=None, arch=None):
+    def get(config, name, output, sync, max_size=None, retries=0, arch=None):
         """Return the concrete RepoSync* class corresponding to the method."""
         RepoSyncFactory.check_valid_method(sync['method'])
         return RepoSyncFactory.METHODS[sync['method']](
-            config, name, output, sync, max_size, arch
+            config, name, output, sync, max_size, retries, arch
         )

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -57,7 +57,7 @@ SyncPatterns = collections.namedtuple('SyncPatterns', ['include', 'exclude'])
 
 class RepoSyncBase:
     """Common parent to all RepoSync* classes."""
-    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, enable_log_file=False, arch=None):
         self.config = config
         self.name = name
         subdir = sync.get('subdir', '').lstrip('/')
@@ -74,6 +74,7 @@ class RepoSyncBase:
         self.patterns = SyncPatterns(sync['include'], sync['exclude'])
         self.max_size = max_size
         self.retries = retries
+        self.enable_log_file = enable_log_file
 
     @property
     def base_url(self):
@@ -100,13 +101,15 @@ class RepoSyncBase:
         raise NotImplementedError
 
     def _log_open(self):
-        self._logfh = open(self.logfile, 'w+', encoding='utf-8')
+        if self.enable_log_file:
+            self._logfh = open(self.logfile, 'w+', encoding='utf-8')
 
     def log_write(self, entry):
         """Add entry message in synchronizer log file."""
-        if self._logfh is None:
-            self._log_open()
-        self._logfh.write(entry + '\n')
+        if self.enable_log_file:
+            if self._logfh is None:
+                self._log_open()
+            self._logfh.write(entry + '\n')
 
     def _log_close(self):
         if self._logfh is not None:
@@ -122,8 +125,8 @@ class RepoSyncBase:
 
 class RepoSyncLftp(RepoSyncBase):
     """Synchronize remote repositories with LFTP."""
-    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
-        super().__init__(config, name, output, sync, max_size, retries, arch)
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, enable_log_file=False, arch=None):
+        super().__init__(config, name, output, sync, max_size, retries, enable_log_file, arch)
         self.include_arg = ' '.join(
             [f"--include={pattern}" for pattern in self.patterns.include]
         )
@@ -138,13 +141,18 @@ class RepoSyncLftp(RepoSyncBase):
 
     def _run(self):
         """Run repository synchronization with LFTP."""
+        log_part = (
+            f"--log {self.logfile} {self.source.path} {self.output}"
+            if self.enable_log_file
+            else ""
+        )
         cmd = [
             'lftp',
             self.base_url,
             '-e',
-            "set ssl:verify-certificate off; mirror --no-empty-dirs "
-            f"{self.include_arg} {self.exclude_arg} --delete "
-            f"--log {self.logfile} {self.source.path} {self.output}; quit"
+            "set ssl:verify-certificate off; mirror --no-empty-dirs ",
+            f"{log_part} --delete "
+            f"; quit"
         ]
         logging.debug(
             "running synchronization command: %s",
@@ -165,8 +173,8 @@ class RepoSyncIndexed(RepoSyncBase):
     declared in index.
     """
 
-    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
-        super().__init__(config, name, output, sync, max_size, retries, arch)
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, enable_log_file=False, arch=None):
+        super().__init__(config, name, output, sync, max_size, retries, enable_log_file, arch)
         self.indexed_files = []
 
     def _relpath_matches(self, relpath):
@@ -229,8 +237,8 @@ class RepoSyncEpel(RepoSyncIndexed):
 
     PUB_ROOT = "/pub/epel"
 
-    def __init__(self, config, name, output, sync, max_size=None, retries=0, arch=None):
-        super().__init__(config, name, output, sync, max_size, retries, arch)
+    def __init__(self, config, name, output, sync, max_size=None, retries=0, enable_log_file=False, arch=None):
+        super().__init__(config, name, output, sync, max_size, retries, enable_log_file, arch)
         self.pub_url = f"{self.base_url}{self.PUB_ROOT}"
 
     def _process_line(self, line):
@@ -444,9 +452,9 @@ class RepoSyncFactory:
             )
 
     @staticmethod
-    def get(config, name, output, sync, max_size=None, retries=0, arch=None):
+    def get(config, name, output, sync, max_size=None, retries=0, enable_log_file=False, arch=None):
         """Return the concrete RepoSync* class corresponding to the method."""
         RepoSyncFactory.check_valid_method(sync['method'])
         return RepoSyncFactory.METHODS[sync['method']](
-            config, name, output, sync, max_size, retries, arch
+            config, name, output, sync, max_size, retries, enable_log_file, arch
         )

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -59,19 +59,20 @@ def download_file(url, output, max_size=None, retries=0):
     Download file pointed by url and save it in output path. Convert
     potential urllib download errors into RiftError.
     """
+
+
+    if max_size is not None:
+        with urllib.request.urlopen(url) as opened_url:
+            meta = opened_url.info()
+            length = meta["Content-Length"]
+            if (isinstance(length, str) and int(length) > max_size):
+                raise RiftError(
+                    f"'{url}' has a size of '{length}' bytes, larger than "
+                    f"max size '{max_size}', skipping download",
+                )
+
     for attempt in range(retries + 1):
         try:
-            if max_size is not None:
-                with urllib.request.urlopen(url) as opened_url:
-                    meta = opened_url.info()
-                    length = meta["Content-Length"]
-                    if (isinstance(length, str) and int(length) > max_size):
-                        raise RiftError(
-                            f"'{url}' has a size of '{length}' bytes, larger than "
-                            f"max size '{max_size}', skipping download",
-                        )
-
-
             urllib.request.urlretrieve(url, output)
 
         except (urllib.error.HTTPError, urllib.error.URLError) as error:
@@ -84,7 +85,7 @@ def download_file(url, output, max_size=None, retries=0):
             else:
                 delay = (attempt + 1) * 3
                 logging.info(
-                    "HTTP error while downloading %s: %s. Will retry in %s...",
+                    "Error while downloading %s: %s. Will retry in %s...",
                     url,
                     error,
                     delay

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -35,6 +35,8 @@ Set of utilities used in multiple Rift modules.
 
 import os
 import urllib
+import logging
+import time
 
 from datetime import datetime, timezone
 
@@ -52,32 +54,43 @@ def banner(title):
     """
     print(f"** {title} **")
 
-def download_file(url, output, max_size=None):
+def download_file(url, output, max_size=None, retries=0):
     """
     Download file pointed by url and save it in output path. Convert
     potential urllib download errors into RiftError.
     """
-    try:
-        if max_size is not None:
-            with urllib.request.urlopen(url) as opened_url:
-                meta = opened_url.info()
-                length = meta["Content-Length"]
-                if (isinstance(length, str) and int(length) > max_size):
-                    raise RiftError(
-                        f"'{url}' has a size of '{length}' bytes, larger than "
-                        f"max size '{max_size}', skipping download",
-                    )
+    for attempt in range(retries + 1):
+        try:
+            if max_size is not None:
+                with urllib.request.urlopen(url) as opened_url:
+                    meta = opened_url.info()
+                    length = meta["Content-Length"]
+                    if (isinstance(length, str) and int(length) > max_size):
+                        raise RiftError(
+                            f"'{url}' has a size of '{length}' bytes, larger than "
+                            f"max size '{max_size}', skipping download",
+                        )
 
 
-        urllib.request.urlretrieve(url, output)
-    except urllib.error.HTTPError as error:
-        raise RiftError(
-            f"HTTP error while downloading {url}: {str(error)}"
-        ) from error
-    except urllib.error.URLError as error:
-        raise RiftError(
-            f"URL error while downloading {url}: {str(error)}"
-        ) from error
+            urllib.request.urlretrieve(url, output)
+
+        except (urllib.error.HTTPError, urllib.error.URLError) as error:
+            if attempt == retries:
+            # maximun retries exceeded
+                raise RiftError(
+                    f"Error while downloading {url}: {str(error)}"
+                ) from error
+
+            else:
+                delay = (attempt + 1) * 3
+                logging.info(
+                    "HTTP error while downloading %s: %s. Will retry in %s...",
+                    url,
+                    error,
+                    delay
+                )
+                time.sleep(delay)
+
 
 def last_modified(url):
     """

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -60,7 +60,6 @@ def download_file(url, output, max_size=None, retries=0):
     potential urllib download errors into RiftError.
     """
 
-
     if max_size is not None:
         with urllib.request.urlopen(url) as opened_url:
             meta = opened_url.info()

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -85,7 +85,7 @@ def download_file(url, output, max_size=None, retries=0):
             else:
                 delay = (attempt + 1) * 3
                 logging.info(
-                    "Error while downloading %s: %s. Will retry in %s...",
+                    "Error while downloading %s: %s, will retry in %s...",
                     url,
                     error,
                     delay

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -692,7 +692,7 @@ class VMBuildTest(RiftProjectTestCase):
         ):
             with self.assertRaisesRegex(
                 RiftError,
-                "^URL error while downloading http://test: .*$",
+                "^Error while downloading http://test: .*$",
             ):
                 vm.build("http://test", False, False, vm.image_local)
         with patch(
@@ -701,7 +701,7 @@ class VMBuildTest(RiftProjectTestCase):
         ):
             with self.assertRaisesRegex(
                 RiftError,
-                "^HTTP error while downloading http://test: HTTP "
+                "^Error while downloading http://test: HTTP "
                 "Error 404: Not Found$",
             ):
                 vm.build(

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -376,7 +376,7 @@ class RepoSyncEpelTest(RiftTestCase):
                 self.assertRegex(
                     log.output[0],
                     r"WARNING:root:Download failed, skipping entry: "
-                    r"URL error while downloading http://test/.*: .*$"
+                    r"Error while downloading http://test/.*: .*$"
                 )
         synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
         with patch(

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -388,8 +388,8 @@ class RepoSyncEpelTest(RiftTestCase):
                 self.assertRegex(
                     log.output[0],
                     r"WARNING:root:Download failed, skipping entry: "
-                    r"HTTP error while downloading http://test/.*: "
-                    r"HTTP Error 404: Not Found"
+                    r"Error while downloading http://test/.*: "
+                    r"Error 404: Not Found"
                 )
 
 

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -97,22 +97,21 @@ class RepoSyncLftpTest(RiftTestCase):
         }
         synchronizer = RepoSyncLftp(self.config, 'repo', self.output, sync)
         synchronizer.run()
-        mock_subprocess_run.assert_called_once()
+        mock_subprocess_run.assert_called()
         args = mock_subprocess_run.call_args[0]
         self.assertEqual(args[0][0], 'lftp')
         self.assertEqual(args[0][1], 'http://repo')
-        self.assertTrue(f"/directory/ {self.output}/repo" in args[0][3])
-        self.assertFalse("--include" in args[0][3])
-        self.assertFalse("--exclude" in args[0][3])
-
+        self.assertTrue(f"/directory/ {self.output}/repo" in args[0][5])
+        self.assertFalse("--include" in args[0][4])
+        self.assertFalse("--exclude" in args[0][4])
+        self.assertFalse("--log {self.output}/sync_repo_" in args[0][5])
 
         # Test with log file enabled
         synchronizer = RepoSyncLftp(self.config, 'repo', self.output, sync, enable_log_file=True)
         synchronizer.run()
-        mock_subprocess_run.assert_called_once()
+        mock_subprocess_run.assert_called()
         args = mock_subprocess_run.call_args[0]
-        
-        self.assertTrue(f"--log {self.output}/sync_repo_" in args[0][3])
+        self.assertTrue(f"--log {self.output}/sync_repo_" in args[0][5])
 
     @patch('subprocess.run')
     def test_run_with_include_exclude(self, mock_subprocess_run):
@@ -127,10 +126,10 @@ class RepoSyncLftpTest(RiftTestCase):
         synchronizer.run()
         mock_subprocess_run.assert_called_once()
         args = mock_subprocess_run.call_args[0]
-        self.assertTrue("--include=include1" in args[0][3])
-        self.assertTrue("--include=include2" in args[0][3])
-        self.assertTrue("--exclude=exclude1" in args[0][3])
-        self.assertTrue("--exclude=exclude2" in args[0][3])
+        self.assertTrue("--include=include1" in args[0][4])
+        self.assertTrue("--include=include2" in args[0][4])
+        self.assertTrue("--exclude=exclude1" in args[0][4])
+        self.assertTrue("--exclude=exclude2" in args[0][4])
 
 class RepoSyncEpelTest(RiftTestCase):
     """

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -101,10 +101,18 @@ class RepoSyncLftpTest(RiftTestCase):
         args = mock_subprocess_run.call_args[0]
         self.assertEqual(args[0][0], 'lftp')
         self.assertEqual(args[0][1], 'http://repo')
-        self.assertTrue(f"--log {self.output}/sync_repo_" in args[0][3])
         self.assertTrue(f"/directory/ {self.output}/repo" in args[0][3])
         self.assertFalse("--include" in args[0][3])
         self.assertFalse("--exclude" in args[0][3])
+
+
+        # Test with log file enabled
+        synchronizer = RepoSyncLftp(self.config, 'repo', self.output, sync, enable_log_file=True)
+        synchronizer.run()
+        mock_subprocess_run.assert_called_once()
+        args = mock_subprocess_run.call_args[0]
+        
+        self.assertTrue(f"--log {self.output}/sync_repo_" in args[0][3])
 
     @patch('subprocess.run')
     def test_run_with_include_exclude(self, mock_subprocess_run):

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -388,8 +388,8 @@ class RepoSyncEpelTest(RiftTestCase):
                 self.assertRegex(
                     log.output[0],
                     r"WARNING:root:Download failed, skipping entry: "
-                    r"Error while downloading http://test/.*: "
-                    r"Error 404: Not Found"
+                    r"HTTP error while downloading http://test/.*: "
+                    r"HTTP error 404: Not Found"
                 )
 
 

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -388,8 +388,8 @@ class RepoSyncEpelTest(RiftTestCase):
                 self.assertRegex(
                     log.output[0],
                     r"WARNING:root:Download failed, skipping entry: "
-                    r"HTTP error while downloading http://test/.*: "
-                    r"HTTP error 404: Not Found"
+                    r"Error while downloading http://test/.*: "
+                    r"HTTP Error 404: Not Found"
                 )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,7 @@ class UtilsTest(RiftTestCase):
     def test_download_file_url_error(self):
         with self.assertRaisesRegex(
                 RiftError,
-                "URL error while downloading blob:localhost: "
+                "Error while downloading blob:localhost: "
                 "<urlopen error unknown url type: blob>"
         ):
             download_file("blob:localhost", "/tmp/blob")


### PR DESCRIPTION
Add the `--retries` option to the sync command to automatically retry downloading a package if it fails, as the issue is often temporary.

Additionally, disable the sync log file by default and introduce the `--log-file` option to re-enable logging when needed.