### PR TITLE
VM: support IDP token auth for remote images

### DIFF
--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -289,6 +289,10 @@ class Config():
                 'build_post_script': {
                     'default': _DEFAULT_VM_BUILD_POST_SCRIPT,
                 },
+                'auth': {
+                    'check': 'enum',
+                    'values': ['idp_token'],
+                },
             }
         },
         'vm_image':    {

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -59,6 +59,7 @@ from subprocess import Popen, PIPE, STDOUT, check_output, run, CalledProcessErro
 from jinja2 import Template
 
 from rift import RiftError
+from rift.auth import Auth
 from rift.Config import _DEFAULT_VIRTIOFSD, _DEFAULT_VARIANT
 from rift.repository import ProjectArchRepositories
 from rift.TempDir import TempDir
@@ -133,6 +134,11 @@ class VM():
             self._image_src = urllib.parse.urlparse(image)
         else:
             self._image_src = None
+        self._image_auth = vm_config.get('auth')
+        if self._image_auth:
+            self._auth = Auth(config)
+        else:
+            self._auth = None
 
         self._project_dir = config.project_dir
 
@@ -234,6 +240,12 @@ class VM():
         return (
             int(self.vmid, 16) % (port_range['max'] - port_range['min'])
         ) + port_range['min']
+
+    def _vm_image_bearer_token(self):
+        """Return bearer token for remote VM image HTTP(S) requests, or None."""
+        if self._image_auth != 'idp_token' or self._auth is None:
+            return None
+        return self._auth.get_idp_token_noninteractive()
 
     def _mk_tmp_img(self, image):
         """Create a temp VM image to avoid modifying the real image disk."""
@@ -419,6 +431,9 @@ class VM():
         # Setup proxy if defined
         setup_dl_opener(self.proxy, self.no_proxy)
 
+        # Get optional bearer token for remote VM image HTTP(S) requests.
+        bearer = self._vm_image_bearer_token()
+
         # Check presence of the local copy. If present and force is True, remove it
         # to force re-download. Otherwise skip download.
         if os.path.exists(self.image_local):
@@ -430,7 +445,10 @@ class VM():
                 os.unlink(self.image_local)
             else:
                 try:
-                    last_remote_modification = last_modified(self._image_src.geturl())
+                    last_remote_modification = last_modified(
+                        self._image_src.geturl(),
+                        bearer_token=bearer,
+                    )
                 except RiftError as err:
                     logging.debug(
                         "Local copy of VM image is present, unable to get remote image "
@@ -456,7 +474,11 @@ class VM():
 
         message(f"Download remote VM image {self._image_src.geturl()}")
         # Download VM image
-        download_file(self._image_src.geturl(), self.image_local)
+        download_file(
+            self._image_src.geturl(),
+            self.image_local,
+            bearer_token=bearer,
+        )
 
     def spawn(self, image=None, seed=None):
         """

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -34,6 +34,7 @@ Set of utilities used in multiple Rift modules.
 """
 
 import os
+import shutil
 import urllib
 import logging
 import time
@@ -54,51 +55,71 @@ def banner(title):
     """
     print(f"** {title} **")
 
-def download_file(url, output, max_size=None, retries=0):
+def download_file(url, output, max_size=None, retries=0, bearer_token=None):
     """
     Download file pointed by url and save it in output path. Convert
     potential urllib download errors into RiftError.
+
+    When max_size is set, the server Content-Length header is checked against
+    max_size before streaming the body (single GET).
+
+    If retries is set and is greater than 0, retry the download up to retries
+    times.
+
+    If bearer_token is set, send Authorization: Bearer <token> on the request.
     """
 
-    if max_size is not None:
-        with urllib.request.urlopen(url) as opened_url:
-            meta = opened_url.info()
-            length = meta["Content-Length"]
-            if (isinstance(length, str) and int(length) > max_size):
-                raise RiftError(
-                    f"'{url}' has a size of '{length}' bytes, larger than "
-                    f"max size '{max_size}', skipping download",
-                )
+    req = urllib.request.Request(url)
+    if bearer_token:
+        req.add_header('Authorization', f'Bearer {bearer_token}')
 
     for attempt in range(retries + 1):
         try:
-            urllib.request.urlretrieve(url, output)
+            if max_size is not None:
+                with urllib.request.urlopen(req) as opened_url:
+                    meta = opened_url.info()
+                    length = meta["Content-Length"]
+                    if (isinstance(length, str) and int(length) > max_size):
+                        raise RiftError(
+                            f"'{url}' has a size of '{length}' bytes, larger than "
+                            f"max size '{max_size}', skipping download",
+                        )
+                    with open(output, 'wb') as out_fh:
+                        shutil.copyfileobj(opened_url, out_fh)
+                    break
+            else:
+                with urllib.request.urlopen(req) as opened_url:
+                    with open(output, 'wb') as out_fh:
+                        shutil.copyfileobj(opened_url, out_fh)
+                break
 
         except (urllib.error.HTTPError, urllib.error.URLError) as error:
             if attempt == retries:
-            # maximun retries exceeded
+                # maximum retries exceeded
                 raise RiftError(
                     f"Error while downloading {url}: {str(error)}"
                 ) from error
 
-            else:
-                delay = (attempt + 1) * 3
-                logging.info(
-                    "Error while downloading %s: %s, will retry in %s...",
-                    url,
-                    error,
-                    delay
-                )
-                time.sleep(delay)
+            delay = (attempt + 1) * 3
+            logging.info(
+                "Error while downloading %s: %s, will retry in %s seconds…",
+                url,
+                error,
+                delay
+            )
+            time.sleep(delay)
 
-
-def last_modified(url):
+def last_modified(url, bearer_token=None):
     """
     Return the mtime of the URL using the Last-Modified header. By convention,
     Last-Modified is always in GMT/UTC timezone. Raises RiftError when unable to
     get or convert Last-Modified header to timestamp.
+
+    If bearer_token is set, send Authorization: Bearer <token> on the request.
     """
     req = urllib.request.Request(url, method='HEAD')
+    if bearer_token:
+        req.add_header('Authorization', f'Bearer {bearer_token}')
 
     try:
         with urllib.request.urlopen(req) as response:

--- a/template/project.conf
+++ b/template/project.conf
@@ -41,6 +41,12 @@ vm:
   # When a remote URL is set, rift downloads a copy of this image in temporary
   # directory before running it.
   #
+  # Authentication method for remote VM image. When not set, Rift uses no
+  # authentication. When set to idp_token, Rift sends the IDP access token as an
+  # HTTP Bearer token in the Authorization header.
+  #
+  # auth: idp_token
+  #
   # Optional VM settings
   #
   # Make a full copy of the image before using it.

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -435,7 +435,39 @@ class VMTest(RiftTestCase):
             self.assertFalse(os.path.exists(vm.image_local))
             vm._download(False)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
-            mock_download_file.assert_called_once_with(url, vm.image_local)
+            mock_download_file.assert_called_once_with(
+                url, vm.image_local, bearer_token=None)
+
+    @patch('rift.VM.Auth')
+    @patch('rift.VM.download_file')
+    @patch('rift.VM.message')
+    def test_download_idp_token_bearer(
+        self, mock_message, mock_download_file, mock_auth_cls
+    ):
+        """Remote VM image download sends Bearer token when vm.auth is idp_token."""
+        mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
+            'test-idp-token'
+        )
+        url = 'http://localhost/path/to/my_image.qcow2'
+        self.config.set(
+            'vm',
+            {
+                'image': url,
+                'auth': 'idp_token',
+            }
+        )
+        with patch(
+            'rift.VM.VM.image_local', new_callable=PropertyMock
+        ) as mock_image_local:
+            vm = VM(self.config, platform.machine())
+            tmpfile = make_temp_file("")
+            mock_image_local.return_value = tmpfile.name
+            os.unlink(vm.image_local)
+            self.assertFalse(os.path.exists(vm.image_local))
+            vm._download(False)
+            mock_message.assert_called_once_with(f"Download remote VM image {url}")
+            mock_download_file.assert_called_once_with(
+                url, vm.image_local, bearer_token='test-idp-token')
 
     @patch('rift.VM.download_file')
     @patch('rift.VM.message')
@@ -458,7 +490,8 @@ class VMTest(RiftTestCase):
             with self.assertLogs(level='DEBUG') as cm:
                 vm._download(True)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
-            mock_download_file.assert_called_once_with(url, vm.image_local)
+            mock_download_file.assert_called_once_with(
+                url, vm.image_local, bearer_token=None)
         self.assertIn(
             'INFO:root:Remove VM image local copy and force re-download for remote '
             'image',
@@ -492,6 +525,8 @@ class VMTest(RiftTestCase):
             mock_message.assert_not_called()
             # Check download_file() has not been called
             mock_download_file.assert_not_called()
+            mock_last_modified.assert_called_once_with(
+                url, bearer_token=None)
             self.assertIn(
                 "DEBUG:root:Local copy of VM image is already updated "
                 f"({int(os.path.getmtime(tmpfile.name))} > 0), skipping download of "
@@ -524,11 +559,44 @@ class VMTest(RiftTestCase):
             with self.assertLogs(level='DEBUG') as cm:
                 vm._download(False)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
-            mock_download_file.assert_called_once_with(url, vm.image_local)
+            mock_download_file.assert_called_once_with(
+                url, vm.image_local, bearer_token=None)
+            mock_last_modified.assert_called_once_with(
+                url, bearer_token=None)
         self.assertIn(
             'INFO:root:Remote VM image has been updated, removing local copy',
             cm.output
         )
+
+    @patch('rift.VM.last_modified')
+    @patch('rift.VM.Auth')
+    @patch('rift.VM.download_file')
+    def test_download_last_modified_bearer(
+        self, mock_download_file, mock_auth_cls, mock_last_modified
+    ):
+        """Test VM download last modified check uses Bearer token when vm.auth is idp_token."""
+        mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
+            'tok-head'
+        )
+        mock_last_modified.return_value = 0.0
+        url = 'http://localhost/path/to/my_image.qcow2'
+        self.config.set(
+            'vm',
+            {
+                'image': url,
+                'auth': 'idp_token',
+            }
+        )
+        with patch(
+            'rift.VM.VM.image_local', new_callable=PropertyMock
+        ) as mock_image_local:
+            vm = VM(self.config, platform.machine())
+            tmpfile = make_temp_file("")
+            mock_image_local.return_value = tmpfile.name
+            self.assertTrue(os.path.exists(vm.image_local))
+            vm._download(False)
+            mock_last_modified.assert_called_once_with(url, bearer_token='tok-head')
+            mock_download_file.assert_not_called()
 
     @patch('rift.VM.last_modified')
     @patch('rift.VM.download_file')
@@ -556,6 +624,8 @@ class VMTest(RiftTestCase):
                 vm._download(False)
             mock_message.assert_not_called()
             mock_download_file.assert_not_called()
+            mock_last_modified.assert_called_once_with(
+                url, bearer_token=None)
         self.assertIn(
             "DEBUG:root:Local copy of VM image is present, unable to get remote image "
             "modification date because of error (last-modified failure), skipping "
@@ -687,7 +757,7 @@ class VMBuildTest(RiftProjectTestCase):
         """Test VM build with URL error"""
         vm = VM(self.config, 'x86_64')
         with patch(
-            'rift.utils.urllib.request.urlretrieve',
+            'rift.utils.urllib.request.urlopen',
             side_effect=urllib.error.URLError('fake URL error')
         ):
             with self.assertRaisesRegex(
@@ -696,7 +766,7 @@ class VMBuildTest(RiftProjectTestCase):
             ):
                 vm.build("http://test", False, False, vm.image_local)
         with patch(
-            'rift.utils.urllib.request.urlretrieve',
+            'rift.utils.urllib.request.urlopen',
             side_effect=urllib.error.HTTPError(404, "404", 'Not Found', None, None)
         ):
             with self.assertRaisesRegex(

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -375,7 +375,7 @@ class RepoSyncEpelTest(RiftTestCase):
         }
         synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
         with patch(
-            'rift.utils.urllib.request.urlretrieve',
+            'rift.utils.urllib.request.urlopen',
             side_effect=urllib.error.URLError('fake URL error'),
         ):
             with self.assertLogs(level='WARNING') as log:
@@ -387,7 +387,7 @@ class RepoSyncEpelTest(RiftTestCase):
                 )
         synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
         with patch(
-            'rift.utils.urllib.request.urlretrieve',
+            'rift.utils.urllib.request.urlopen',
             side_effect=urllib.error.HTTPError(404, "404", 'Not Found', None, None),
         ):
             with self.assertLogs(level='WARNING') as log:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,9 @@
 #
 
 from io import StringIO, BytesIO
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, call, MagicMock
 import os
+import urllib.error
 
 from rift import RiftError
 from rift.utils import message, banner, download_file, last_modified
@@ -60,6 +61,63 @@ class UtilsTest(RiftTestCase):
         ):
             download_file("blob:localhost", "/tmp/blob")
 
+    @patch('rift.utils.time.sleep')
+    @patch('urllib.request.urlopen')
+    def test_download_file_retries_success(self, mock_urlopen, mock_sleep):
+        url = 'https://example.test/file'
+
+        open_cm = MagicMock()
+        open_cm.__enter__.return_value = BytesIO(b'payload')
+        open_cm.__exit__.return_value = False
+
+        # Simulate a transient error followed by a successful download
+        mock_urlopen.side_effect = [urllib.error.URLError('transient'), open_cm]
+
+        out = '/tmp/rift-dl-retry-test'
+        with self.assertLogs(level='INFO') as log_cm:
+            download_file(url, out, retries=2)
+
+        self.assert_file_exists(out)
+        mock_sleep.assert_called_once_with(3)
+        self.assertEqual(mock_urlopen.call_count, 2)
+        self.assertEqual(
+            log_cm.output,
+            [
+                f'INFO:root:Error while downloading {url}: <urlopen error transient>, '
+                f'will retry in 3 seconds…',
+            ],
+        )
+        os.remove(out)
+
+    @patch('rift.utils.time.sleep')
+    @patch('urllib.request.urlopen')
+    def test_download_file_retries_failure(
+            self, mock_urlopen, mock_sleep):
+        url = 'https://example.test/missing'
+        out = '/tmp/never-written'
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url, 503, 'Service Unavailable', None, None
+        )
+
+        with self.assertLogs(level='INFO') as log_cm:
+            with self.assertRaisesRegex(
+                RiftError,
+                r'^Error while downloading https://example\.test/missing: '
+                r'HTTP Error 503: Service Unavailable$',
+            ):
+                download_file(url, out, retries=2)
+
+        self.assertFalse(os.path.isfile(out))
+        self.assertCountEqual(
+            log_cm.output,
+            [
+                f'INFO:root:Error while downloading {url}: HTTP Error 503: '
+                f'Service Unavailable, will retry in 3 seconds…',
+                f'INFO:root:Error while downloading {url}: HTTP Error 503: '
+                f'Service Unavailable, will retry in 6 seconds…',
+            ],
+        )
+        mock_sleep.assert_has_calls([call(3), call(6)])
 
     @patch('urllib.request.urlopen')
     def test_last_modified(self, mock_urlopen):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2025 CEA
 #
 
-from io import StringIO
+from io import StringIO, BytesIO
 from unittest.mock import patch, Mock
 import os
 
@@ -27,6 +27,16 @@ class UtilsTest(RiftTestCase):
         download_file("file:///etc/hosts", "/tmp/blob", 40000)
         self.assert_file_exists("/tmp/blob")
         os.remove("/tmp/blob")
+
+    @patch('urllib.request.urlopen')
+    def test_download_file_bearer_token(self, mock_urlopen):
+        mock_urlopen.return_value.__enter__.return_value = BytesIO(b'x')
+        download_file('https://test', '/tmp/blob', bearer_token='tok')
+        # Check that Authorization header is set
+        req = mock_urlopen.call_args[0][0]
+        hdrs = dict(req.header_items())
+        self.assertEqual(hdrs.get('Authorization'), 'Bearer tok')
+        os.remove('/tmp/blob')
 
     @patch('urllib.request.urlopen')
     def test_download_file_too_large(self, mock_urlopen):
@@ -57,6 +67,17 @@ class UtilsTest(RiftTestCase):
         mock_response.getheader.return_value = "Sat, 1 Jan 2000 00:00:00 GMT"
         mock_urlopen.return_value.__enter__.return_value = mock_response
         self.assertEqual(last_modified("http://test"), 946684800)
+
+    @patch('urllib.request.urlopen')
+    def test_last_modified_bearer_token(self, mock_urlopen):
+        mock_response = Mock()
+        mock_response.getheader.return_value = "Sat, 1 Jan 2000 00:00:00 GMT"
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        self.assertEqual(last_modified("http://test", bearer_token='tok'), 946684800)
+        # Check that Authorization header is set
+        req = mock_urlopen.call_args[0][0]
+        hdrs = dict(req.header_items())
+        self.assertEqual(hdrs.get('Authorization'), 'Bearer tok')
 
     @patch('urllib.request.urlopen')
     def test_last_modified_header_not_found(self, mock_urlopen):


### PR DESCRIPTION
This commit adds support for HTTP authentication to download remote VM images with IDP token, using this configuration:

```
vm:
  image: https://server/…
  auth: idp_token
```

When set, the IDP token is obtained by rift non-interactively (ie. using RIFT_AUTH_IDP_TOKEN environment variable to auth cache file) and set as authorization bearer token in HTTP last modified and download requests.