### PR TITLE
OCI: support detached GPG signature

### DIFF
--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -53,7 +53,7 @@ from rift.repository import ProjectArchRepositories, StagingRepository
 from rift.graph import PackagesDependencyGraph
 from rift.RPM import RPM, Spec
 from rift.Mock import Mock
-from rift.container import ContainerFile
+from rift.container import ContainerFile, ContainerArchive
 from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
 from rift.VM import VM
@@ -569,7 +569,7 @@ def validate_pkgs(config, args, pkgs, arch):
         # Also publish on working repo if requested
         # XXX: All packages should be published when all of them have been validated
         if (pkg_results is None or pkg_results.global_result) and args.publish:
-            pkg_arch.publish()
+            pkg_arch.publish(sign=args.sign)
 
         # Clean build environment
         pkg_arch.clean(noquit=args.noquit)
@@ -718,7 +718,7 @@ def build_pkgs(args, pkgs, arch, staging):
 
         # Publish
         if build_success and args.publish:
-            pkg_arch.publish(updaterepo=args.updaterepo)
+            pkg_arch.publish(updaterepo=args.updaterepo, sign=args.sign)
         else:
             logging.info("Skipping publication")
 
@@ -816,9 +816,14 @@ def action_build(args, config):
 def action_sign(args, config):
     """Action for 'sign' command."""
     for package in args.packages:
-        banner(f"Signing package {package} with GPG key")
-        rpm = RPM(package, config)
-        rpm.sign()
+        if package.endswith('.rpm'):
+            banner(f"Signing RPM package {package} with GPG key")
+            rpm = RPM(package, config)
+            rpm.sign()
+        elif package.endswith('.tar'):
+            banner(f"Signing OCI archive {package} with GPG key")
+            container_archive = ContainerArchive(config, package)
+            container_archive.sign()
     return 0
 
 def action_test(args, config):

--- a/lib/rift/container.py
+++ b/lib/rift/container.py
@@ -91,7 +91,7 @@ class ContainerRuntime:
         ]
         return run_command(cmd, capture_output=True)
 
