### PR TITLE
Automatic IDP access token refresh

### DIFF
--- a/lib/rift/annex/s3.py
+++ b/lib/rift/annex/s3.py
@@ -96,9 +96,9 @@ class S3Annex(GenericAnnex):
 
         self.push_s3_client = boto3.client(
             "s3",
-            aws_access_key_id=self.push_s3_auth.config["access_key_id"],
-            aws_secret_access_key=self.push_s3_auth.config["secret_access_key"],
-            aws_session_token=self.push_s3_auth.config["session_token"],
+            aws_access_key_id=self.push_s3_auth.state.access_key_id,
+            aws_secret_access_key=self.push_s3_auth.state.secret_access_key,
+            aws_session_token=self.push_s3_auth.state.session_token,
             endpoint_url=self.push_s3_endpoint,
         )
 

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -41,6 +41,7 @@ import json
 import logging
 import os
 import sys
+import threading
 
 import requests
 import urllib3
@@ -266,12 +267,16 @@ class Auth:
         self.idp_token_refresh_threshold = config.get("idp_token_refresh_threshold")
 
         self.state = AuthState()
+        # Serialize IDP refresh across threads (e.g. repos proxy) so only one
+        # identical refresh_token grant is sent when many callers race near expiry.
+        self._idp_refresh_lock = threading.Lock()
 
     def _request_idp_token(self, data):
         """
         Request an IDP token with the given grant form data, update AuthState,
         and persist.
         """
