### PR TITLE
VM: fix wrongly renamed vm_cmd shell function

### DIFF
--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -684,7 +684,7 @@ class VM():
         running on hosts for handling this VM.
         """
         return {
-            'cm_cmd': (
+            'vm_cmd': (
                 "ssh -oUserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no "
                 f"-oLogLevel=ERROR -T -p {self.port} root@127.0.0.1 \"$@\""
             ),

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -695,7 +695,7 @@ class VMTest(RiftTestCase):
         vm = VM(self.config, platform.machine())
         funcs = vm.local_test_funcs()
         self.assertIsInstance(funcs, dict)
-        self.assertCountEqual(funcs.keys(), ['cm_cmd', 'vm_wait', 'vm_reboot'])
+        self.assertCountEqual(funcs.keys(), ['vm_cmd', 'vm_wait', 'vm_reboot'])
 
     @patch('rift.VM.run_command')
     def test_run_test(self, mock_run_command):


### PR DESCRIPTION
This function has been renamed by mistake in 460e9a3. This commit restores previous name to fix the regression.