### PR TITLE
Install kernel-devel in Mock's chroot along with rpmlint

### DIFF
--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -61,11 +61,6 @@ _mock_chroot_global_mutex = threading.Lock()
 RPMLINT_CONFIG_V1 = 'rpmlint'
 RPMLINT_CONFIG_V2 = 'rpmlint.toml'
 
-# Host RPM database bind-mounted into mock chroot for rpmspec/rpmlint. This is
-# required for some advanced macros (eg. for kernel modules packages) that need
-# to query a valid RPM database.
-HOST_RPM_LIB_DIR = '/var/lib/rpm'
-
 
 def rpmlint_env(configdir=None):
     """
@@ -290,7 +285,7 @@ class Mock():
         filepath_rp = os.path.realpath(filepath)
         proc = self._exec(
             [
-                self._bind_mount_dirs_opt([HOST_RPM_LIB_DIR, filepath_rp]),
+                self._bind_mount_dirs_opt([filepath_rp]),
                 'chroot',
                 'rpmspec',
                 '--parse',
@@ -320,7 +315,7 @@ class Mock():
         """
         spec_fp = os.path.realpath(spec_filepath)
         spec_dir = os.path.dirname(spec_fp)
-        mount_paths = {HOST_RPM_LIB_DIR, spec_dir}
+        mount_paths = {spec_dir}
         if configdir:
             mount_paths.add(os.path.realpath(configdir))
         bind_opt = self._bind_mount_dirs_opt(mount_paths)

--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -312,6 +312,12 @@ class Mock():
         """
         Install rpmlint in the chroot, run rpmlint on spec file in chroot, then
         clean the chroot. Return RunResult of rpmlint command.
+
+        This method also installs kernel-devel in the chroot, which is required
+        for some advanced macros (eg. for kernel modules packages) that expects
+        to find this package in RPM database. When this package is absent,
+        macros evaluation fails and rpmlint eventually returns an error while
+        the spec file is valid.
         """
         spec_fp = os.path.realpath(spec_filepath)
         spec_dir = os.path.dirname(spec_fp)
@@ -320,7 +326,7 @@ class Mock():
             mount_paths.add(os.path.realpath(configdir))
         bind_opt = self._bind_mount_dirs_opt(mount_paths)
 
-        # Install rpmlint in the chroot.
+        # Install rpmlint and kernel-devel in the chroot (removed by --clean).
         self._exec(
             [
                 '--no-clean',
@@ -330,6 +336,7 @@ class Mock():
                 'install',
                 '-y',
                 'rpmlint',
+                'kernel-devel',
             ]
         )
 
@@ -354,7 +361,7 @@ class Mock():
                 env=rpmlint_env(configdir),
             )
         finally:
-            # Clean the chroot to remove rpmlint.
+            # Clean the chroot to remove rpmlint, kernel-devel, and deps.
             self._exec(['--quiet', '--clean'])
 
     def resultrpms(self, pattern='*.rpm', sources=True):

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from unittest.mock import patch, MagicMock, ANY
 
 from .TestUtils import RiftProjectTestCase
-from rift.Mock import Mock, HOST_RPM_LIB_DIR, rpmlint_chroot_script, rpmlint_env
+from rift.Mock import Mock, rpmlint_chroot_script, rpmlint_env
 from rift.repository import ProjectArchRepositories
 from rift.repository.rpm import ConsumableRepository
 from rift.RPM import RPM
@@ -205,17 +205,13 @@ class MockTest(RiftProjectTestCase):
         )
         mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
         mock.init([])
-        rpm_rp = os.path.realpath(HOST_RPM_LIB_DIR)
-        expected_bind_opt = (
-            '--plugin-option=bind_mount:dirs=['
-            f"('/dev/package.spec', '/dev/package.spec'),('{rpm_rp}', '{rpm_rp}')]"
-        )
         result = mock.read_spec('/dev/package.spec')
         mock_run_command.assert_called_with(
             [
                 'mock', '--config-opts', 'print_main_output=yes',
                 f"--configdir={mock._tmpdir.path}",
-                expected_bind_opt,
+                "--plugin-option=bind_mount:dirs="
+                "[('/dev/package.spec', '/dev/package.spec')]",
                 'chroot',
                 'rpmspec',
                 '--parse',
@@ -332,12 +328,6 @@ class MockTest(RiftProjectTestCase):
             RunResult(0, None, None),  # clean
         ]
         mock.init([])
-        rpm_rp: str = os.path.realpath(HOST_RPM_LIB_DIR)
-        expected_bind_opt = (
-            '--plugin-option=bind_mount:dirs=['
-            f"('/dev', '/dev'),('{rpm_rp}', '{rpm_rp}')]"
-        )
-
         result = mock.rpmlint(spec_path)
 
         # Check return value
@@ -361,7 +351,7 @@ class MockTest(RiftProjectTestCase):
         )
         mock_run_command.assert_any_call(
             base + [
-                expected_bind_opt,
+                "--plugin-option=bind_mount:dirs=[('/dev', '/dev')]",
                 '--quiet', 'chroot', '--', 'bash', '-c', expected_script,
             ],
             capture_output=True,

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -342,7 +342,7 @@ class MockTest(RiftProjectTestCase):
         mock_run_command.assert_any_call(
             base + [
                 '--no-clean', '--no-cleanup-after', '--quiet',
-                '--pm-cmd', 'install', '-y', 'rpmlint',
+                '--pm-cmd', 'install', '-y', 'rpmlint', 'kernel-devel',
             ],
             live_output=ANY,
             capture_output=True,
@@ -374,11 +374,11 @@ class MockTest(RiftProjectTestCase):
         mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
         mock_run_command.side_effect = [
             RunResult(0, None, None),  # init
-            RunResult(1, 'install failed', None),  # install rpmlint
+            RunResult(1, 'install failed', None),  # install rpmlint/kernel-devel
         ]
         mock.init([])
         with self.assertRaisesRegex(RiftError, 'install failed'):
             mock.rpmlint('/dev/package.spec')
         mock.clean()
-        # Check mock called 2 commands: init and install rpmlint.
+        # Check mock called 2 commands: init and install rpmlint/kernel-devel.
         self.assertEqual(mock_run_command.call_count, 2)


### PR DESCRIPTION
This is a tentative fix fox rpmlint failure on kernel modules spec files.

Revert host RPM database bind mount which does not work in all cases:

- kernel-devel might not be installed on host (eg. in containers in CI)
- path to RPM database directory might not match on host and mock's chroot environment