### PR TITLE
VM: possibility to pin kernel in VM image

### DIFF
--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -289,6 +289,7 @@ class Config():
                 'build_post_script': {
                     'default': _DEFAULT_VM_BUILD_POST_SCRIPT,
                 },
+                'kernel': {},
                 'auth': {
                     'check': 'enum',
                     'values': ['idp_token'],

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -190,6 +190,7 @@ class VM():
             vm_config.get('build_post_script')
         )
         self.images_cache = vm_config.get('images_cache')
+        self.kernel = vm_config.get('kernel')
 
     @property
     def vmid(self):
@@ -950,7 +951,8 @@ class VM():
         env_str = (
             f"RIFT_SHARED_FS_TYPE={self.shared_fs_type} "
             f"RIFT_ADDITIONAL_RPMS={':'.join(rpm_basenames)} "
-            f"RIFT_REPOS={':'.join([repo.name for repo in self._repos])}"
+            f"RIFT_REPOS={':'.join([repo.name for repo in self._repos])} "
+            f"RIFT_KERNEL={self.kernel or ''}"
         )
         with open(self.build_post_script, encoding='utf-8') as fh:
             if self.cmd(

--- a/template/build-post.sh
+++ b/template/build-post.sh
@@ -6,12 +6,26 @@ set -e
 echo '> Fetching Vm kernel version...'
 uname -r
 
+# When RIFT_KERNEL is defined (mapped to project's vm>kernel configuration
+# parameter, install this specific kernel from cloud image default package
+# repositories and pin this kernel as default entry in bootloader.
+if [ -n "${RIFT_KERNEL}" ]; then
+    echo "> Installing kernel ${RIFT_KERNEL}..."
+    dnf install -y "kernel-${RIFT_KERNEL}"
+    VMLINUZ=$(ls /boot/vmlinuz-*"${RIFT_KERNEL}"* 2>/dev/null | head -1)
+    if [ -z "${VMLINUZ}" ]; then
+        echo "Unable to find vmlinuz for kernel ${RIFT_KERNEL}"
+        exit 1
+    fi
+    grubby --set-default "${VMLINUZ}"
+fi
+
 echo '> Fetching Vm repositories...'
 grep '^\[' /etc/yum.repos.d/*
 
 echo '> Disable default repositories'
 for repo in $(grep "^\[" /etc/yum.repos.d/CentOS* /etc/yum.repos.d/alma* /etc/yum.repos.d/Rocky* -h | sed -e "s/\]\|\[//g"); do
-    yum-config-manager --disable $repo
+    dnf config-manager --disable $repo
     echo "    * $repo - disabled"
 done
 

--- a/template/project.conf
+++ b/template/project.conf
@@ -84,6 +84,12 @@ vm:
   # architecture or 'host' for other architectures.
   # cpu: "cortex-a72"
   # build_post_script: /path/to/build-post.sh
+  #
+  # Distro kernel release to install when building the VM image with
+  # `rift vm build`. When not set, the kernel from the base image
+  # is kept.
+  #
+  # kernel: 4.18.0-513.el8
 
 # Dedicated options for aarch64 builds
 #arch: "aarch64"

--- a/tests/Config.py
+++ b/tests/Config.py
@@ -512,6 +512,24 @@ class ConfigTest(RiftTestCase):
         )
         self.assertEqual(config.get('vm').get('port_range').get('max'), 30000)
 
+    def test_load_vm_kernel(self):
+        """Load vm.kernel parameter"""
+        cfgfile = make_temp_file(
+            textwrap.dedent(
+                """
+                set_annex:
+                  address: /a/dir
+                  type: directory
+                vm:
+                  image: /a/image.img
+                  kernel: 4.18.0-513.el8
+                """
+            )
+        )
+        config = Config()
+        config.load(cfgfile.name)
+        self.assertEqual(config.get('vm').get('kernel'), '4.18.0-513.el8')
+
     def test_load_gpg(self):
         """Load gpg parameters"""
         # Check without passphrase

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -75,6 +75,7 @@ class VMTest(RiftTestCase):
         self.assertFalse(vm.copymode)
         self.assertIsNone(vm._vm)
         self.assertIsNone(vm._tmpimg)
+        self.assertIsNone(vm.kernel)
 
         # arch specific
         self.config.set('arch', ['aarch64'])
@@ -823,6 +824,23 @@ class VMBuildTest(RiftProjectTestCase):
             fh.write("#!/bin/bash\n/bin/true\n")
         vm.build(self.valid_url, False, False, vm.image_local)
         self.assertEqual(os.path.exists(vm.image_local), True)
+
+    def test_build_build_script_kernel(self):
+        """Test VM build with build script and kernel configuration"""
+        self.config.options['vm']['kernel'] = '4.18.0-513.el8'
+        vm = VM(self.config, 'x86_64')
+        with open(vm.build_post_script, 'w', encoding='utf-8') as fh:
+            fh.write('#!/bin/bash\n')
+        vm.cmd = Mock(return_value=Mock(returncode=0))
+        vm._build_run_post_script([])
+        vm.cmd.assert_called_once()
+        self.assertIn('RIFT_KERNEL=4.18.0-513.el8', vm.cmd.call_args[0][0])
+
+        vm.kernel = None
+        vm.cmd.reset_mock()
+        vm._build_run_post_script([])
+        self.assertIn('RIFT_KERNEL=', vm.cmd.call_args[0][0])
+        self.assertNotIn('RIFT_KERNEL=4.18.0-513.el8', vm.cmd.call_args[0][0])
 
     def test_build_with_build_script_error(self):
         """Test VM build with build script error"""


### PR DESCRIPTION
Add possibility to pin a specific VM kernel version in Rift's project configuration. This kernel is installed and make default in bootloader at image build time, in build post script.

This makes possible to pin a specific kernel in testing VM, which is booted by default for all project's tests.