-    def archive(self, actionable_pkg, path):
+    def archive(self, actionable_pkg, container_archive):
         """
         Execute command to export the provided OCI actionable package container
         image as OCI archive in the provided path.
@@ -100,9 +100,77 @@ class ContainerRuntime:
             self.config.get('containers').get('command'),
             '--root', self.rootdir,
             'push', self.tag(actionable_pkg),
-            f"oci-archive:{path}:{self.tag(actionable_pkg)}"
+            f"oci-archive:{container_archive.path}:{self.tag(actionable_pkg)}"
         ]
         return run_command(cmd)
+
+
+class ContainerArchive:
+    """Handle OCI container archive and their cryptographic signatures."""
+
+    def __init__(self, config, path):
+        self.config = config
+        self.path = path
+
+    @property
+    def signature(self):
+        """Return path to container archive detached signature file."""
+        return f"{self.path}.gpg"
+
+    def sign(self):
+        """
+        Cryptographically sign OCI archive with GPG key. Raise RiftError if GPG
+        parameters are missing in project configuration or GPG key is not found.
+        """
+        # GPG parameters not defined in project config, raise RiftError.
+        if self.config is None or self.config.get('gpg') is None:
+            raise RiftError(
+                "Unable to retrieve GPG configuration, unable to sign OCI "
+                f"archive {self.path}",
+            )
+
+        gpg = self.config.get('gpg')
+        keyring = os.path.expanduser(gpg.get('keyring'))
+
+        # Check gpg_keyring path exists or raise error
+        if not os.path.exists(keyring):
+            raise RiftError(
+                f"GPG keyring path {keyring} does not exist, unable to sign "
+                f"OCI archive {self.path}"
+            )
+
+        gpg_passphrase_args = []
+
+        # If passphrase is defined, add the passphrase to gpg command
+        # parameters and make it non-interactive.
+        if gpg.get('passphrase') is not None:
+            gpg_passphrase_args = [
+                '--batch',
+                '--passphrase',
+                gpg.get('passphrase'),
+                '--pinentry-mode',
+                'loopback',
+            ]
+
+        cmd = [
+            'gpg',
+            '--detach-sign',
+            '--output',
+            self.signature,
+            '--default-key',
+            gpg.get('key'),
+            self.path,
+        ]
+
+        cmd[2:2] = gpg_passphrase_args
+        print(cmd)
+        # Run gpg command and raise error in case of failure.
+        proc = run_command(cmd, capture_output=True, merge_out_err=True, env={'GNUPGHOME': keyring})
+        if proc.returncode:
+            raise RiftError(
+                f"Error with signing OCI archive {self.path} command: "
+                f"{proc.out}"
+            )
 
 
 class ContainerFile:

--- a/lib/rift/package/oci.py
+++ b/lib/rift/package/oci.py
@@ -44,7 +44,7 @@ from rift.Config import _DEFAULT_VARIANT
 from rift.package._base import Package, ActionableArchPackage
 from rift.annex import Annex
 from rift.TestResults import TestCase, TestResults
-from rift.container import ContainerRuntime, ContainerFile
+from rift.container import ContainerRuntime, ContainerFile, ContainerArchive
 from rift.utils import message, banner
 
 class PackageOCI(Package):
@@ -165,16 +165,6 @@ class ActionableArchPackageOCI(ActionableArchPackage):
 
     def build(self, **kwargs):
         """Build container image of an OCI package."""
-        # Unfortunately, podman does not support signatures on OCI images, only
-        # on images pushed in remote registries. Warn signature is skipped when
-        # requested.
-        if kwargs.get('sign', False):
-            logging.warning(
-                "Signing OCI container image is not supported, skipping %s OCI "
-                "package signature",
-                self.name
-            )
-
         sources_topdir = self._setup_sources()
         message(f"Building container image '{self.name}' on "
                 f"architecture {self.arch}")
@@ -297,6 +287,15 @@ class ActionableArchPackageOCI(ActionableArchPackage):
 
         message("Publishing container image...")
         self.repos.ensure_created()
-        archive_path = os.path.join(self.repos.path,
-            f"{self.name}_{self.package.version}-{self.package.release}.{self.arch}.tar")
-        self.runtime.archive(self, archive_path)
+        container_archive = ContainerArchive(
+            self.config,
+            os.path.join(
+                self.repos.path,
+                f"{self.name}_{self.package.version}-{self.package.release}.{self.arch}.tar"
+            )
+        )
+        self.runtime.archive(self, container_archive)
+        if kwargs.get('sign', False):
+            logging.info(
+                "Signing OCI archive %s with GPG key", container_archive.path)
+            container_archive.sign()

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -11,8 +11,9 @@ import textwrap
 from io import StringIO
 
 from .TestUtils import (
-    make_temp_file,
     make_temp_dir,
+    make_temp_file,
+    make_temp_tar,
     gen_rpm_spec,
     read_file,
     host_rpmlint,
@@ -682,9 +683,15 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_oci.build.assert_has_calls(
             [call(sign=False, staging=None), call(sign=False, staging=None)])
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(updaterepo=True), call(updaterepo=True)])
+            [
+                call(updaterepo=True, sign=False),
+                call(updaterepo=True, sign=False),
+            ])
         mock_act_arch_pkg_oci.publish.assert_has_calls(
-            [call(updaterepo=True), call(updaterepo=True)])
+            [
+                call(updaterepo=True, sign=False),
+                call(updaterepo=True, sign=False),
+            ])
         mock_act_arch_pkg_rpm.clean.assert_has_calls([call(), call()])
         mock_act_arch_pkg_oci.clean.assert_has_calls([call(), call()])
 
@@ -2246,14 +2253,14 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # publish() are called for all supported arch (ie. twice).
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
             [call(staging=mock_staging_repo),
-             call(),
+             call(sign=False),
              call(staging=mock_staging_repo),
-             call()])
+             call(sign=False)])
         mock_act_arch_pkg_oci.publish.assert_has_calls(
             [call(staging=mock_staging_repo),
-             call(),
+             call(sign=False),
              call(staging=mock_staging_repo),
-             call()])
+             call(sign=False)])
 
         # Remove temporary working repo and unregister its deletion at exit
         shutil.rmtree(working_repo)
@@ -2482,15 +2489,16 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
     """
     Tests class for Controller action sign
     """
-    def test_action_sign(self):
-        """ Test sign package """
-        gpg_home = os.path.join(self.projdir, '.gnupg')
+
+    def setUp(self):
+        super().setUp()
+        self.gpg_home = os.path.join(self.projdir, '.gnupg')
 
         # Launch GPG agent for this test
         cmd = [
           'gpg-agent',
           '--homedir',
-          gpg_home,
+          self.gpg_home,
           '--daemon',
         ]
         subprocess.run(cmd)
@@ -2500,7 +2508,7 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         cmd = [
             'gpg',
             '--homedir',
-            gpg_home,
+            self.gpg_home,
             '--batch',
             '--passphrase',
             '',
@@ -2513,12 +2521,25 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         self.config.options.update(
             {
                 'gpg': {
-                    'keyring': gpg_home,
+                    'keyring': self.gpg_home,
                     'key': gpg_key,
                 }
             }
         )
         self.update_project_conf()
+
+    def tearDown(self):
+        # Kill GPG agent launched for the test
+        cmd = ['gpgconf', '--homedir', self.gpg_home, '--kill', 'gpg-agent']
+        subprocess.run(cmd)
+
+        # Remove temporary GPG home with generated key
+        shutil.rmtree(self.gpg_home)
+
+        super().tearDown()
+
+    def test_action_sign_rpm(self):
+        """ Test sign RPM package """
 
         # Path of RPM packages assets
         tests_dir = os.path.dirname(os.path.abspath(__file__))
@@ -2542,7 +2563,7 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         self.assertFalse(src_rpm.is_signed)
 
         # Launch rift sign
-        os.environ['GNUPGHOME'] = gpg_home
+        os.environ['GNUPGHOME'] = self.gpg_home
         self.assertEqual(main(['sign', copy_bin_rpm, copy_src_rpm]), 0)
         del os.environ['GNUPGHOME']
 
@@ -2552,16 +2573,28 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         self.assertTrue(bin_rpm.is_signed)
         self.assertTrue(src_rpm.is_signed)
 
-        # Kill GPG agent launched for the test
-        cmd = ['gpgconf', '--homedir', gpg_home, '--kill', 'gpg-agent']
-        subprocess.run(cmd)
-
         # Remove copy of packages assets
         os.unlink(copy_bin_rpm)
         os.unlink(copy_src_rpm)
 
-        # Remove temporary GPG home with generated key
-        shutil.rmtree(gpg_home)
+    def test_action_sign_oci_archive(self):
+        """ Test sign OCI archive """
+        # Create temporary tarball to emulate OCI archive
+        tmp_tar = make_temp_tar()
+
+        # Check rift sign runs succesfully
+        self.assertEqual(main(['sign', tmp_tar]), 0)
+
+        # Check detached signature has been successfully created
+        sig = f"{tmp_tar}.gpg"
+        self.assertTrue(os.path.exists(sig))
+
+        # Remove signature
+        os.unlink(sig)
+
+        # Remove temporary tarball
+        os.unlink(tmp_tar)
+
 
 class ControllerProjectActionSyncTest(RiftProjectTestCase):
     """

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -12,15 +12,17 @@ from collections import namedtuple
 from contextlib import contextmanager
 import io
 import jinja2
