### PR TITLE
Config: add 'image_source' key

### DIFF
--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -264,6 +264,7 @@ class Config():
                     'check':    'digit',
                     'default': 0,
                 },
+                'image_source':  {},
                 'port_range': {
                     'check':    'dict',
                     'syntax': {

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -271,7 +271,7 @@ def make_parser():
     subsubprs.add_argument('source', help='source files')
     subsubprs.add_argument('dest', help='destination files')
     subsubprs = subprs_vm.add_parser('build', help='build image of test VM')
-    subsubprs.add_argument('url', help='URL of base cloud image')
+    subsubprs.add_argument('--url', help='URL of base cloud image')
     subsubprs.add_argument('--force', action='store_true',
                            help='ignore cache and force download of cloud image')
     subsubprs.add_argument('-o', '--output',
@@ -581,7 +581,7 @@ def validate_pkgs(config, args, pkgs, arch):
 
     return results
 
-def vm_build(vm, args):
+def vm_build(config, vm, args):
     """Build VM image."""
     if not args.deploy and args.output is None:
         raise RiftError(
@@ -600,8 +600,24 @@ def vm_build(vm, args):
         output = vm.image_local
     else:
         output = args.output
+
+    vm_source_url = ''
+    if args.url is not None:
+        vm_source_url = args.url
+
+    elif "image_source" in config.get(args.arch)['vm']:
+        vm_source_url = config.get(args.arch)['vm']['image_source']
+
+    else:
+        raise RiftError(
+            "VM source image must be specified with --url or 'image_source'"
+            "in project.conf"
+        )
+
+    logging.debug("Using %s as VM source URL", vm_source_url)
+
     message(f"Building new vm image {output}")
-    vm.build(args.url, args.force, args.keep, output)
+    vm.build(vm_source_url, args.force, args.keep, output)
     banner(f"New vm image {output} is ready")
     return 0
 
@@ -655,7 +671,7 @@ def action_vm(args, config):
     elif args.vm_cmd == 'stop':
         ret = vm.cmd('poweroff').returncode
     elif args.vm_cmd == 'build':
-        ret = vm_build(vm, args)
+        ret = vm_build(config, vm, args)
     return ret
 
 def build_pkgs(args, pkgs, arch, staging):

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -3445,11 +3445,6 @@ class ControllerArgumentsTest(RiftTestCase):
         opts = parser.parse_args(args)
         self.assertEqual(opts.vm_cmd, 'connect')
 
-        args = ['vm', 'build']
-        # This must fail due to missing image URL
-        with self.assertRaises(RiftError):
-            parser.parse_args(args)
-
         args = ['vm', 'build', '--url', 'http://image']
         opts = parser.parse_args(args)
         self.assertEqual(opts.vm_cmd, 'build')

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -2370,7 +2370,7 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
         mock_vm_objects.image_is_remote.return_value = False
         mock_vm_objects.image_local = 'test.qcow2'
 
-        main(['vm', 'build', 'http://image', '--deploy'])
+        main(['vm', 'build', '--url', 'http://image', '--deploy'])
         # check VM class has been instanciated
         mock_vm_class.assert_called()
 
@@ -2378,18 +2378,18 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
             'http://image', False, False, 'test.qcow2'
         )
         mock_vm_objects.build.reset_mock()
-        main(['vm', 'build', 'http://image', '--deploy', '--force'])
+        main(['vm', 'build', '--url', 'http://image', '--deploy', '--force'])
         mock_vm_objects.build.assert_called_once_with(
             'http://image', True, False, 'test.qcow2'
         )
         mock_vm_objects.build.reset_mock()
-        main(['vm', 'build', 'http://image', '--deploy', '--keep'])
+        main(['vm', 'build', '--url', 'http://image', '--deploy', '--keep'])
         mock_vm_objects.build.assert_called_once_with(
             'http://image', False, True, 'test.qcow2'
         )
         mock_vm_objects.build.reset_mock()
         main(
-            ['vm', 'build', 'http://image', '--output', 'OUTPUT.img', '--force']
+            ['vm', 'build', '--url', 'http://image', '--output', 'OUTPUT.img', '--force']
         )
         mock_vm_objects.build.assert_called_once_with(
             'http://image', True, False, 'OUTPUT.img'
@@ -2398,7 +2398,7 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError, "^Either --deploy or -o,--output option must be used$"
         ):
-            main(['vm', 'build', 'http://image'])
+            main(['vm', 'build', '--url', 'http://image'])
         with self.assertRaisesRegex(
             RiftError,
             "^Both --deploy and -o,--output options cannot be used together$",
@@ -2407,6 +2407,7 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
                 [
                     'vm',
                     'build',
+                    '--url',
                     'http://image',
                     '--deploy',
                     '--output',
@@ -3446,34 +3447,34 @@ class ControllerArgumentsTest(RiftTestCase):
 
         args = ['vm', 'build']
         # This must fail due to missing image URL
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(RiftError):
             parser.parse_args(args)
 
-        args = ['vm', 'build', 'http://image']
+        args = ['vm', 'build', '--url', 'http://image']
         opts = parser.parse_args(args)
         self.assertEqual(opts.vm_cmd, 'build')
         self.assertEqual(opts.url, 'http://image')
         self.assertFalse(opts.force)
 
-        args = ['vm', 'build', 'http://image', '--force']
+        args = ['vm', 'build', '--url', 'http://image', '--force']
         opts = parser.parse_args(args)
         self.assertTrue(opts.force)
 
-        args = ['vm', 'build', 'http://image', '--deploy']
+        args = ['vm', 'build', '--url', 'http://image', '--deploy']
         opts = parser.parse_args(args)
         self.assertTrue(opts.deploy)
 
         OUTPUT_IMG = 'OUTPUT'
 
-        args = ['vm', 'build', 'http://image', '-o', OUTPUT_IMG]
+        args = ['vm', 'build', '--url', 'http://image', '-o', OUTPUT_IMG]
         opts = parser.parse_args(args)
         self.assertEqual(opts.output, OUTPUT_IMG)
 
-        args = ['vm', 'build', 'http://image', '--output', OUTPUT_IMG]
+        args = ['vm', 'build', '--url', 'http://image', '--output', OUTPUT_IMG]
         opts = parser.parse_args(args)
         self.assertEqual(opts.output, OUTPUT_IMG)
 
         # This must fail due to missing output filename
-        args = ['vm', 'build', 'http://image', '--output']
+        args = ['vm', 'build', '--url', 'http://image', '--output']
         with self.assertRaises(SystemExit):
             parser.parse_args(args)

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -2421,7 +2421,7 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
             "^Cannot build VM image with remote image URL and --deploy option, -o, "
             "--output option must be used$"
         ):
-            main(['vm', 'build', 'http://image', '--deploy'])
+            main(['vm', 'build', '--url', 'http://image', '--deploy'])
 
 
     def test_vm_build_and_validate(self):


### PR DESCRIPTION
Add a 'image_source' key to the config that will be used for the Rift vm build command. The url parameter is now optional. 