### PR TITLE
Mock: bind-mount host RPM lib dir to evaluate spec

### DIFF
--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -61,6 +61,11 @@ _mock_chroot_global_mutex = threading.Lock()
 RPMLINT_CONFIG_V1 = 'rpmlint'
 RPMLINT_CONFIG_V2 = 'rpmlint.toml'
 
+# Host RPM database bind-mounted into mock chroot for rpmspec/rpmlint. This is
+# required for some advanced macros (eg. for kernel modules packages) that need
+# to query a valid RPM database.
+HOST_RPM_LIB_DIR = '/var/lib/rpm'
+
 
 def rpmlint_env(configdir=None):
     """
@@ -285,7 +290,7 @@ class Mock():
         filepath_rp = os.path.realpath(filepath)
         proc = self._exec(
             [
-                self._bind_mount_dirs_opt([filepath_rp]),
+                self._bind_mount_dirs_opt([HOST_RPM_LIB_DIR, filepath_rp]),
                 'chroot',
                 'rpmspec',
                 '--parse',
@@ -315,7 +320,7 @@ class Mock():
         """
         spec_fp = os.path.realpath(spec_filepath)
         spec_dir = os.path.dirname(spec_fp)
-        mount_paths = {spec_dir}
+        mount_paths = {HOST_RPM_LIB_DIR, spec_dir}
         if configdir:
             mount_paths.add(os.path.realpath(configdir))
         bind_opt = self._bind_mount_dirs_opt(mount_paths)

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from unittest.mock import patch, MagicMock, ANY
 
 from .TestUtils import RiftProjectTestCase
-from rift.Mock import Mock, rpmlint_chroot_script, rpmlint_env
+from rift.Mock import Mock, HOST_RPM_LIB_DIR, rpmlint_chroot_script, rpmlint_env
 from rift.repository import ProjectArchRepositories
 from rift.repository.rpm import ConsumableRepository
 from rift.RPM import RPM
@@ -205,13 +205,17 @@ class MockTest(RiftProjectTestCase):
         )
         mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
         mock.init([])
+        rpm_rp = os.path.realpath(HOST_RPM_LIB_DIR)
+        expected_bind_opt = (
+            '--plugin-option=bind_mount:dirs=['
+            f"('/dev/package.spec', '/dev/package.spec'),('{rpm_rp}', '{rpm_rp}')]"
+        )
         result = mock.read_spec('/dev/package.spec')
         mock_run_command.assert_called_with(
             [
                 'mock', '--config-opts', 'print_main_output=yes',
                 f"--configdir={mock._tmpdir.path}",
-                "--plugin-option=bind_mount:dirs="
-                "[('/dev/package.spec', '/dev/package.spec')]",
+                expected_bind_opt,
                 'chroot',
                 'rpmspec',
                 '--parse',
@@ -328,6 +332,12 @@ class MockTest(RiftProjectTestCase):
             RunResult(0, None, None),  # clean
         ]
         mock.init([])
+        rpm_rp: str = os.path.realpath(HOST_RPM_LIB_DIR)
+        expected_bind_opt = (
+            '--plugin-option=bind_mount:dirs=['
+            f"('/dev', '/dev'),('{rpm_rp}', '{rpm_rp}')]"
+        )
+
         result = mock.rpmlint(spec_path)
 
         # Check return value
@@ -351,7 +361,7 @@ class MockTest(RiftProjectTestCase):
         )
         mock_run_command.assert_any_call(
             base + [
-                "--plugin-option=bind_mount:dirs=[('/dev', '/dev')]",
+                expected_bind_opt,
                 '--quiet', 'chroot', '--', 'bash', '-c', expected_script,
             ],
             capture_output=True,


### PR DESCRIPTION
Some spec files (eg. kernel modules packages) have some advanced macros that need a valid RPM database to query. Bind-mount host RPM library directory to have host database in Mock's chroot.