-import logging
 import os
 import pathlib as pl
+import random
 import shutil
+import string
 import tarfile
 import tempfile
 import time
 import unittest
 import yaml
+
 
 from rift.Config import Config, Staff, Modules
 from rift.Mock import Mock, rpmlint_env, rpmlint_chroot_script
@@ -534,6 +536,34 @@ def make_temp_file(text, delete=True, suffix=None):
 def nullcontext():
     """Context manager that does nothing."""
     yield
+
+def make_temp_tar():
+    """ Create temporary tarball with one random file"""
+    # Create temporary file
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w+", suffix=".txt"
+    ) as tmp_inner:
+        tmp_inner.write(
+            ''.join(
+                random.choices(
+                    string.ascii_letters + string.digits, k=2**10
+                )
+            )
+        )
+        inner_path = tmp_inner.name
+
+    # Create tarball archive
+    with tempfile.NamedTemporaryFile(
+        delete=False, suffix=".tar"
+    ) as tmp_tar:
+        tar_path = tmp_tar.name
+        with tarfile.open(fileobj=tmp_tar, mode="w:") as tar:
+            tar.add(inner_path, arcname=os.path.basename(inner_path))
+
+    # Remove temporary file
+    os.unlink(inner_path)
+
+    return tar_path
 
 #
 # Executable commands utilities

