### PR TITLE
Controller: add graph --formats CLI argument

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -319,6 +319,9 @@ def make_parser():
                         help="add project external dependencies in the graph")
     subprs.add_argument('--module',
                         help="represent packages from this module in the graph")
+    subprs.add_argument('-F', '--formats', nargs='+',
+                        choices=RIFT_SUPPORTED_FORMATS,
+                        help='restrict command to specific package formats')
     subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
                         help='packages to represent in the graph')
 
@@ -1107,7 +1110,7 @@ def action_graph(args, config, staff, modules):
     """Action for 'graph' command."""
     # Build dependency graph with all selected packages and generate graphviz
     # representation of this graph.
-    PackagesDependencyGraph.from_project(config, staff, modules).draw(
+    PackagesDependencyGraph.from_project(config, staff, modules, args.format).draw(
         args.with_external, get_packages_in_graph(args, config, staff, modules)
     )
     return 0

--- a/lib/rift/graph.py
+++ b/lib/rift/graph.py
@@ -399,8 +399,14 @@ class PackagesDependencyGraph:
         logging.debug("Graph size: %d", len(self.nodes))
 
     @classmethod
-    def from_project(cls, config, staff, modules):
-        """Build graph with all project's packages."""
+    def from_project(cls, config, staff, modules, formats=None):
+        """Build graph with all project's packages, optionally filtered by format."""
         graph = cls()
-        graph.build(ProjectPackages.list(config, staff, modules))
+        graph.build(
+            [
+                package for package in ProjectPackages.list(
+                    config, staff, modules
+                ) if not formats or package.format in formats
+            ]
+        )
         return graph

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -2018,9 +2018,16 @@ class ControllerProjectActionGraphTest(RiftProjectTestCase):
         )
         args = Mock()
         args.module = 'Great module'
+        args.formats = None
         args.packages = []
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
+        self.assertCountEqual(
+            get_packages_in_graph(args, self.config, self.staff, self.modules),
+            ['libone', 'libtwo']
+        )
+        # Check adding format does not change result in this case.
+        args.formats = ['rpm']
         self.assertCountEqual(
             get_packages_in_graph(args, self.config, self.staff, self.modules),
             ['libone', 'libtwo']
@@ -2416,6 +2423,29 @@ class ControllerArgumentsTest(RiftTestCase):
 
         args = ['gerrit', '--change', '1', '--patchset', '2', '/dev/null',
                 '--formats', 'fail']
+        with self.assertRaises(SystemExit):
+            opts = parser.parse_args(args)
+
+    def test_parse_args_graph(self):
+        """ Test graph command options parsing """
+        parser = make_parser()
+
+        args = ['graph']
+        opts = parser.parse_args(args)
+        self.assertFalse(opts.with_external)
+        self.assertIsNone(opts.formats)
+        self.assertIsNone(opts.module)
+        self.assertCountEqual(opts.packages, [])
+
+        args = ['graph', '--with-external', '--formats', 'rpm',
+                '--module', 'storage', 'package1', 'package2']
+        opts = parser.parse_args(args)
+        self.assertTrue(opts.with_external)
+        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertEqual(opts.module, 'storage')
+        self.assertCountEqual(opts.packages, ['package1', 'package2'])
+
+        args = ['graph', '--formats', 'fail']
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 


### PR DESCRIPTION
This new command line option allows restricting graph action to specific package formats, which could be useful when packages supports multiple formats.