+        logging.debug("requesting new idp token on %s", self.idp_auth_endpoint)
         res = requests.post(
             self.idp_auth_endpoint,
             data=data,
@@ -307,6 +312,9 @@ class Auth:
         """
         Refresh the IDP access token when remaining validity is below threshold
         and a refresh token is available.
+
+        Uses double-checked locking so concurrent callers (e.g. repos proxy
+        request threads) trigger at most one refresh request.
         """
         if not self.idp_token_refresh_threshold:
             return
@@ -320,15 +328,24 @@ class Auth:
             logging.debug("idp access token near expiry but no refresh token available")
             return
 
-        logging.debug("refreshing idp access token")
-        self._request_idp_token(
-            {
-                "client_id": "minio",
-                "grant_type": "refresh_token",
-                "refresh_token": self.state.idp_refresh_token,
-                "client_secret": self.idp_app_token,
-            }
-        )
+        with self._idp_refresh_lock:
+            # Another thread may have refreshed while we waited for the lock.
+            remaining = self.state.idp_seconds_remaining()
+            if remaining is None or remaining >= self.idp_token_refresh_threshold:
+                return
+
+            logging.debug(
+                "refreshing idp access token (remaining: %.0f seconds)", remaining
+            )
+
+            self._request_idp_token(
+                {
+                    "client_id": "minio",
+                    "grant_type": "refresh_token",
+                    "refresh_token": self.state.idp_refresh_token,
+                    "client_secret": self.idp_app_token,
+                }
+            )
 
     # Step 1: Get OpenID token
     def get_idp_token(self):

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -267,14 +267,17 @@ class Auth:
         self.idp_token_refresh_threshold = config.get("idp_token_refresh_threshold")
 
         self.state = AuthState()
+        # Persist refreshed tokens to the credentials file by default. Disabled
+        # when tokens come from RIFT_AUTH_IDP_* env vars (ephemeral in-memory use).
+        self._persist_credentials = True
         # Serialize IDP refresh across threads (e.g. repos proxy) so only one
         # identical refresh_token grant is sent when many callers race near expiry.
         self._idp_refresh_lock = threading.Lock()
 
     def _request_idp_token(self, data):
         """
-        Request an IDP token with the given grant form data, update AuthState,
-        and persist.
+        Request an IDP token with the given grant form data and update AuthState.
+        Persist to the credentials file when _persist_credentials is true.
         """
         logging.debug("requesting new idp token on %s", self.idp_auth_endpoint)
         res = requests.post(
@@ -306,7 +309,8 @@ class Auth:
         if refresh_token:
             self.state.idp_refresh_token = refresh_token
 
-        self.state.save(self.credentials_file)
+        if self._persist_credentials:
+            self.state.save(self.credentials_file)
 
     def _ensure_idp_token_fresh(self):
         """
@@ -422,6 +426,9 @@ class Auth:
                 )
             else:
                 self.state.idp_token_expiration = exp_dt
+
+            # Env-sourced tokens stay in memory only (do not write state file).
+            self._persist_credentials = False
 
             # Refresh the token if it is near expiry.
             self._ensure_idp_token_fresh()

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -52,6 +52,24 @@ urllib3.disable_warnings()
 _EXPIRATION_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 
+def _parse_expiration(value):
+    """Parse an expiration value to datetime, or None if unset."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime.datetime):
+        return value
+    return datetime.datetime.strptime(value, _EXPIRATION_FMT)
+
+
+def _format_expiration(value):
+    """Format a datetime expiration for JSON persistence, or None if unset."""
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        return value.strftime(_EXPIRATION_FMT)
+    return value
+
+
 class AuthState:
     """
     Persisted authentication credentials (credentials file payload).
@@ -82,22 +100,22 @@ class AuthState:
             return cls()
         return cls(
             idp_token=data.get("idp_token"),
-            idp_token_expiration=data.get("idp_token_expiration"),
+            idp_token_expiration=_parse_expiration(data.get("idp_token_expiration")),
             access_key_id=data.get("access_key_id"),
             secret_access_key=data.get("secret_access_key"),
             session_token=data.get("session_token"),
-            expiration=data.get("expiration"),
+            expiration=_parse_expiration(data.get("expiration")),
         )
 
     def to_dict(self):
         """Return dict suitable for JSON persistence; omit unset fields."""
         data = {
             "idp_token": self.idp_token,
-            "idp_token_expiration": self.idp_token_expiration,
+            "idp_token_expiration": _format_expiration(self.idp_token_expiration),
             "access_key_id": self.access_key_id,
             "secret_access_key": self.secret_access_key,
             "session_token": self.session_token,
-            "expiration": self.expiration,
+            "expiration": _format_expiration(self.expiration),
         }
         return {key: value for key, value in data.items() if value is not None}
 
@@ -111,8 +129,7 @@ class AuthState:
 
         # Check S3 credentials expiration
         if self.expiration:
-            expiration = datetime.datetime.strptime(self.expiration, _EXPIRATION_FMT)
-            if expiration > now:
+            if self.expiration > now:
                 logging.info("found existing, valid S3 credentials")
             else:
                 logging.info("info: found existing, expired S3 credentials")
@@ -124,10 +141,7 @@ class AuthState:
 
         # Check IDP token expiration
         if self.idp_token_expiration:
-            expiration = datetime.datetime.strptime(
-                self.idp_token_expiration, _EXPIRATION_FMT
-            )
-            if expiration > now:
+            if self.idp_token_expiration > now:
                 logging.info("found existing, valid idp access token")
             else:
                 logging.info("found existing, expired idp access token")
@@ -184,21 +198,14 @@ class AuthState:
             self.session_token,
         )
 
-    def s3_expiration_dt(self):
-        """Parse expiration string to datetime, or None if unset."""
-        if not self.expiration:
-            return None
-        return datetime.datetime.strptime(self.expiration, _EXPIRATION_FMT)
-
     def s3_expiration_str(self):
         """
         Returns a human readable time string of auth token, if possible.
         If token expiration date is not set, returns an empty string.
         """
-        expiration_dt = self.s3_expiration_dt()
-        if not expiration_dt:
+        if not self.expiration:
             return ""
-        return expiration_dt.strftime("%a %b %d %H:%M:%S %Y")
+        return self.expiration.strftime("%a %b %d %H:%M:%S %Y")
 
 
 class Auth:
@@ -271,9 +278,9 @@ class Auth:
             msg += " missing field 'expires_in'"
             logging.info(msg)
 
-        expire_dt = datetime.datetime.now() + datetime.timedelta(seconds=expires_in_sec)
-
-        self.state.idp_token_expiration = expire_dt.strftime(_EXPIRATION_FMT)
+        self.state.idp_token_expiration = (
+            datetime.datetime.now() + datetime.timedelta(seconds=expires_in_sec)
+        )
         self.state.idp_token = token
         self.state.save(self.credentials_file)
 
@@ -377,7 +384,7 @@ class Auth:
         self.state.access_key_id = access_key_id
         self.state.secret_access_key = secret_access_key
         self.state.session_token = session_token
-        self.state.expiration = expiration
+        self.state.expiration = _parse_expiration(expiration)
 
         self.state.save(self.credentials_file)
 

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -49,6 +49,157 @@ from rift import RiftError
 
 urllib3.disable_warnings()
 
+_EXPIRATION_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+class AuthState:
+    """
+    Persisted authentication credentials (credentials file payload).
+    """
+
+    def __init__(
+        self,
+        idp_token=None,
+        idp_token_expiration=None,
+        access_key_id=None,
+        secret_access_key=None,
+        session_token=None,
+        expiration=None,
+    ):
+        # IDP token and expiration
+        self.idp_token = idp_token
+        self.idp_token_expiration = idp_token_expiration
+        # S3 credentials
+        self.access_key_id = access_key_id
+        self.secret_access_key = secret_access_key
+        self.session_token = session_token
+        self.expiration = expiration
+
+    @classmethod
+    def from_dict(cls, data):
+        """Build AuthState from a credentials-file dict."""
+        if not data:
+            return cls()
+        return cls(
+            idp_token=data.get("idp_token"),
+            idp_token_expiration=data.get("idp_token_expiration"),
+            access_key_id=data.get("access_key_id"),
+            secret_access_key=data.get("secret_access_key"),
+            session_token=data.get("session_token"),
+            expiration=data.get("expiration"),
+        )
+
+    def to_dict(self):
+        """Return dict suitable for JSON persistence; omit unset fields."""
+        data = {
+            "idp_token": self.idp_token,
+            "idp_token_expiration": self.idp_token_expiration,
+            "access_key_id": self.access_key_id,
+            "secret_access_key": self.secret_access_key,
+            "session_token": self.session_token,
+            "expiration": self.expiration,
+        }
+        return {key: value for key, value in data.items() if value is not None}
+
+    def clear_expired(self):
+        """
+        Drop expired S3 and/or IDP fields.
+        Returns True if anything was scrubbed.
+        """
+        now = datetime.datetime.now()
+        updated = False
+
+        # Check S3 credentials expiration
+        if self.expiration:
+            expiration = datetime.datetime.strptime(self.expiration, _EXPIRATION_FMT)
+            if expiration > now:
+                logging.info("found existing, valid S3 credentials")
+            else:
+                logging.info("info: found existing, expired S3 credentials")
+                self.expiration = None
+                self.access_key_id = None
+                self.secret_access_key = None
+                self.session_token = None
+                updated = True
+
+        # Check IDP token expiration
+        if self.idp_token_expiration:
+            expiration = datetime.datetime.strptime(
+                self.idp_token_expiration, _EXPIRATION_FMT
+            )
+            if expiration > now:
+                logging.info("found existing, valid idp access token")
+            else:
+                logging.info("found existing, expired idp access token")
+                self.idp_token = None
+                self.idp_token_expiration = None
+                updated = True
+
+        return updated
+
+    @classmethod
+    def restore(cls, path):
+        """
+        Load credentials file at path.
+        On JSON decode failure, start empty.
+        Run clear_expired(); if scrubbed, rewrite file via save().
+        Return AuthState instance.
+        """
+        with open(path, "r", encoding="utf-8") as fs:
+            data = fs.read()
+
+        raw = {}
+        try:
+            raw = json.loads(data)
+        except json.JSONDecodeError as e:
+            logging.info("failed to decode json from existing credentials file: %s", e)
+
+        state = cls.from_dict(raw)
+        if state.clear_expired():
+            state.save(path)
+        return state
+
+    def save(self, path):
+        """
+        Persist to_dict() to path with mode 0600.
+        """
+        os.umask(0)
+        fd = os.open(
+            path=path,
+            flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            mode=0o600,
+        )
+        with open(fd, "w", encoding="utf-8") as fs:
+            json.dump(self.to_dict(), fs, indent=2, sort_keys=True)
+
+    def has_s3_credentials(self):
+        """Return True if all S3 credential fields are set."""
+        return None not in (
+            self.access_key_id,
+            self.secret_access_key,
+            self.session_token,
+        ) and "" not in (
+            self.access_key_id,
+            self.secret_access_key,
+            self.session_token,
+        )
+
+    def s3_expiration_dt(self):
+        """Parse expiration string to datetime, or None if unset."""
+        if not self.expiration:
+            return None
+        return datetime.datetime.strptime(self.expiration, _EXPIRATION_FMT)
+
+    def s3_expiration_str(self):
+        """
+        Returns a human readable time string of auth token, if possible.
+        If token expiration date is not set, returns an empty string.
+        """
+        expiration_dt = self.s3_expiration_dt()
+        if not expiration_dt:
+            return ""
+        return expiration_dt.strftime("%a %b %d %H:%M:%S %Y")
+
 
 class Auth:
     """
@@ -65,93 +216,14 @@ class Auth:
         self.s3_auth_endpoint = config.get("s3_auth_endpoint")
         self.credentials_file = os.path.expanduser(config.get("s3_credential_file"))
 
-        self.config = {}
-        self.expiration_dt = ""
-
-    def get_expiration_timestr(self):
-        """
-        Returns a human readable time string of auth token, if possible.
-        If token expiration date is not set, returns an emptry string
-        """
-        if not self.expiration_dt:
-            return ""
-        return self.expiration_dt.strftime("%a %b %d %H:%M:%S %Y")
-
-    def restore_state(self):
-        """
-        Loads data from existing credentials file, if one exists.
-        If credentials file contains expired data, remove expired items from file.
-        """
-
-        with open(self.credentials_file, "r", encoding="utf-8") as fs:
-            data = fs.read()
-
-            config = {}
-            try:
-                config = json.loads(data)
-            except json.JSONDecodeError as e:
-                logging.info(
-                    "failed to decode json from existing credentials file: %s", e
-                )
-
-            update_authfile = False
-
-            expiry = config.get("expiration")
-            if expiry:
-                expiration = datetime.datetime.strptime(expiry, "%Y-%m-%dT%H:%M:%SZ")
-                if expiration > datetime.datetime.now():
-                    # S3 credentials are still valid
-                    logging.info("found existing, valid S3 credentials")
-                    self.expiration_dt = expiration
-                else:
-                    # S3 credentials expired
-                    logging.info("info: found existing, expired S3 credentials")
-                    config.pop("expiration", None)
-                    config.pop("access_key_id", None)
-                    config.pop("secret_access_key", None)
-                    config.pop("session_token", None)
-                    update_authfile = True
-
-            idp_expiry = config.get("idp_token_expiration")
-            if idp_expiry:
-                expiration = datetime.datetime.strptime(
-                    idp_expiry, "%Y-%m-%dT%H:%M:%SZ"
-                )
-                if expiration > datetime.datetime.now():
-                    # IDP access token is still valid
-                    logging.info("found existing, valid idp access token")
-                else:
-                    # IDP access token has expired
-                    logging.info("found existing, expired idp access token")
-                    config.pop("idp_token")
-                    config.pop("idp_token_expiration")
-                    update_authfile = True
-
-            self.config = config
-
-            if update_authfile:
-                self.save_state()
-
-    def save_state(self):
-        """
-        Saves auth object config information to credentials file.
-        """
-        os.umask(0)
-        fd = os.open(
-            path=self.credentials_file,
-            flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            mode=0o600,
-        )
-        with open(fd, "w", encoding="utf-8") as fs:
-            json.dump(self.config, fs, indent=2, sort_keys=True)
+        self.state = AuthState()
 
     # Step 1: Get OpenID token
     def get_idp_token(self):
         """
         Get OpenID Token
         """
-        token = self.config.get("idp_token")
-        if token:
+        if self.state.idp_token:
             logging.info("retrieved existing idp_token from auth file")
             return True
 
@@ -201,9 +273,9 @@ class Auth:
 
         expire_dt = datetime.datetime.now() + datetime.timedelta(seconds=expires_in_sec)
 
-        self.config["idp_token_expiration"] = expire_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        self.config["idp_token"] = token
-        self.save_state()
+        self.state.idp_token_expiration = expire_dt.strftime(_EXPIRATION_FMT)
+        self.state.idp_token = token
+        self.state.save(self.credentials_file)
 
         return True
 
@@ -223,8 +295,8 @@ class Auth:
                 f"Missing authentication state file {self.credentials_file}. "
                 "Run 'rift auth' first."
             )
-        self.restore_state()
-        token = self.config.get("idp_token")
+        self.state = AuthState.restore(self.credentials_file)
+        token = self.state.idp_token
         if not token:
             raise RiftError(
                 "Missing idp_token in authentication state file "
@@ -237,17 +309,13 @@ class Auth:
     def get_s3_credentials(self):
         """
         Obtains an S3 credential using an already-obtained OpenID credential,
-        unless an S3 credential is already available in auth object's config,
+        unless an S3 credential is already available in auth object's state,
         in which case the credential is considered to have already been
         obtained.
 
         Returns True on success, False on failure.
         """
-        access_key_id = self.config.get("access_key_id", "")
-        secret_access_key = self.config.get("secret_access_key", "")
-        session_token = self.config.get("session_token", "")
-
-        if "" not in (access_key_id, secret_access_key, session_token):
+        if self.state.has_s3_credentials():
             return True
 
         if not self.s3_auth_endpoint:
@@ -262,7 +330,7 @@ class Auth:
             "Version": "2011-06-15",
             "Action": "AssumeRoleWithWebIdentity",
             "DurationSeconds": "86000",
-            "WebIdentityToken": self.config["idp_token"],
+            "WebIdentityToken": self.state.idp_token,
         }
 
         res = requests.post(
@@ -306,16 +374,12 @@ class Auth:
             msg += "AccessKeyId, SecretAccessKey, SessionToken, Expiration"
             raise RiftError(msg)
 
-        self.config["access_key_id"] = access_key_id
-        self.config["secret_access_key"] = secret_access_key
-        self.config["session_token"] = session_token
-        self.config["expiration"] = expiration
+        self.state.access_key_id = access_key_id
+        self.state.secret_access_key = secret_access_key
+        self.state.session_token = session_token
+        self.state.expiration = expiration
 
-        self.expiration_dt = datetime.datetime.strptime(
-            expiration, "%Y-%m-%dT%H:%M:%SZ"
-        )
-
-        self.save_state()
+        self.state.save(self.credentials_file)
 
         return True
 
@@ -342,14 +406,14 @@ class Auth:
             )
             msg += " AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN"
             logging.info(msg)
-            self.config["access_key_id"] = aws_access_key_id
-            self.config["secret_access_key"] = aws_secret_access_key
-            self.config["session_token"] = aws_session_token
+            self.state.access_key_id = aws_access_key_id
+            self.state.secret_access_key = aws_secret_access_key
+            self.state.session_token = aws_session_token
             return True
 
         if os.path.isfile(self.credentials_file):
             logging.info("found credentials file: %s", self.credentials_file)
-            self.restore_state()
+            self.state = AuthState.restore(self.credentials_file)
         else:
             base = os.path.dirname(self.credentials_file)
             if os.path.exists(base):

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -34,6 +34,7 @@ Auth:
     This package manage rift s3 authentication
 """
 
+import base64
 import datetime
 import getpass
 import json
@@ -70,6 +71,33 @@ def _format_expiration(value):
     return value
 
 
+def jwt_expiration_dt(token):
+    """
+    Return expiration datetime from a JWT access token payload exp claim.
+
+    Decodes the payload without verifying the signature. Returns None if the
+    token is not a JWT or has no usable exp claim.
+    """
+    if not token or not isinstance(token, str):
+        return None
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1]
+    try:
+        padding = "=" * (-len(payload) % 4)
+        data = json.loads(base64.urlsafe_b64decode(payload + padding))
+    except (ValueError, json.JSONDecodeError, TypeError):
+        return None
+    exp = data.get("exp")
+    if exp is None:
+        return None
+    try:
+        return datetime.datetime.fromtimestamp(int(exp))
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
 class AuthState:
     """
     Persisted authentication credentials (credentials file payload).
@@ -79,6 +107,7 @@ class AuthState:
         self,
         idp_token=None,
         idp_token_expiration=None,
+        idp_refresh_token=None,
         access_key_id=None,
         secret_access_key=None,
         session_token=None,
@@ -87,6 +116,7 @@ class AuthState:
         # IDP token and expiration
         self.idp_token = idp_token
         self.idp_token_expiration = idp_token_expiration
+        self.idp_refresh_token = idp_refresh_token
         # S3 credentials
         self.access_key_id = access_key_id
         self.secret_access_key = secret_access_key
@@ -101,6 +131,7 @@ class AuthState:
         return cls(
             idp_token=data.get("idp_token"),
             idp_token_expiration=_parse_expiration(data.get("idp_token_expiration")),
+            idp_refresh_token=data.get("idp_refresh_token"),
             access_key_id=data.get("access_key_id"),
             secret_access_key=data.get("secret_access_key"),
             session_token=data.get("session_token"),
@@ -112,6 +143,7 @@ class AuthState:
         data = {
             "idp_token": self.idp_token,
             "idp_token_expiration": _format_expiration(self.idp_token_expiration),
+            "idp_refresh_token": self.idp_refresh_token,
             "access_key_id": self.access_key_id,
             "secret_access_key": self.secret_access_key,
             "session_token": self.session_token,
@@ -147,6 +179,7 @@ class AuthState:
                 logging.info("found existing, expired idp access token")
                 self.idp_token = None
                 self.idp_token_expiration = None
+                self.idp_refresh_token = None
                 updated = True
 
         return updated
@@ -207,6 +240,14 @@ class AuthState:
             return ""
         return self.expiration.strftime("%a %b %d %H:%M:%S %Y")
 
+    def idp_seconds_remaining(self):
+        """
+        Return seconds until IDP access token expiry, or None if expiration unset.
+        """
+        if self.idp_token_expiration is None:
+            return None
+        return (self.idp_token_expiration - datetime.datetime.now()).total_seconds()
+
 
 class Auth:
     """
@@ -222,8 +263,72 @@ class Auth:
         self.idp_auth_endpoint = config.get("idp_auth_endpoint")
         self.s3_auth_endpoint = config.get("s3_auth_endpoint")
         self.credentials_file = os.path.expanduser(config.get("s3_credential_file"))
+        self.idp_token_refresh_threshold = config.get("idp_token_refresh_threshold")
 
         self.state = AuthState()
+
+    def _request_idp_token(self, data):
+        """
+        Request an IDP token with the given grant form data, update AuthState,
+        and persist.
+        """
+        res = requests.post(
+            self.idp_auth_endpoint,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=60,
+        )
+        js = res.json()
+
+        token = js.get("access_token")
+        if not token:
+            msg = "received unexpected response while fetching idp access token:"
+            msg += " missing field 'access_token'"
+            raise RiftError(msg)
+
+        expires_in_sec = js.get("expires_in")
+        if not expires_in_sec:
+            msg = "received unexpected response while fetching idp access token:"
+            msg += " missing field 'expires_in'"
+            logging.info(msg)
+        else:
+            self.state.idp_token_expiration = (
+                datetime.datetime.now() + datetime.timedelta(seconds=expires_in_sec)
+            )
+
+        self.state.idp_token = token
+        refresh_token = js.get("refresh_token")
+        if refresh_token:
+            self.state.idp_refresh_token = refresh_token
+
+        self.state.save(self.credentials_file)
+
+    def _ensure_idp_token_fresh(self):
+        """
+        Refresh the IDP access token when remaining validity is below threshold
+        and a refresh token is available.
+        """
+        if not self.idp_token_refresh_threshold:
+            return
+        remaining = self.state.idp_seconds_remaining()
+        if remaining is None or remaining >= self.idp_token_refresh_threshold:
+            return
+        if not self.idp_auth_endpoint:
+            logging.error("missing required config parameter: idp_auth_endpoint")
+            return
+        if not self.state.idp_refresh_token:
+            logging.debug("idp access token near expiry but no refresh token available")
+            return
+
+        logging.debug("refreshing idp access token")
+        self._request_idp_token(
+            {
+                "client_id": "minio",
+                "grant_type": "refresh_token",
+                "refresh_token": self.state.idp_refresh_token,
+                "client_secret": self.idp_app_token,
+            }
+        )
 
     # Step 1: Get OpenID token
     def get_idp_token(self):
@@ -231,6 +336,7 @@ class Auth:
         Get OpenID Token
         """
         if self.state.idp_token:
+            self._ensure_idp_token_fresh()
             logging.info("retrieved existing idp_token from auth file")
             return True
 
@@ -249,53 +355,60 @@ class Auth:
         if not password:
             password = getpass.getpass("Password: ")
 
-        data = {
-            "client_id": "minio",
-            "grant_type": "password",
-            "username": user,
-            "password": password,
-            "client_secret": client_secret,
-        }
-
-        res = requests.post(
-            self.idp_auth_endpoint,
-            data=data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=60,
+        self._request_idp_token(
+            {
+                "client_id": "minio",
+                "grant_type": "password",
+                "username": user,
+                "password": password,
+                "client_secret": client_secret,
+            }
         )
-
-        js = res.json()
-
-        token = js.get("access_token")
-        if not token:
-            msg = "received unexpected response while fetching idp access token:"
-            msg += " missing field 'access_token'"
-            raise RiftError(msg)
-
-        expires_in_sec = js.get("expires_in")
-        if not expires_in_sec:
-            msg = "received unexpected response while fetching idp access token:"
-            msg += " missing field 'expires_in'"
-            logging.info(msg)
-
-        self.state.idp_token_expiration = (
-            datetime.datetime.now() + datetime.timedelta(seconds=expires_in_sec)
-        )
-        self.state.idp_token = token
-        self.state.save(self.credentials_file)
-
         return True
 
     def get_idp_token_noninteractive(self):
         """
-        Return cached OpenID token from environment or state file without
-        prompting user. Raise RiftError if token is missing or expired.
+        Return an IDP access token without prompting the user.
+
+        Prefer a token already loaded in state (so successive calls keep a
+        previously refreshed token), otherwise load from RIFT_AUTH_IDP_TOKEN
+        (and optional RIFT_AUTH_IDP_REFRESH_TOKEN / JWT exp), otherwise restore
+        from the credentials file. Refresh when remaining validity is below
+        threshold. Raise RiftError if no token is available.
         """
+
+        # Prefer tokens already loaded into state (e.g. after a prior refresh)
+        # so successive calls do not overwrite them with a stale env value.
+        if self.state.idp_token:
+            self._ensure_idp_token_fresh()
+            return self.state.idp_token
 
         token = os.environ.get("RIFT_AUTH_IDP_TOKEN")
         if token:
             logging.debug("fetched idp token from environment")
-            return token
+            # Set the IDP access token in the state.
+            self.state.idp_token = token
+
+            # Check if the IDP refresh token is set in the environment. If so,
+            # set it in the state.
+            refresh = os.environ.get("RIFT_AUTH_IDP_REFRESH_TOKEN")
+            if refresh:
+                self.state.idp_refresh_token = refresh
+
+            # Get the expiration date of the token based on the exp claim in JWT
+            # payload and set it in the state.
+            exp_dt = jwt_expiration_dt(token)
+            if exp_dt is None:
+                logging.warning(
+                    "unable to extract expiration from RIFT_AUTH_IDP_TOKEN "
+                    "(not a JWT or missing exp claim); token refresh disabled"
+                )
+            else:
+                self.state.idp_token_expiration = exp_dt
+
+            # Refresh the token if it is near expiry.
+            self._ensure_idp_token_fresh()
+            return self.state.idp_token
 
         if not os.path.isfile(self.credentials_file):
             raise RiftError(
@@ -310,7 +423,8 @@ class Auth:
                 f"{self.credentials_file}. "
                 "Run 'rift auth' first."
             )
-        return token
+        self._ensure_idp_token_fresh()
+        return self.state.idp_token
 
     # Step 2: Get S3 credentials using token from (1)
     def get_s3_credentials(self):

--- a/lib/rift/config.py
+++ b/lib/rift/config.py
@@ -98,6 +98,7 @@ _DEFAULT_VARIANT = "main"
 _DEFAULT_REPOS_VARIANTS = [_DEFAULT_VARIANT]
 _DEFAULT_DEPENDENCY_TRACKING = False
 _DEFAULT_S3_CREDENTIAL_FILE = "~/.rift/auth.json"
+_DEFAULT_IDP_TOKEN_REFRESH_THRESHOLD = 300
 
 
 class Config:
@@ -134,6 +135,11 @@ class Config:
         },
         "idp_auth_endpoint": {"required": False},
         "idp_app_token": {"required": False},
+        "idp_token_refresh_threshold": {
+            "required": False,
+            "check": "digit",
+            "default": _DEFAULT_IDP_TOKEN_REFRESH_THRESHOLD,
+        },
         "annex_restore_cache": {
             "required": False,
         },

--- a/lib/rift/controller.py
+++ b/lib/rift/controller.py
@@ -642,7 +642,7 @@ def action_auth(config):
     if auth_obj.authenticate():
         msg = "succesfully authenticated"
 
-        t = auth_obj.get_expiration_timestr()
+        t = auth_obj.state.s3_expiration_str()
         if t != "":
             msg += f"; token expires in {t}"
         else:

--- a/lib/rift/proxy.py
+++ b/lib/rift/proxy.py
@@ -266,7 +266,7 @@ class AuthenticatedRepositoryProxyRuntime:
         self.repositories = {
             repo.name: repo for repo in repositories if repo.authenticated()
         }
-        self.token = None
+        self._auth = None
         self.server = None
         self._thread = None
 
@@ -274,6 +274,19 @@ class AuthenticatedRepositoryProxyRuntime:
     def timeout(self):
         """Get repository proxy timeout."""
         return self._timeout
+
+    @property
+    def token(self):
+        """
+        Return a current IDP access token, refreshing when needed.
+
+        Fetched per access so long-running proxy sessions pick up refreshed
+        tokens before the access token expires. Returns None when the proxy
+        is not running.
+        """
+        if self._auth is None:
+            return None
+        return self._auth.get_idp_token_noninteractive()
 
     @property
     def active(self):
@@ -293,8 +306,10 @@ class AuthenticatedRepositoryProxyRuntime:
             logging.debug("No repositories need proxy, skipping proxy startup")
             return
 
-        # Get IDP token non-interactively.
-        self.token = Auth(self._config).get_idp_token_noninteractive()
+        # Ensure an IDP token is available before accepting proxy traffic.
+        # Tokens are re-fetched per upstream request via the token property.
+        self._auth = Auth(self._config)
+        self._auth.get_idp_token_noninteractive()
 
         # Start HTTP server in a separate thread.
         self.server = _ThreadingHTTPServer(
@@ -315,7 +330,7 @@ class AuthenticatedRepositoryProxyRuntime:
         self.server.server_close()
         self.server = None
         self._thread = None
-        self.token = None
+        self._auth = None
         logging.debug("Stopped repository proxy")
 
     @property

--- a/template/project.conf
+++ b/template/project.conf
@@ -15,7 +15,13 @@ set_annex:
 
 # Remote HTTP(S) annex example. When auth is idp_token, Rift sends the IDP access
 # token as an HTTP Bearer token in the Authorization header (from
-# RIFT_AUTH_IDP_TOKEN or the state file produced by rift auth).
+# RIFT_AUTH_IDP_TOKEN or the state file produced by rift auth). When a refresh
+# token is available (credentials file or RIFT_AUTH_IDP_REFRESH_TOKEN), Rift
+# refreshes the access token before expiry using idp_token_refresh_threshold
+# (seconds of remaining validity; default 300). Set to 0 to disable automatic
+# refresh.
+#
+# idp_token_refresh_threshold: 300
 #
 # set_annex:
 #   type: server

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -393,6 +393,7 @@ class AuthTest(unittest.TestCase):
             "expires_in": 3600,
             "refresh_token": "refresh-new",
         }
+        os.unlink(self._cred_path)
         auth = Auth(self._minimal_config)
 
         # Generate near-expiry JWT token.
@@ -409,9 +410,16 @@ class AuthTest(unittest.TestCase):
             token = auth.get_idp_token_noninteractive()
 
         self.assertEqual(token, "access-refreshed")
+        # Make sure the state in memory is updated with the new token.
+        self.assertEqual(auth.state.idp_token, "access-refreshed")
+        self.assertEqual(auth.state.idp_refresh_token, "refresh-new")
+        self.assertFalse(auth._persist_credentials)
         mock_post.assert_called_once()
         self.assertEqual(mock_post.call_args[1]["data"]["grant_type"], "refresh_token")
         self.assertEqual(mock_post.call_args[1]["data"]["refresh_token"], "refresh-env")
+        # Make sure the credentials file is not created after tokens from environment
+        # are refreshed.
+        self.assertFalse(os.path.isfile(self._cred_path))
 
     @patch("rift.auth.requests.post")
     def test_get_idp_token_noninteractive_successive_calls_reuse_refreshed_env_token(
@@ -423,6 +431,7 @@ class AuthTest(unittest.TestCase):
             "expires_in": 3600,
             "refresh_token": "refresh-new",
         }
+        os.unlink(self._cred_path)
         auth = Auth(self._minimal_config)
 
         # Generate near-expiry JWT token.
@@ -441,6 +450,9 @@ class AuthTest(unittest.TestCase):
 
         # Check the refreshed token has been requested only once.
         mock_post.assert_called_once()
+        # Make sure the credentials file is not created after tokens from environment
+        # are refreshed.
+        self.assertFalse(os.path.isfile(self._cred_path))
 
     @patch("rift.auth.requests.post")
     def test_get_idp_token_noninteractive_non_jwt_env_skips_refresh(self, mock_post):

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -1,14 +1,166 @@
 import json
 import os
 import re
+import stat
 import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from rift import RiftError
-from rift.auth import Auth
+from rift.auth import Auth, AuthState
 
 from .test_utils import make_temp_file
+
+
+class AuthStateTest(unittest.TestCase):
+    """Unit tests for rift.auth.AuthState."""
+
+    def setUp(self):
+        self._cred_tmp = make_temp_file("{}", delete=False, suffix=".json")
+        self._cred_path = self._cred_tmp.name
+        self._cred_tmp.close()
+
+    def tearDown(self):
+        if os.path.isfile(self._cred_path):
+            os.unlink(self._cred_path)
+
+    def _write_state(self, data):
+        with open(self._cred_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def test_from_dict_to_dict_roundtrip(self):
+        """from_dict then to_dict preserves all credential fields."""
+        data = {
+            "idp_token": "tok",
+            "idp_token_expiration": "2099-01-01T00:00:00Z",
+            "access_key_id": "ak",
+            "secret_access_key": "sk",
+            "session_token": "st",
+            "expiration": "2099-01-02T00:00:00Z",
+        }
+        state = AuthState.from_dict(data)
+        self.assertEqual(state.to_dict(), data)
+
+    def test_to_dict_omits_none(self):
+        """to_dict drops unset (None) fields from the persisted payload."""
+        state = AuthState(idp_token="tok")
+        self.assertEqual(state.to_dict(), {"idp_token": "tok"})
+
+    def test_restore_scrubs_expired_and_rewrites(self):
+        """restore clears expired IDP/S3 fields and rewrites the credentials file."""
+        past = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._write_state(
+            {
+                "idp_token": "expired",
+                "idp_token_expiration": past,
+                "access_key_id": "ak",
+                "secret_access_key": "sk",
+                "session_token": "st",
+                "expiration": past,
+            }
+        )
+        with self.assertLogs(level="INFO") as logs:
+            restored = AuthState.restore(self._cred_path)
+        self.assertIn(
+            "found existing, expired S3 credentials",
+            "\n".join(logs.output),
+        )
+        self.assertIn(
+            "found existing, expired idp access token",
+            "\n".join(logs.output),
+        )
+        self.assertIsNone(restored.idp_token)
+        self.assertIsNone(restored.idp_token_expiration)
+        self.assertIsNone(restored.access_key_id)
+        self.assertIsNone(restored.secret_access_key)
+        self.assertIsNone(restored.session_token)
+        self.assertIsNone(restored.expiration)
+
+        with open(self._cred_path, encoding="utf-8") as f:
+            on_disk = json.load(f)
+        self.assertEqual(on_disk, {})
+
+    def test_restore_invalid_json(self):
+        """restore tolerates invalid JSON and returns an empty AuthState."""
+        with open(self._cred_path, "w", encoding="utf-8") as f:
+            f.write("not-json")
+        with self.assertLogs(level="INFO") as logs:
+            restored = AuthState.restore(self._cred_path)
+        self.assertIsNone(restored.idp_token)
+        self.assertIn(
+            "failed to decode json from existing credentials file",
+            "\n".join(logs.output),
+        )
+
+    def test_save_and_restore(self):
+        """save writes mode 0600; restore reloads valid credentials."""
+        exp = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        state = AuthState(
+            idp_token="tok-from-file",
+            idp_token_expiration=exp,
+            access_key_id="ak",
+            secret_access_key="sk",
+            session_token="st",
+            expiration=exp,
+        )
+        state.save(self._cred_path)
+        mode = stat.S_IMODE(os.stat(self._cred_path).st_mode)
+        self.assertEqual(mode, 0o600)
+
+        restored = AuthState.restore(self._cred_path)
+        self.assertEqual(restored.idp_token, "tok-from-file")
+        self.assertEqual(restored.access_key_id, "ak")
+        self.assertTrue(restored.has_s3_credentials())
+        self.assertIsNotNone(restored.s3_expiration_dt())
+
+    def test_has_s3_credentials_true(self):
+        """has_s3_credentials is True when access, secret, and session are set."""
+        state = AuthState(
+            access_key_id="ak",
+            secret_access_key="sk",
+            session_token="st",
+        )
+        self.assertTrue(state.has_s3_credentials())
+
+    def test_has_s3_credentials_false_when_missing(self):
+        """has_s3_credentials is False when any S3 field is unset."""
+        self.assertFalse(AuthState().has_s3_credentials())
+        self.assertFalse(
+            AuthState(access_key_id="ak", secret_access_key="sk").has_s3_credentials()
+        )
+
+    def test_has_s3_credentials_false_when_empty_string(self):
+        """has_s3_credentials is False when an S3 field is an empty string."""
+        state = AuthState(
+            access_key_id="ak",
+            secret_access_key="sk",
+            session_token="",
+        )
+        self.assertFalse(state.has_s3_credentials())
+
+    def test_s3_expiration_dt_unset(self):
+        """s3_expiration_dt returns None when expiration is unset."""
+        self.assertIsNone(AuthState().s3_expiration_dt())
+
+    def test_s3_expiration_dt_parses(self):
+        """s3_expiration_dt parses the ISO UTC expiration string."""
+        state = AuthState(expiration="2099-01-02T03:04:05Z")
+        self.assertEqual(
+            state.s3_expiration_dt(),
+            datetime(2099, 1, 2, 3, 4, 5),
+        )
+
+    def test_s3_expiration_str_unset(self):
+        """s3_expiration_str returns an empty string when expiration is unset."""
+        self.assertEqual(AuthState().s3_expiration_str(), "")
+
+    def test_s3_expiration_str_formats(self):
+        """s3_expiration_str returns a human-readable local-style timestamp."""
+        state = AuthState(expiration="2099-01-02T03:04:05Z")
+        self.assertEqual(
+            state.s3_expiration_str(),
+            datetime(2099, 1, 2, 3, 4, 5).strftime("%a %b %d %H:%M:%S %Y"),
+        )
 
 
 class AuthTest(unittest.TestCase):

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -94,7 +94,7 @@ class AuthStateTest(unittest.TestCase):
 
     def test_save_and_restore(self):
         """save writes mode 0600; restore reloads valid credentials."""
-        exp = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        exp = datetime.now() + timedelta(days=1)
         state = AuthState(
             idp_token="tok-from-file",
             idp_token_expiration=exp,
@@ -111,7 +111,9 @@ class AuthStateTest(unittest.TestCase):
         self.assertEqual(restored.idp_token, "tok-from-file")
         self.assertEqual(restored.access_key_id, "ak")
         self.assertTrue(restored.has_s3_credentials())
-        self.assertIsNotNone(restored.s3_expiration_dt())
+        self.assertIsInstance(restored.expiration, datetime)
+        self.assertIsInstance(restored.idp_token_expiration, datetime)
+        self.assertIsNotNone(restored.expiration)
 
     def test_has_s3_credentials_true(self):
         """has_s3_credentials is True when access, secret, and session are set."""
@@ -138,28 +140,17 @@ class AuthStateTest(unittest.TestCase):
         )
         self.assertFalse(state.has_s3_credentials())
 
-    def test_s3_expiration_dt_unset(self):
-        """s3_expiration_dt returns None when expiration is unset."""
-        self.assertIsNone(AuthState().s3_expiration_dt())
-
-    def test_s3_expiration_dt_parses(self):
-        """s3_expiration_dt parses the ISO UTC expiration string."""
-        state = AuthState(expiration="2099-01-02T03:04:05Z")
-        self.assertEqual(
-            state.s3_expiration_dt(),
-            datetime(2099, 1, 2, 3, 4, 5),
-        )
-
     def test_s3_expiration_str_unset(self):
         """s3_expiration_str returns an empty string when expiration is unset."""
         self.assertEqual(AuthState().s3_expiration_str(), "")
 
     def test_s3_expiration_str_formats(self):
         """s3_expiration_str returns a human-readable local-style timestamp."""
-        state = AuthState(expiration="2099-01-02T03:04:05Z")
+        exp = datetime(2099, 1, 2, 3, 4, 5)
+        state = AuthState(expiration=exp)
         self.assertEqual(
             state.s3_expiration_str(),
-            datetime(2099, 1, 2, 3, 4, 5).strftime("%a %b %d %H:%M:%S %Y"),
+            exp.strftime("%a %b %d %H:%M:%S %Y"),
         )
 
 

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -1,15 +1,43 @@
+import base64
 import json
 import os
 import re
 import stat
 import unittest
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from rift import RiftError
-from rift.auth import Auth, AuthState
+from rift.auth import Auth, AuthState, jwt_expiration_dt
 
 from .test_utils import make_temp_file
+
+
+def _make_jwt(payload):
+    """Build a dummy unsigned JWT-like string with the given payload dict."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode("ascii")
+    body = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8"))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    return f"{header}.{body}.sig"
+
+
+class JwtExpirationDtTest(unittest.TestCase):
+    """Unit tests for jwt_expiration_dt helper."""
+
+    def test_reads_exp(self):
+        exp = int((datetime.now() + timedelta(hours=1)).timestamp())
+        token = _make_jwt({"exp": exp})
+        self.assertEqual(jwt_expiration_dt(token), datetime.fromtimestamp(exp))
+
+    def test_non_jwt_returns_none(self):
+        self.assertIsNone(jwt_expiration_dt("not-a-jwt"))
+        self.assertIsNone(jwt_expiration_dt(None))
+
+    def test_missing_exp_returns_none(self):
+        self.assertIsNone(jwt_expiration_dt(_make_jwt({"sub": "user"})))
 
 
 class AuthStateTest(unittest.TestCase):
@@ -33,6 +61,7 @@ class AuthStateTest(unittest.TestCase):
         data = {
             "idp_token": "tok",
             "idp_token_expiration": "2099-01-01T00:00:00Z",
+            "idp_refresh_token": "refresh",
             "access_key_id": "ak",
             "secret_access_key": "sk",
             "session_token": "st",
@@ -53,6 +82,7 @@ class AuthStateTest(unittest.TestCase):
             {
                 "idp_token": "expired",
                 "idp_token_expiration": past,
+                "idp_refresh_token": "refresh",
                 "access_key_id": "ak",
                 "secret_access_key": "sk",
                 "session_token": "st",
@@ -71,6 +101,7 @@ class AuthStateTest(unittest.TestCase):
         )
         self.assertIsNone(restored.idp_token)
         self.assertIsNone(restored.idp_token_expiration)
+        self.assertIsNone(restored.idp_refresh_token)
         self.assertIsNone(restored.access_key_id)
         self.assertIsNone(restored.secret_access_key)
         self.assertIsNone(restored.session_token)
@@ -98,6 +129,7 @@ class AuthStateTest(unittest.TestCase):
         state = AuthState(
             idp_token="tok-from-file",
             idp_token_expiration=exp,
+            idp_refresh_token="refresh-from-file",
             access_key_id="ak",
             secret_access_key="sk",
             session_token="st",
@@ -109,6 +141,7 @@ class AuthStateTest(unittest.TestCase):
 
         restored = AuthState.restore(self._cred_path)
         self.assertEqual(restored.idp_token, "tok-from-file")
+        self.assertEqual(restored.idp_refresh_token, "refresh-from-file")
         self.assertEqual(restored.access_key_id, "ak")
         self.assertTrue(restored.has_s3_credentials())
         self.assertIsInstance(restored.expiration, datetime)
@@ -153,6 +186,16 @@ class AuthStateTest(unittest.TestCase):
             exp.strftime("%a %b %d %H:%M:%S %Y"),
         )
 
+    def test_idp_seconds_remaining(self):
+        """idp_seconds_remaining reflects stored datetime expiry."""
+        self.assertIsNone(AuthState().idp_seconds_remaining())
+        future = datetime.now() + timedelta(seconds=120)
+        state = AuthState(idp_token_expiration=future)
+        remaining = state.idp_seconds_remaining()
+        self.assertIsNotNone(remaining)
+        self.assertGreater(remaining, 100)
+        self.assertLess(remaining, 130)
+
 
 class AuthTest(unittest.TestCase):
     """Unit tests for rift.auth.Auth; add new test groups as methods here."""
@@ -164,6 +207,8 @@ class AuthTest(unittest.TestCase):
         self._minimal_config = {
             "idp_app_token": "app-token",
             "s3_credential_file": self._cred_path,
+            "idp_auth_endpoint": "https://idp.example/token",
+            "idp_token_refresh_threshold": 300,
         }
 
     def tearDown(self):
@@ -174,12 +219,116 @@ class AuthTest(unittest.TestCase):
         with open(self._cred_path, "w", encoding="utf-8") as f:
             json.dump(data, f)
 
+    @patch("rift.auth.requests.post")
+    def test_ensure_idp_token_fresh_near_expiry_without_refresh_skips(self, mock_post):
+        auth = Auth(self._minimal_config)
+        auth.state.idp_token_expiration = datetime.now() + timedelta(seconds=100)
+        auth._ensure_idp_token_fresh()
+        mock_post.assert_not_called()
+
+    @patch("rift.auth.requests.post")
+    def test_ensure_idp_token_fresh_above_threshold_skips_refresh(self, mock_post):
+        auth = Auth(self._minimal_config)
+        auth.state.idp_token_expiration = datetime.now() + timedelta(seconds=600)
+        auth.state.idp_refresh_token = "refresh"
+        auth._ensure_idp_token_fresh()
+        mock_post.assert_not_called()
+
+    @patch("rift.auth.requests.post")
+    def test_ensure_idp_token_fresh_unset_expiration_skips_refresh(self, mock_post):
+        auth = Auth(self._minimal_config)
+        auth.state.idp_refresh_token = "refresh"
+        auth._ensure_idp_token_fresh()
+        mock_post.assert_not_called()
+
+    @patch("rift.auth.requests.post")
+    def test_ensure_idp_token_fresh_disabled_when_threshold_zero(self, mock_post):
+        self._minimal_config["idp_token_refresh_threshold"] = 0
+        auth = Auth(self._minimal_config)
+        auth.state.idp_token_expiration = datetime.now() + timedelta(seconds=100)
+        auth.state.idp_refresh_token = "refresh"
+        auth._ensure_idp_token_fresh()
+        mock_post.assert_not_called()
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_password_persists_refresh_token(self, mock_post):
+        mock_post.return_value = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "access_token": "access-1",
+            "expires_in": 3600,
+            "refresh_token": "refresh-1",
+        }
+        auth = Auth(self._minimal_config)
+        with patch.dict(
+            os.environ,
+            {"RIFT_AUTH_USER": "user", "RIFT_AUTH_PASSWORD": "pass"},
+        ):
+            self.assertTrue(auth.get_idp_token())
+
+        self.assertEqual(auth.state.idp_token, "access-1")
+        self.assertEqual(auth.state.idp_refresh_token, "refresh-1")
+        self.assertIsInstance(auth.state.idp_token_expiration, datetime)
+        with open(self._cred_path, encoding="utf-8") as f:
+            on_disk = json.load(f)
+        self.assertEqual(on_disk["idp_refresh_token"], "refresh-1")
+        mock_post.assert_called_once()
+        self.assertEqual(mock_post.call_args[1]["data"]["grant_type"], "password")
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_refreshes_when_below_threshold(self, mock_post):
+        mock_post.return_value = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "access_token": "access-2",
+            "expires_in": 3600,
+            "refresh_token": "refresh-2",
+        }
+        auth = Auth(self._minimal_config)
+        auth.state.idp_token = "access-old"
+        auth.state.idp_refresh_token = "refresh-old"
+        auth.state.idp_token_expiration = datetime.now() + timedelta(seconds=60)
+
+        with self.assertLogs(level="INFO") as logs:
+            self.assertTrue(auth.get_idp_token())
+        self.assertIn(
+            "retrieved existing idp_token from auth file",
+            "\n".join(logs.output),
+        )
+
+        self.assertEqual(auth.state.idp_token, "access-2")
+        self.assertEqual(auth.state.idp_refresh_token, "refresh-2")
+        mock_post.assert_called_once()
+        self.assertEqual(mock_post.call_args[1]["data"]["grant_type"], "refresh_token")
+        self.assertEqual(mock_post.call_args[1]["data"]["refresh_token"], "refresh-old")
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_skips_refresh_above_threshold(self, mock_post):
+        auth = Auth(self._minimal_config)
+        auth.state.idp_token = "access-ok"
+        auth.state.idp_refresh_token = "refresh-ok"
+        auth.state.idp_token_expiration = datetime.now() + timedelta(seconds=600)
+
+        with self.assertLogs(level="INFO") as logs:
+            self.assertTrue(auth.get_idp_token())
+        self.assertIn(
+            "retrieved existing idp_token from auth file",
+            "\n".join(logs.output),
+        )
+
+        self.assertEqual(auth.state.idp_token, "access-ok")
+        mock_post.assert_not_called()
+
     def test_get_idp_token_noninteractive_env_token(self):
         self._write_state({})
         auth = Auth(self._minimal_config)
-        with patch.dict(os.environ, {"RIFT_AUTH_IDP_TOKEN": "from-env"}):
+
+        # Generate JWT token with 1 hour expiration.
+        exp = int((datetime.now() + timedelta(hours=1)).timestamp())
+        jwt_token = _make_jwt({"exp": exp})
+
+        with patch.dict(os.environ, {"RIFT_AUTH_IDP_TOKEN": jwt_token}, clear=False):
+            os.environ.pop("RIFT_AUTH_IDP_REFRESH_TOKEN", None)
             with self.assertLogs(level="DEBUG") as logs:
-                self.assertEqual(auth.get_idp_token_noninteractive(), "from-env")
+                self.assertEqual(auth.get_idp_token_noninteractive(), jwt_token)
         self.assertIn("fetched idp token from environment", "\n".join(logs.output))
 
     def test_get_idp_token_noninteractive_missing_credentials_file(self):
@@ -235,3 +384,113 @@ class AuthTest(unittest.TestCase):
             ),
         ):
             auth.get_idp_token_noninteractive()
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_noninteractive_refreshes_from_env_jwt(self, mock_post):
+        mock_post.return_value = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "access_token": "access-refreshed",
+            "expires_in": 3600,
+            "refresh_token": "refresh-new",
+        }
+        auth = Auth(self._minimal_config)
+
+        # Generate near-expiry JWT token.
+        exp = int((datetime.now() + timedelta(seconds=60)).timestamp())
+        jwt_token = _make_jwt({"exp": exp})
+
+        with patch.dict(
+            os.environ,
+            {
+                "RIFT_AUTH_IDP_TOKEN": jwt_token,
+                "RIFT_AUTH_IDP_REFRESH_TOKEN": "refresh-env",
+            },
+        ):
+            token = auth.get_idp_token_noninteractive()
+
+        self.assertEqual(token, "access-refreshed")
+        mock_post.assert_called_once()
+        self.assertEqual(mock_post.call_args[1]["data"]["grant_type"], "refresh_token")
+        self.assertEqual(mock_post.call_args[1]["data"]["refresh_token"], "refresh-env")
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_noninteractive_successive_calls_reuse_refreshed_env_token(
+        self, mock_post
+    ):
+        mock_post.return_value = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "access_token": "access-refreshed",
+            "expires_in": 3600,
+            "refresh_token": "refresh-new",
+        }
+        auth = Auth(self._minimal_config)
+
+        # Generate near-expiry JWT token.
+        exp = int((datetime.now() + timedelta(seconds=60)).timestamp())
+        jwt_token = _make_jwt({"exp": exp})
+
+        with patch.dict(
+            os.environ,
+            {
+                "RIFT_AUTH_IDP_TOKEN": jwt_token,
+                "RIFT_AUTH_IDP_REFRESH_TOKEN": "refresh-env",
+            },
+        ):
+            self.assertEqual(auth.get_idp_token_noninteractive(), "access-refreshed")
+            self.assertEqual(auth.get_idp_token_noninteractive(), "access-refreshed")
+
+        # Check the refreshed token has been requested only once.
+        mock_post.assert_called_once()
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_noninteractive_non_jwt_env_skips_refresh(self, mock_post):
+        auth = Auth(self._minimal_config)
+        with patch.dict(
+            os.environ,
+            {
+                "RIFT_AUTH_IDP_TOKEN": "opaque-token",
+                "RIFT_AUTH_IDP_REFRESH_TOKEN": "refresh-env",
+            },
+        ):
+            with self.assertLogs(level="WARNING") as logs:
+                # Check opaque token from environment is returned.
+                self.assertEqual(auth.get_idp_token_noninteractive(), "opaque-token")
+
+        # Check warning is emitted because unable to extract expiration from non-JWT.
+        self.assertIn(
+            "unable to extract expiration from RIFT_AUTH_IDP_TOKEN",
+            "\n".join(logs.output),
+        )
+
+        # Check the token has been returned without refreshing.
+        mock_post.assert_not_called()
+
+    @patch("rift.auth.requests.post")
+    def test_get_idp_token_noninteractive_refreshes_from_state_file(self, mock_post):
+        mock_post.return_value = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "access_token": "access-new",
+            "expires_in": 3600,
+        }
+        # Generate near-expiry token expiration.
+        exp = (datetime.now() + timedelta(seconds=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._write_state(
+            {
+                "idp_token": "access-old",
+                "idp_token_expiration": exp,
+                "idp_refresh_token": "refresh-file",
+            }
+        )
+        auth = Auth(self._minimal_config)
+        with patch.dict(os.environ, {}, clear=False):
+            # Ensure environment variables are not defined
+            os.environ.pop("RIFT_AUTH_IDP_TOKEN", None)
+            os.environ.pop("RIFT_AUTH_IDP_REFRESH_TOKEN", None)
+            # Check the refreshed token is returned
+            self.assertEqual(auth.get_idp_token_noninteractive(), "access-new")
+
+        # Check new token has been requested with refresh token from state file.
+        mock_post.assert_called_once()
+        self.assertEqual(
+            mock_post.call_args[1]["data"]["refresh_token"], "refresh-file"
+        )

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -97,7 +97,7 @@ class AuthenticatedRepositoryProxyRuntimeTest(RiftTestCase):
 
         runtime.start()
 
-        mock_auth.get_idp_token_noninteractive.assert_called_once()
+        mock_auth.get_idp_token_noninteractive.assert_called()
         mock_server_cls.assert_called_once_with(
             ("127.0.0.1", 0),
             _TokenAuthRepositoryProxyHandler,
@@ -111,6 +111,8 @@ class AuthenticatedRepositoryProxyRuntimeTest(RiftTestCase):
         self.assertTrue(runtime.active)
         self.assertEqual(runtime.token, "idp-token")
         self.assertEqual(runtime.port, 51234)
+        # Token is re-fetched per access (start + property read above).
+        self.assertGreaterEqual(mock_auth.get_idp_token_noninteractive.call_count, 2)
 
     @patch("rift.proxy.Auth")
     def test_start_skips_when_no_authenticated_repos(self, mock_auth):
@@ -133,7 +135,7 @@ class AuthenticatedRepositoryProxyRuntimeTest(RiftTestCase):
         server = Mock()
         runtime.server = server
         runtime._thread = Mock()
-        runtime.token = "idp-token"
+        runtime._auth = Mock()
 
         runtime.stop()
 
@@ -141,6 +143,7 @@ class AuthenticatedRepositoryProxyRuntimeTest(RiftTestCase):
         server.server_close.assert_called_once()
         self.assertIsNone(runtime.server)
         self.assertIsNone(runtime._thread)
+        self.assertIsNone(runtime._auth)
         self.assertIsNone(runtime.token)
 
     @patch("rift.proxy.Auth")


### PR DESCRIPTION
Use IDP refresh token to automatically renew IDP access token when it reaches a remaining time before expiry threshold (300 seconds, or 5 minutes by default).

When IDP access token is read from environment variable, Rift also expects the refresh token to be available in environment as well.

The feature can be disabled by setting a refresh threshold to 0 in configuration.

The Auth class has been refactored with a new AuthState class to handle the token in memory and on disk with credentials file.