--- a/tests/container.py
+++ b/tests/container.py
@@ -2,16 +2,20 @@
 # Copyright (C) 2026 CEA
 #
 from unittest.mock import patch, Mock
+import subprocess
+import shutil
+import os
 
 from .TestUtils import (
     RiftProjectTestCase,
     command_available,
     make_temp_file,
+    make_temp_tar,
     gen_containerfile,
     EXPECTED_HADOLINT_EXEC
 )
 
-from rift.container import ContainerRuntime, ContainerFile
+from rift.container import ContainerRuntime, ContainerFile, ContainerArchive
 from rift.package.oci import PackageOCI
 from rift.run import RunResult
 from rift.Gerrit import Review
@@ -91,11 +95,181 @@ class ContainerRuntimeTest(RiftProjectTestCase):
         archive_result = RunResult(0, 'ok', None)
         mock_run_command.return_value = archive_result
         self.assertEqual(
-            container.archive(actionable_package, '/path/to/container.tar'),
+            container.archive(
+                actionable_package,
+                ContainerArchive(self.config, '/path/to/container.tar')
+            ),
             archive_result)
         mock_run_command.assert_called_once_with(
             ['podman', '--root', container.rootdir, 'push', 'pkg:1.0-1-x86_64',
              'oci-archive:/path/to/container.tar:pkg:1.0-1-x86_64'])
