### PR TITLE
VM: add 'enable_kvm' config option

### DIFF
--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -79,6 +79,7 @@ _DEFAULT_VM_CLOUD_INIT_TPL = 'cloud-init.tpl'
 _DEFAULT_VM_BUILD_POST_SCRIPT = 'build-post.sh'
 _DEFAULT_VM_PORT_RANGE_MIN = 10000
 _DEFAULT_VM_PORT_RANGE_MAX = 15000
+_DEFAULT_VM_ENABLE_KVM = True
 _DEFAULT_QEMU_CMD = 'qemu-system-$arch'
 _DEFAULT_REPO_CMD = 'createrepo_c'
 _DEFAULT_SHARED_FS_TYPE = '9p'
@@ -302,6 +303,10 @@ class Config():
                     'check': 'enum',
                     'values': ['idp_token'],
                 },
+                'enable_kvm': {
+                    'check': 'bool',
+                    'default': _DEFAULT_VM_ENABLE_KVM
+                }
             }
         },
         'vm_image':    {

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -156,9 +156,13 @@ class VM():
         self.memory = vm_config.get('memory')
         self.qemu = config.get('qemu', arch=arch)
 
+        self.enable_kvm = vm_config.get('enable_kvm')
+
         # default emulated cpu architecture
         if self.arch == 'aarch64':
             self.cpu_type = vm_config.get('cpu', 'cortex-a72')
+        elif self.enable_kvm == False:
+            self.cpu_type = vm_config.get('cpu', 'qemu64')
         else:
             self.cpu_type = vm_config.get('cpu', 'host')
 
@@ -191,6 +195,7 @@ class VM():
         )
         self.images_cache = vm_config.get('images_cache')
         self.kernel = vm_config.get('kernel')
+
 
     @property
     def vmid(self):
@@ -295,7 +300,7 @@ class VM():
                     f'memory-backend-file,id=mem,size={str(self.memory)}M,mem-path=/tmp,share=on']
             # Use platform.machine() instead of platform.proccessor to be container
             # compatible.
-            if self.arch == platform.machine():
+            if self.arch == platform.machine() and self.enable_kvm:
                 cmd += ['-machine', 'memory-backend=mem,accel=kvm']
             else:
                 cmd += ['-machine', 'memory-backend=mem']
@@ -355,9 +360,9 @@ class VM():
         # acceleration
         # Use platform.machine() instead of platform.proccessor to be container
         # compatible.
-        if self.arch == platform.machine():
+        if self.arch == platform.machine() and self.enable_kvm:
             cmd += ['-enable-kvm']
-        else:
+        elif self.arch != platform.machine():
             cmd += ['-machine', 'virt']
 
         cmd += ['-cpu', self.cpu_type]


### PR DESCRIPTION
Some environments may not have '/dev/kvm' available. This commit allows using QEMU without KVM. This is much slower than with KVM due to the emulation overhead.