### PR TITLE
Static analysis of Containerfile with hadolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
           chown ci:ci ~ci/bin/podman
           chmod 755 ~ci/bin/podman
 
+      # hadolint is used for static analysis of Containerfile. Unfortunately, it
+      # is not packaged in distribution. Executable binary is downloaded from
+      # upstream project for CI.
+      - name: Download and install Hadolint
+        run: |
+          curl -L https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-x86_64 -o /usr/local/sbin/hadolint-linux-x86_64
+          chmod 0755 /usr/local/sbin/hadolint-linux-x86_64
+
       - name: Run podman info
         run: |
           su ci -c 'export PATH="/home/ci/bin:$PATH"; podman --root /tmp info'

--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -83,6 +83,7 @@ _DEFAULT_VM_ENABLE_KVM = True
 _DEFAULT_QEMU_CMD = 'qemu-system-$arch'
 _DEFAULT_REPO_CMD = 'createrepo_c'
 _DEFAULT_CONTAINER_CMD = 'podman'
+_DEFAULT_CONTAINER_LINTER_CMD = 'hadolint'
 _DEFAULT_SHARED_FS_TYPE = '9p'
 _DEFAULT_VIRTIOFSD = '/usr/libexec/virtiofsd'
 _DEFAULT_SYNC_METHOD = 'dnf'