+
+
+class ContainerArchiveTest(RiftProjectTestCase):
+
+    def setUp(self):
+        super().setUp()
+        # Initialize ContainerArchive with temporary tarball
+        self.container_archive = ContainerArchive(self.config, make_temp_tar())
+
+    def tearDown(self):
+        super().tearDown()
+        os.unlink(self.container_archive.path)
+        if os.path.exists(self.container_archive.signature):
+            os.unlink(self.container_archive.signature)
+
+    def test_sign_no_conf(self):
+        """ContainerArchive.sign() fail with nonexistent keyring."""
+        with self.assertRaisesRegex(
+            RiftError,
+            r"^Unable to retrieve GPG configuration, unable to sign OCI "
+            r"archive .*\.tar$"
+        ):
+            self.container_archive.sign()
+        self.assertFalse(os.path.exists(self.container_archive.signature))
+
+    def test_sign_no_keyring(self):
+        """ContainerArchive.sign() fail with nonexistent keyring."""
+        self.config.options.update(
+            {
+                'gpg': {
+                  'keyring': '/path/to/nonexistent/keyring',
+                  'key': 'rift',
+                }
+            }
+        )
+        self.config._check()
+        with self.assertRaisesRegex(
+            RiftError,
+            r"^GPG keyring path /path/to/nonexistent/keyring does not exist, "
+            r"unable to sign OCI archive .*\.tar$"
+        ):
+            self.container_archive.sign()
+        self.assertFalse(os.path.exists(self.container_archive.signature))
+
+    def sign_copy(self, gpg_passphrase, conf_passphrase=None, preset_passphrase=None):
+        """
+        Generate keyring with provided gpg passphrase, update configuration with
+        generated keyring, copy unsigned rpm_pkg, sign it, verify signature and
+        cleanup everything.
+        """
+        gpg_home = os.path.join(self.projdir, '.gnupg')
+
+        # Launch the agent with --allow-preset-passphrase to accept passphrase
+        # provided non-interactively by gpg-preset-passphrase.
+        cmd = [
+          'gpg-agent',
+          '--homedir',
+          gpg_home,
+          '--allow-preset-passphrase',
+          '--daemon',
+        ]
+        subprocess.run(cmd)
+
+        # Generate keyring
+        gpg_key = 'rift'
+        cmd = [
+            'gpg',
+            '--homedir',
+            gpg_home,
+            '--batch',
+            '--passphrase',
+            gpg_passphrase or '',
+            '--quick-generate-key',
+            gpg_key,
+        ]
+        subprocess.run(cmd)
+
+        # If preset passphrase is provided, add it to the agent
+        # non-interactively with gpg-preset-passphrase.
+        if preset_passphrase:
+            # First find keygrip
+            keygrip = None
+            cmd = [
+                'gpg',
+                '--homedir',
+                gpg_home,
+                '--fingerprint',
+                '--with-keygrip',
+                '--with-colons',
+                gpg_key
+            ]
+            proc = subprocess.run(cmd, stdout=subprocess.PIPE)
+            for line in proc.stdout.decode().split('\n'):
+                if line.startswith('grp'):
+                    keygrip = line.split(':')[9]
+                    break
+            # Run gpg-preset-passphrase to add passphrase in agent
+            cmd = ['/usr/libexec/gpg-preset-passphrase', '--preset', keygrip]
+            subprocess.run(
+                cmd,
+                env={'GNUPGHOME': gpg_home},
+                input=preset_passphrase.encode()
+            )
+
+        # Update project configuration with generated key
+        self.config.options.update(
+            {
+                'gpg': {
+                    'keyring': gpg_home,
+                    'key': gpg_key,
+                }
+            }
+        )
+
+        if conf_passphrase is not None:
+            self.config.options['gpg']['passphrase'] = conf_passphrase
+        self.config._check()
+
+        try:
+            self.container_archive.sign()
+
+        finally:
+            # Kill GPG agent launched for the test
+            cmd = ['gpgconf', '--homedir', gpg_home, '--kill', 'gpg-agent']
+            subprocess.run(cmd)
+
+            # Remove temporary GPG home with generated key
+            shutil.rmtree(gpg_home)
+
+    def test_sign(self):
+        """Container archive signature."""
+        self.sign_copy('TOPSECRET', 'TOPSECRET')
+        self.assertTrue(os.path.exists(self.container_archive.signature))
+
+    def test_sign_wrong_passphrase(self):
+        """
+        Container archive signature raises RiftError with wrong passphrase.
+        """
+        with self.assertRaisesRegex(
+            RiftError,
+            "^Error with signing OCI archive .*"
+        ):
+            self.sign_copy('TOPSECRET', 'WRONG_PASSPHRASE')
+        self.assertFalse(os.path.exists(self.container_archive.signature))
+
+    def test_sign_passphrase_agent_not_interactive(self):
+        """
+        Container archive signature with passphrase in agent not interactive.
+        """
+        # When the key is encrypted with passphrase, the passphrase is not set
+        # in Rift configuration but loaded in GPG agent, Rift must sign the
+        # package without making the agent launch pinentry to ask for the
+        # passphrase interactively.
+        self.sign_copy('TOPSECRET', preset_passphrase='TOPSECRET')
+        self.assertTrue(os.path.exists(self.container_archive.signature))
+
+    def test_sign_empty_passphrase_not_interactive(self):
+        """
+        Container archive signature with empty passphrase no interactive
+        passphrase.
+        """
+        # When the key is NOT encrypted with passphrase, Rift must sign the
+        # package without making the agent launch pinentry to ask for the
+        # passphrase interactively.
+        self.sign_copy(None)
+        self.assertTrue(os.path.exists(self.container_archive.signature))
+
 
 class ContainerFileTest(RiftProjectTestCase):
     """Tests class for ContainerFile"""


### PR DESCRIPTION
Add support of cryptographic signatures of OCI artifacts with rift sign, rift build --sign, rift validate --sign and rift validdiff --sign.

Native cryptographic signatures of OCI containers images is performed in interaction with remote OCI registry. Rift supports OCI archives exports but not fully featured OCI registry. For this reason, it has been choosen to sign OCI archives with GPG command directly and detached signatures.

The signatures of OCI archives is performed at publish time rather than build time like for RPM packages, because OCI archives are exported at publish time only.

This feature introduces ContainerArchive class to handle OCI archives files and their GPG signatures.