@@ -373,7 +374,10 @@ class Config():
             'syntax': {
                 'command': {
                     'default': _DEFAULT_CONTAINER_CMD,
-                }
+                },
+                'linter': {
+                    'default': _DEFAULT_CONTAINER_LINTER_CMD,
+                },
             }
         },
         'rpm_macros': {

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -53,6 +53,7 @@ from rift.repository import ProjectArchRepositories, StagingRepository
 from rift.graph import PackagesDependencyGraph
 from rift.RPM import RPM, Spec
 from rift.Mock import Mock
+from rift.container import ContainerFile
 from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
 from rift.VM import VM
@@ -116,7 +117,8 @@ def make_parser():
     # Check options
     subprs = subparsers.add_parser('check',
                                    help='verify various config file syntaxes')
-    subprs.add_argument('type', choices=['staff', 'modules', 'info', 'spec'],
+    subprs.add_argument('type', choices=['staff', 'modules', 'info',
+                                         'spec', 'containerfile'],
                         metavar='CHKTYPE', help='type of check')
     subprs.add_argument('-f', '--file', metavar='FILE',
                         help='path of file to check')
@@ -375,7 +377,7 @@ def action_check(args, config):
         modules.load(config.get('modules_file'))
 
         if args.file is None:
-            raise RiftError("You must specifiy a file path (-f)")
+            raise RiftError("You must specify a file path (-f)")
 
         # If the package supports multiple format, check only the first as
         # the info file is the name for all formats.
@@ -387,13 +389,22 @@ def action_check(args, config):
     elif args.type == 'spec':
 
         if args.file is None:
-            raise RiftError("You must specifiy a file path (-f)")
+            raise RiftError("You must specify a file path (-f)")
 
         mock = Mock(config, platform.machine())
         repos = ProjectArchRepositories(config, platform.machine()).for_format('rpm')
         spec = Spec(args.file, mock, repos.all, config=config)
         spec.check()
         logging.info('Spec file is OK.')
+
+    elif args.type == 'containerfile':
+
+        if args.file is None:
+            raise RiftError("You must specify a file path (-f)")
+
+        container_file = ContainerFile(config, args.file)
+        container_file.check()
+        logging.info('Containerfile is OK.')
 
 
 def action_annex(args, config, staff, modules):

--- a/lib/rift/container.py
+++ b/lib/rift/container.py
@@ -126,7 +126,7 @@ class ContainerFile:
             if os.path.exists(pkg_config):
                 cmd[1:1] = ['--config', pkg_config]
 
-        logging.debug('Running hadolint: %s', ' '.join(cmd))
+        logging.debug('Running OCI linter command: %s', ' '.join(cmd))
         return run_command(cmd, capture_output=True, merge_out_err=True)
 
     def check(self, pkg=None):

--- a/lib/rift/package/oci.py
+++ b/lib/rift/package/oci.py
@@ -44,7 +44,7 @@ from rift.Config import _DEFAULT_VARIANT
 from rift.package._base import Package, ActionableArchPackage
 from rift.annex import Annex
 from rift.TestResults import TestCase, TestResults
-from rift.container import ContainerRuntime
+from rift.container import ContainerRuntime, ContainerFile
 from rift.utils import message, banner
 
 class PackageOCI(Package):
@@ -52,6 +52,7 @@ class PackageOCI(Package):
 
     def __init__(self, name, config, staff, modules):
         super().__init__(name, config, staff, modules, 'oci', 'Containerfile')
+        self.containerfile = None
         self.version = None
         self.release = None
         self.main_source = None
@@ -91,6 +92,21 @@ class PackageOCI(Package):
         if not self.release:
             raise RiftError("Unable to load oci release from metadata")
 
+    def load(self, infopath=None):
+        """Load package metadata, check its content and load Containerfile."""
+        # load infos.yaml with parent class
+        super().load(infopath)
+        self.containerfile = ContainerFile(self._config, self.buildfile)
+
+    def check(self):
+        # Check generic package metadata
+        super().check()
+
+        # Check Containerfile
+        assert self.containerfile is not None
+        message('Validate Containerfile...')
+        self.containerfile.check()
+
     def subpackages(self):
         """Returns list with container name."""
         # Containerfile do not really provide subpackages, then just return name
@@ -108,8 +124,9 @@ class PackageOCI(Package):
         raise NotImplementedError
 
     def analyze(self, review, configdir):
-        """Not supported for OCI packages."""
-        raise NotImplementedError
+        """Analyze Containerfile and update review accordingly."""
+        assert self.containerfile is not None
+        self.containerfile.analyze(review, configdir)
 
     def supports_arch(self, arch):
         """

--- a/template/project.conf
+++ b/template/project.conf
@@ -131,6 +131,19 @@ vm:
   #
   # kernel: 4.18.0-513.el8
 
+# OCI container options
+#
+# The command key defines the container runtime CLI used to build, run and
+# export OCI images. Default value is 'podman'.
+#
+# The linter key defines the Containerfile static analysis tool; either
+# executable name in $PATH or absolute path. Note that Hadolint is the only
+# tool supported by Rift. Default value is 'hadolint'.
+#
+#containers:
+#  command: podman
+#  linter: hadolint
+
 # Dedicated options for aarch64 builds
 #arch: "aarch64"
 #arch_efi_bios: "/ccc/home/cont001/ocre/cedeyna/Ocean/rift/vendor/QEMU_EFI.fd"

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -330,7 +330,7 @@ class ControllerProjectActionCheckTest(RiftProjectTestCase):
     def test_check_info_without_file(self):
         """check info without file fails"""
         with self.assertRaisesRegex(
-            RiftError, r"You must specifiy a file path \(-f\)"
+            RiftError, r"You must specify a file path \(-f\)"
         ):
             exit_code = main(['check', 'info'])
             self.assertEqual(exit_code, 1)
@@ -359,7 +359,7 @@ class ControllerProjectActionCheckTest(RiftProjectTestCase):
     def test_check_spec_without_file(self):
         """check spec without file fails"""
         with self.assertRaisesRegex(
-            RiftError, r"You must specifiy a file path \(-f\)"
+            RiftError, r"You must specify a file path \(-f\)"
         ):
             exit_code = main(['check', 'spec'])
             self.assertEqual(exit_code, 1)
@@ -386,6 +386,30 @@ class ControllerProjectActionCheckTest(RiftProjectTestCase):
         self.make_pkg()
         with self.assertRaisesRegex(RiftError, "/dev/fail does not exist"):
             main(['check', 'spec', '-f', '/dev/fail'])
+
+    def test_check_containerfile_without_file(self):
+        """check containerfile without file fails"""
+        with self.assertRaisesRegex(
+            RiftError, r"You must specify a file path \(-f\)"):
+            main(['check', 'containerfile'])
+
+    def test_check_containerfile(self):
+        """simple check containerfile"""
+        self.make_pkg(formats=['oci'])
+        with self.assertLogs(level='INFO') as log:
+            main(
+                ['check', 'containerfile', '-f', self.buildfiles['pkg:oci']]
+            )
+        self.assertIn(
+            'INFO:root:Containerfile is OK.',
+            log.output
+        )
+
+    def test_check_containerfile_not_found(self):
+        """check containerfile file not found fails"""
+        self.make_pkg()
+        with self.assertRaisesRegex(RiftError, "Unable to find Containerfile /dev/fail"):
+            main(['check', 'containerfile', '-f', '/dev/fail'])
 
 
 class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
@@ -2890,9 +2914,11 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
     Tests class for Controller action gerrit
     """
 
+    @patch('rift.container.ContainerFile.analyze')
     @patch('rift.package.rpm.Mock')
     @patch('rift.Controller.Review')
-    def test_gerrit_multiformats(self, mock_review, mock_mock):
+    def test_gerrit_multiformats(self, mock_review, mock_mock,
+                                 mock_containerfile_analyze):
         """simple gerrit with multiformats package"""
         self.make_pkg()
         patch_file = make_temp_file(
@@ -2925,24 +2951,19 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         mock_mock.return_value.read_spec = read_file
         # Emulate rpmlint to return returncode 0
         mock_mock.return_value.rpmlint.return_value.returncode = 0
-        with self.assertLogs(level='INFO') as log:
-            main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
         # Check rpmlint is run to analyze the RPM buildfile.
         mock_mock.return_value.rpmlint.assert_called_once()
-        # Check presence of log message to indicate unable to analyze OCI
-        # buildfile.
-        self.assertIn(
-            'INFO:root:Skipping package format oci which does not support '
-            'static analysis',
-            log.output,
-        )
+        # Check Containerfile static analysis is run for OCI buildfile.
+        mock_containerfile_analyze.assert_called_once()
         # Check review has not been invalidated but pushed
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
+    @patch('rift.container.ContainerFile.analyze')
     @patch('rift.package.rpm.Mock')
     @patch('rift.Controller.Review')
-    def test_gerrit_rpm(self, mock_review, mock_mock):
+    def test_gerrit_rpm(self, mock_review, mock_mock, mock_containerfile_analyze):
         """simple gerrit on rpm package"""
         self.make_pkg(formats=['rpm'])
         patch_file = make_temp_file(
@@ -2967,15 +2988,18 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
         # Check rpmlint is run to analyze the RPM buildfile.
         mock_mock.return_value.rpmlint.assert_called_once()
+        # Check Containerfile static analysis is skipped for RPM-only package.
+        mock_containerfile_analyze.assert_not_called()
 
         # Check review has not been invalidated but pushed
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
+    @patch('rift.container.ContainerFile.analyze')
     @patch('rift.package.rpm.Mock')
     @patch('rift.Controller.Review')
-    def test_gerrit_oci(self, mock_review, mock_mock):
-        """simple gerrit on rpm package"""
+    def test_gerrit_oci(self, mock_review, mock_mock, mock_containerfile_analyze):
+        """simple gerrit on oci package"""
         self.make_pkg(formats=['oci'])
         patch_file = make_temp_file(
             textwrap.dedent("""
@@ -2992,25 +3016,21 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                 """))
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with self.assertLogs(level='INFO') as log:
-            main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
-        # Check static analysis is skipped for OCI-only package.
+        main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        # Check RPM static analysis is skipped for OCI-only package.
         mock_mock.return_value.rpmlint.assert_not_called()
-        # Check presence of log message to indicate unable to analyze OCI
-        # buildfile.
-        self.assertIn(
-            'INFO:root:Skipping package format oci which does not support '
-            'static analysis',
-            log.output,
-        )
+        # Check Containerfile static analysis is run for OCI buildfile.
+        mock_containerfile_analyze.assert_called_once()
 
         # Check review has not been invalidated but pushed
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
+    @patch('rift.container.ContainerFile.analyze')
     @patch('rift.package.rpm.Mock')
     @patch('rift.Controller.Review')
-    def test_gerrit_review_invalidated(self, mock_review, mock_mock):
+    def test_gerrit_review_invalidated(self, mock_review, mock_mock,
+                                       mock_containerfile_analyze):
         """gerrit review invalidated"""
         # Make package and inject rpmlint error ($RPM_BUILD_ROOT and
         # RPM_SOURCE_DIR in buildsteps) in RPM spec file, with both rpmlint v1
@@ -3045,6 +3065,8 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         mock_mock.return_value.read_spec = read_file
         with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
             main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        # Check Containerfile static analysis is skipped for RPM-only patch.
+        mock_containerfile_analyze.assert_not_called()
         # Check review has been invalidated and pushed
         mock_review.return_value.invalidate.assert_called_once()
         mock_review.return_value.push.assert_called_once()

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -3065,7 +3065,7 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         mock_mock.return_value.read_spec = read_file
         with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
             main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
-        # Check Containerfile static analysis is skipped for RPM-only patch.
+        # Check Containerfile static analysis is skipped for RPM-only package.
         mock_containerfile_analyze.assert_not_called()
         # Check review has been invalidated and pushed
         mock_review.return_value.invalidate.assert_called_once()

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -156,6 +156,15 @@ Description for package {{ name }} variant %{variant}
 - Update to {{ version }} release
 """
 
+CONTAINERFILE_TPL = """\
+FROM debian:stable
+{% for line in lines %}
+{{ line }}
+{% endfor %}
+"""
+
+EXPECTED_HADOLINT_EXEC = "hadolint-linux-x86_64"
+
 SubPackage = namedtuple("SubPackage", ["name"])
 PackageTestDef = namedtuple("PackageTestDef", ["name", "local", "formats"])
 
@@ -478,6 +487,11 @@ def gen_rpm_spec(**kwargs):
 def read_file(filepath):
     """Read a text file and return its content."""
     return open(filepath).read()
+#
+# Containerfile
+#
+def gen_containerfile(**kwargs):
+    return jinja2.Template(CONTAINERFILE_TPL).render(**kwargs)
 
 def host_rpmlint(filepath, configdir=None):
     """
@@ -520,3 +534,61 @@ def make_temp_file(text, delete=True, suffix=None):
 def nullcontext():
     """Context manager that does nothing."""
     yield
+
+#
+# Executable commands utilities
+#
+
+def command_available(command):
+    """
+    Check if a command is available for execution, by verifying:
+    1. If it's a command name, it checks if it exists in the system PATH
+    2. If it's an absolute path, it checks if the file exists and is executable
+    3. If it's a relative path, it checks if the file exists relative to current
+      directory and is executable
+    Return True if the command is available and executable, False otherwise.
+    """
+
+    # Handle empty or None commands
+    if not command or not command.strip():
+        return False
+
+    # Check if it's an absolute path
+    if os.path.isabs(command):
+        return _is_executable_file(command)
+
+    # Check if it's a relative path (contains path separators or starts with ./)
+    if (os.sep in command or (os.altsep and os.altsep in command) or
+        command.startswith('./') or command.startswith('../')):
+        # Resolve relative path
+        resolved_path = os.path.abspath(command)
+        return _is_executable_file(resolved_path)
+
+    # Check if it's a file in the current directory
+    if os.path.exists(command) and os.path.isfile(command):
+        return os.access(command, os.X_OK)
+
+    # It's a command name, check if it's in PATH
+    return shutil.which(command) is not None
+
+
+def _is_executable_file(file_path):
+    """
+    Check if a file exists and is executable. Return True if the file exists and
+    is executable, False otherwise.
+    """
+    try:
+        # Check if file exists
+        if not os.path.exists(file_path):
+            return False
+
+        # Check if it's a file (not a directory)
+        if not os.path.isfile(file_path):
+            return False
+
+        # Check if it's executable
+        return os.access(file_path, os.X_OK)
+
+    except (OSError, ValueError):
+        # Handle any system errors or invalid paths
+        return False

--- a/tests/container.py
+++ b/tests/container.py
@@ -1,16 +1,24 @@
 #
 # Copyright (C) 2026 CEA
 #
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
-from .TestUtils import RiftProjectTestCase
+from .TestUtils import (
+    RiftProjectTestCase,
+    command_available,
+    make_temp_file,
+    gen_containerfile,
+    EXPECTED_HADOLINT_EXEC
+)
 
-from rift.container import ContainerRuntime
+from rift.container import ContainerRuntime, ContainerFile
 from rift.package.oci import PackageOCI
 from rift.run import RunResult
+from rift.Gerrit import Review
 from rift import RiftError
 
-class ContainerTest(RiftProjectTestCase):
+
+class ContainerRuntimeTest(RiftProjectTestCase):
     """Tests class for ContainerRuntime"""
 
     def test_tag(self):
@@ -88,3 +96,84 @@ class ContainerTest(RiftProjectTestCase):
         mock_run_command.assert_called_once_with(
             ['podman', '--root', container.rootdir, 'push', 'pkg:1.0-1-x86_64',
              'oci-archive:/path/to/container.tar:pkg:1.0-1-x86_64'])
+
+class ContainerFileTest(RiftProjectTestCase):
+    """Tests class for ContainerFile"""
+
+    def test_check(self):
+        """ContainerFile check"""
+        if not command_available(EXPECTED_HADOLINT_EXEC):
+            self.skipTest("hadolint executable not found")
+        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        tmp_container_file = make_temp_file(gen_containerfile())
+        container_file = ContainerFile(self.config, tmp_container_file.name)
+        container_file.check()
+
+    def test_check_error(self):
+        """ContainerFile check with error"""
+        if not command_available(EXPECTED_HADOLINT_EXEC):
+            self.skipTest("hadolint executable not found")
+        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        tmp_container_file = make_temp_file(gen_containerfile(lines=["WORKDIR fail"]))
+        container_file = ContainerFile(self.config, tmp_container_file.name)
+        with self.assertRaisesRegex(
+            RiftError, r"^Containerfile check error\: .* Use absolute WORKDIR"
+        ):
+            container_file.check()
+
+    def test_check_linter_not_found(self):
+        """ContainerFile check error log linter not found"""
+        self.config.update({'containers': { 'linter': 'hadolint-not-found' }})
+        tmp_container_file = make_temp_file(gen_containerfile())
+        container_file = ContainerFile(self.config, tmp_container_file.name)
+        with self.assertLogs(level='ERROR') as log:
+            container_file.check()
+        self.assertIn(
+            "ERROR:root:Unable to find Containerfile linter executable "
+            "'hadolint-not-found'",
+            log.output
+        )
+
+    def test_analyze(self):
+        """ContainerFile analyze"""
+        if not command_available(EXPECTED_HADOLINT_EXEC):
+            self.skipTest("hadolint executable not found")
+        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        self.make_pkg()
+        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        tmp_container_file = make_temp_file(gen_containerfile())
+        container_file = ContainerFile(self.config, tmp_container_file.name)
+        review = Mock(spec=Review)
+        container_file.analyze(review, package.dir)
+        review.add_comment.assert_not_called()
+        review.invalidate.assert_not_called()
+
+    def test_analyze_with_error(self):
+        """ContainerFile analyze with error"""
+        if not command_available(EXPECTED_HADOLINT_EXEC):
+            self.skipTest("hadolint executable not found")
+        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        self.make_pkg()
+        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        tmp_container_file = make_temp_file(gen_containerfile(lines=["WORKDIR fail"]))
+        container_file = ContainerFile(self.config, tmp_container_file.name)
+        review = Mock(spec=Review)
+        container_file.analyze(review, package.dir)
+        review.add_comment.assert_called_with(
+            container_file.path, '3', 'DL3000', 'Use absolute WORKDIR')
+        review.invalidate.assert_called_once()
+
+    def test_analyze_linter_not_found(self):
+        """ContainerFile analyze error when linter not found"""
+        self.config.update({'containers': { 'linter': 'hadolint-not-found' }})
+        self.make_pkg()
+        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        tmp_container_file = make_temp_file(gen_containerfile())
+        container_file = ContainerFile(self.config, tmp_container_file.name)
+        review = Mock(spec=Review)
+        with self.assertRaisesRegex(
+            RiftError,
+            "Unable to find Containerfile linter executable 'hadolint-not-found'"
+        ):
+            container_file.analyze(review, package.dir)
+        review.invalidate.assert_not_called()


### PR DESCRIPTION
Rift now supports static analysis of Containerfile by calling [Hadolint](https://github.com/hadolint/hadolint) linter. This includes `rift {check,gerrit;gitlab}` commands and automatic check on validation.

In the same way `Spec` class handles the RPM package source file, the `ContainerFile` class is introduced to handle operations on OCI container source definition file.

Hadolint is a weak dependency, it is used when present on system but Rift does not fail if not. It just emits an error log if executable cannot be found.

Tests are added to run tests with Hadolint integration, tests are gently skipped if `hadolint` executable cannot be found.