### PR TITLE
Automatic code formatting with ruff and prek commit hook

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,16 @@
+name: Format
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
 repos:
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.0
     hooks:

--- a/Licence_CeCILL-C_V1-en.txt
+++ b/Licence_CeCILL-C_V1-en.txt
@@ -122,7 +122,7 @@ These expressions may be used both in singular and plural form.
 The purpose of the Agreement is the grant by the Licensor to the
 Licensee of a non-exclusive, transferable and worldwide license for the
 Software as set forth in Article 5 hereinafter for the whole term of the
-protection granted by the rights over said Software. 
+protection granted by the rights over said Software.
 
 
     Article 3 - ACCEPTANCE
@@ -268,7 +268,7 @@ When the Licensee creates Derivative Software, this Derivative Software
 may be distributed under a license agreement other than this Agreement,
 subject to compliance with the requirement to include a notice
 concerning the rights over the Software as defined in Article 6.4.
-In the event the creation of the Derivative Software required modification 
+In the event the creation of the Derivative Software required modification
 of the Source Code, the Licensee undertakes that:
 
    1. the resulting Modified Software will be governed by this Agreement,

--- a/Licence_CeCILL-C_V1-fr.txt
+++ b/Licence_CeCILL-C_V1-fr.txt
@@ -273,7 +273,7 @@ Lorsque le Licencié crée un Logiciel Dérivé, ce Logiciel Dérivé peut
 condition de respecter les obligations de mention des droits sur le
 Logiciel telles que définies à l'article 6.4. Dans le cas où la création du
 Logiciel Dérivé a nécessité une modification du Code Source le licencié
-s'engage à ce que: 
+s'engage à ce que:
 
    1. le Logiciel Modifié correspondant à cette modification soit régi
       par le présent Contrat,
@@ -370,7 +370,7 @@ Concédant et le Licencié.
 
     Article 8 - RESPONSABILITE
 
-8.1 Sous réserve des dispositions de l'article 8.2, le Licencié a la 
+8.1 Sous réserve des dispositions de l'article 8.2, le Licencié a la
 faculté, sous réserve de prouver la faute du Concédant concerné, de
 solliciter la réparation du préjudice direct qu'il subirait du fait du
 Logiciel et dont il apportera la preuve.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ Format and sort imports manually with:
 $ ruff check --fix lib tests && ruff format lib tests
 ```
 
-[prek](https://prek.j178.dev/) runs the same checks as a git commit hook and
-in CI on every push and pull request to `master`. Install it with either:
+[prek](https://prek.j178.dev/) runs Ruff plus generic file checks (trailing
+whitespace, end-of-file newlines, YAML/TOML syntax, merge-conflict markers,
+LF line endings) as a git commit hook and in CI on every push and pull
+request to `master`. Install it with either:
 
 ```sh
 $ pip install prek
@@ -77,4 +79,3 @@ Or run all hooks on the whole tree with:
 ```sh
 $ prek run --all-files
 ```
-

--- a/README.md
+++ b/README.md
@@ -41,3 +41,40 @@ Pytest is configured in [pyproject.toml](./pyproject.toml) and in [pytest.ini](p
 > you do not have direct access to Internet, you must define this environment
 > variable with your network's proxy server to run the tests successfully.
 
+
+## Formatting
+
+Python code is formatted with [Ruff](https://docs.astral.sh/ruff/). Install it
+with either:
+
+```sh
+$ pip install ruff
+$ uv tool install ruff
+```
+
+Format and sort imports manually with:
+
+```sh
+$ ruff check --fix lib tests && ruff format lib tests
+```
+
+[prek](https://prek.j178.dev/) runs the same checks as a git commit hook and
+in CI on every push and pull request to `master`. Install it with either:
+
+```sh
+$ pip install prek
+$ uv tool install prek
+```
+
+Then enable the commit hook:
+
+```sh
+$ prek install
+```
+
+Or run all hooks on the whole tree with:
+
+```sh
+$ prek run --all-files
+```
+

--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -609,7 +609,7 @@ class Config:
             return self._record_value(syntax, value)
         if check == "enum":
             enum_values = syntax.get("values", [])
-            if not value in enum_values:
+            if value not in enum_values:
                 raise DeclError(
                     f"Bad value {value} ({value.__class__.__name__}) for "
                     f"'{key}' (correct values: {', '.join(enum_values)})"

--- a/lib/rift/Config.py
+++ b/lib/rift/Config.py
@@ -33,10 +33,11 @@
 Config:
     This package manage rift configuration files.
 """
+
 import errno
+import logging
 import os
 import warnings
-import logging
 
 import yaml
 
@@ -49,353 +50,312 @@ except ImportError:
     # try importing the backported drop-in replacement, it's available on PyPI
     from ordereddict import OrderedDict
 
+
 # Very simplified version of
 # http://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts
 # This does not implement the matching dumper.
 class OrderedLoader(yaml.SafeLoader):
     """Specific yaml SafeLoader which imports yaml mapping using OrderedDict"""
 
+
 def _construct_mapping(loader, node):
     loader.flatten_mapping(node)
     return OrderedDict(loader.construct_pairs(node))
 
+
 class RiftDeprecatedConfWarning(FutureWarning):
     """Warning emitted when deprecated configuration parameter is loaded."""
 
+
 OrderedLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    _construct_mapping)
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+)
 
 
-_DEFAULT_PKG_DIR = 'packages'
-_DEFAULT_STAFF_FILE = os.path.join(_DEFAULT_PKG_DIR, 'staff.yaml')
-_DEFAULT_MODULES_FILE = os.path.join(_DEFAULT_PKG_DIR, 'modules.yaml')
-_DEFAULT_ARCH = ['x86_64']
+_DEFAULT_PKG_DIR = "packages"
+_DEFAULT_STAFF_FILE = os.path.join(_DEFAULT_PKG_DIR, "staff.yaml")
+_DEFAULT_MODULES_FILE = os.path.join(_DEFAULT_PKG_DIR, "modules.yaml")
+_DEFAULT_ARCH = ["x86_64"]
 _DEFAULT_VM_CPUS = 4
 _DEFAULT_VM_MEMORY = 8192
-_DEFAULT_VM_ADDRESS = '10.0.2.15'
+_DEFAULT_VM_ADDRESS = "10.0.2.15"
 _DEFAULT_VM_ADDITIONAL_RPMS = []
-_DEFAULT_VM_CLOUD_INIT_TPL = 'cloud-init.tpl'
-_DEFAULT_VM_BUILD_POST_SCRIPT = 'build-post.sh'
+_DEFAULT_VM_CLOUD_INIT_TPL = "cloud-init.tpl"
+_DEFAULT_VM_BUILD_POST_SCRIPT = "build-post.sh"
 _DEFAULT_VM_PORT_RANGE_MIN = 10000
 _DEFAULT_VM_PORT_RANGE_MAX = 15000
 _DEFAULT_VM_ENABLE_KVM = True
-_DEFAULT_QEMU_CMD = 'qemu-system-$arch'
-_DEFAULT_REPO_CMD = 'createrepo_c'
-_DEFAULT_CONTAINER_CMD = 'podman'
-_DEFAULT_CONTAINER_LINTER_CMD = 'hadolint'
-_DEFAULT_SHARED_FS_TYPE = '9p'
-_DEFAULT_VIRTIOFSD = '/usr/libexec/virtiofsd'
-_DEFAULT_SYNC_METHOD = 'dnf'
+_DEFAULT_QEMU_CMD = "qemu-system-$arch"
+_DEFAULT_REPO_CMD = "createrepo_c"
+_DEFAULT_CONTAINER_CMD = "podman"
+_DEFAULT_CONTAINER_LINTER_CMD = "hadolint"
+_DEFAULT_SHARED_FS_TYPE = "9p"
+_DEFAULT_VIRTIOFSD = "/usr/libexec/virtiofsd"
+_DEFAULT_SYNC_METHOD = "dnf"
 _DEFAULT_SYNC_INCLUDE = []
 _DEFAULT_SYNC_EXCLUDE = []
-_DEFAULT_VARIANT = 'main'
+_DEFAULT_VARIANT = "main"
 _DEFAULT_REPOS_VARIANTS = [_DEFAULT_VARIANT]
 _DEFAULT_DEPENDENCY_TRACKING = False
-_DEFAULT_S3_CREDENTIAL_FILE = '~/.rift/auth.json'
+_DEFAULT_S3_CREDENTIAL_FILE = "~/.rift/auth.json"
 
 
-class Config():
+class Config:
     """
     Config: Manage rift configuration files
         This class parses project.conf and local.conf from the current working
         package repository. It merges content of both files and gives access to
         stored values.
     """
+
     # XXX: Support hierarchical configuration (vm.image = ...)
 
-    _DEFAULT_FILES = ['project.conf', 'local.conf']
+    _DEFAULT_FILES = ["project.conf", "local.conf"]
     ALLOW_MISSING = True
 
     SYNTAX = {
-        'staff_file': {
-            'default':   _DEFAULT_STAFF_FILE,
+        "staff_file": {
+            "default": _DEFAULT_STAFF_FILE,
         },
-        'modules_file': {
-            'default':   _DEFAULT_MODULES_FILE,
+        "modules_file": {
+            "default": _DEFAULT_MODULES_FILE,
         },
-        'proxy': {},
-        'no_proxy': {},
-        'packages_dir': {
-            'default':   _DEFAULT_PKG_DIR,
+        "proxy": {},
+        "no_proxy": {},
+        "packages_dir": {
+            "default": _DEFAULT_PKG_DIR,
         },
-        's3_credential_file': {
-            'required': False,
-            'default':  _DEFAULT_S3_CREDENTIAL_FILE,
+        "s3_credential_file": {
+            "required": False,
+            "default": _DEFAULT_S3_CREDENTIAL_FILE,
         },
-        's3_auth_endpoint': {
-            'required': False,
+        "s3_auth_endpoint": {
+            "required": False,
         },
-        'idp_auth_endpoint': {
-            'required': False
+        "idp_auth_endpoint": {"required": False},
+        "idp_app_token": {"required": False},
+        "annex_restore_cache": {
+            "required": False,
         },
-        'idp_app_token': {
-            'required': False
-        },
-        'annex_restore_cache': {
-            'required': False,
-        },
-        'set_annex': {
-            'check': 'dict',
-            'required': True,
-            'syntax': {
-                'address': {
-                    'required': True,
+        "set_annex": {
+            "check": "dict",
+            "required": True,
+            "syntax": {
+                "address": {
+                    "required": True,
                 },
-                'type': {
-                    'check': 'enum',
-                    'required': True,
-                    'values': ['directory', 'server', 's3']
+                "type": {
+                    "check": "enum",
+                    "required": True,
+                    "values": ["directory", "server", "s3"],
                 },
-                'auth': {
-                    'check': 'enum',
-                    'values': ['idp_token'],
-                }
-            }
-        },
-        'annex': {
-            'deprecated': 'set_annex.address'
-        },
-        'annex_is_s3': {
-            'deprecated': 'set_annex.type'
-        },
-        'staging_annex': {
-            'check': 'dict',
-            'required': False,
-            'syntax': {
-                'address': {
-                    'required': True,
+                "auth": {
+                    "check": "enum",
+                    "values": ["idp_token"],
                 },
-                'type': {
-                    'check': 'enum',
-                    'required': True,
-                    'values': ['directory', 'server', 's3']
+            },
+        },
+        "annex": {"deprecated": "set_annex.address"},
+        "annex_is_s3": {"deprecated": "set_annex.type"},
+        "staging_annex": {
+            "check": "dict",
+            "required": False,
+            "syntax": {
+                "address": {
+                    "required": True,
                 },
-                'auth': {
-                    'check': 'enum',
-                    'values': ['idp_token'],
-                }
-            }
+                "type": {
+                    "check": "enum",
+                    "required": True,
+                    "values": ["directory", "server", "s3"],
+                },
+                "auth": {
+                    "check": "enum",
+                    "values": ["idp_token"],
+                },
+            },
         },
-        'working_repo': {
-        },
-        'repos': {
-            'check':    'record',
-            'content':  'dict',
-            'syntax': {
-                'sync': {
-                    'check': 'dict',
-                    'default': None,
-                    'syntax': {
-                        'method': {
-                            'check': 'enum',
-                            'default': _DEFAULT_SYNC_METHOD,
-                            'values': ['lftp', 'epel', 'dnf']
+        "working_repo": {},
+        "repos": {
+            "check": "record",
+            "content": "dict",
+            "syntax": {
+                "sync": {
+                    "check": "dict",
+                    "default": None,
+                    "syntax": {
+                        "method": {
+                            "check": "enum",
+                            "default": _DEFAULT_SYNC_METHOD,
+                            "values": ["lftp", "epel", "dnf"],
                         },
-                        'source': {
-                            'required': False,
+                        "source": {
+                            "required": False,
                         },
-                        'subdir': {},
-                        'include': {
-                            'check': 'list',
-                            'default': _DEFAULT_SYNC_INCLUDE,
+                        "subdir": {},
+                        "include": {
+                            "check": "list",
+                            "default": _DEFAULT_SYNC_INCLUDE,
                         },
-                        'exclude': {
-                            'check': 'list',
-                            'default': _DEFAULT_SYNC_EXCLUDE,
+                        "exclude": {
+                            "check": "list",
+                            "default": _DEFAULT_SYNC_EXCLUDE,
                         },
                     },
                 },
-                'url': {
-                    'required': True,
+                "url": {
+                    "required": True,
                 },
-                'priority': {
-                    'check': 'digit',
+                "priority": {
+                    "check": "digit",
                 },
-                'excludepkgs': {},
-                'module_hotfixes': {
-                    'check': 'bool'
+                "excludepkgs": {},
+                "module_hotfixes": {"check": "bool"},
+                "proxy": {},
+                "variants": {
+                    "check": "list",
+                    "default": _DEFAULT_REPOS_VARIANTS,
                 },
-                'proxy': {},
-                'variants': {
-                    'check': 'list',
-                    'default': _DEFAULT_REPOS_VARIANTS,
+                "auth": {
+                    "check": "enum",
+                    "values": ["idp_token"],
                 },
-                'auth': {
-                    'check': 'enum',
-                    'values': ['idp_token'],
-                }
-            }
+            },
         },
-        'arch': {
-            'check': 'list',
-            'default':  _DEFAULT_ARCH,
+        "arch": {
+            "check": "list",
+            "default": _DEFAULT_ARCH,
         },
-        'arch_efi_bios': {},
-        'version': {},
-        'maintainer':  {},
-        'qemu': {
-            'default':  _DEFAULT_QEMU_CMD,
+        "arch_efi_bios": {},
+        "version": {},
+        "maintainer": {},
+        "qemu": {
+            "default": _DEFAULT_QEMU_CMD,
         },
-        'createrepo': {
-            'default':  _DEFAULT_REPO_CMD,
+        "createrepo": {
+            "default": _DEFAULT_REPO_CMD,
         },
-        'gpg': {
-            'check':    'dict',
-            'syntax': {
-                'keyring': {
-                    'required': True,
+        "gpg": {
+            "check": "dict",
+            "syntax": {
+                "keyring": {
+                    "required": True,
                 },
-                'passphrase': {},
-                'key': {
-                    'required': True,
-                }
-            }
+                "passphrase": {},
+                "key": {
+                    "required": True,
+                },
+            },
         },
-        'vm': {
-            'check':    'dict',
-            'required': True,
-            'syntax': {
-                'image':    {
-                    'required': True,
+        "vm": {
+            "check": "dict",
+            "required": True,
+            "syntax": {
+                "image": {
+                    "required": True,
                     # XXX?: default value?
                 },
-                'image_copy':    {
-                    'check':    'digit',
-                    'default': 0,
+                "image_copy": {
+                    "check": "digit",
+                    "default": 0,
                 },
-                'image_source':  {},
-                'port_range': {
-                    'check':    'dict',
-                    'syntax': {
-                        'min': {
-                            'check': 'digit',
-                            'default': _DEFAULT_VM_PORT_RANGE_MIN,
+                "image_source": {},
+                "port_range": {
+                    "check": "dict",
+                    "syntax": {
+                        "min": {
+                            "check": "digit",
+                            "default": _DEFAULT_VM_PORT_RANGE_MIN,
                         },
-                        'max': {
-                            'check': 'digit',
-                            'default': _DEFAULT_VM_PORT_RANGE_MAX,
-                        }
-                    }
+                        "max": {
+                            "check": "digit",
+                            "default": _DEFAULT_VM_PORT_RANGE_MAX,
+                        },
+                    },
                 },
-                'cpu': {},
-                'cpus': {
-                    'check':    'digit',
-                    'default':  _DEFAULT_VM_CPUS,
+                "cpu": {},
+                "cpus": {
+                    "check": "digit",
+                    "default": _DEFAULT_VM_CPUS,
                 },
-                'memory': {
-                    'check':    'digit',
-                    'default':   _DEFAULT_VM_MEMORY,
+                "memory": {
+                    "check": "digit",
+                    "default": _DEFAULT_VM_MEMORY,
                 },
-                'address': {
-                    'default':  _DEFAULT_VM_ADDRESS,
+                "address": {
+                    "default": _DEFAULT_VM_ADDRESS,
                 },
-                'images_cache': {},
-                'additional_rpms': {
-                    'check':    'list',
-                    'default':  _DEFAULT_VM_ADDITIONAL_RPMS,
+                "images_cache": {},
+                "additional_rpms": {
+                    "check": "list",
+                    "default": _DEFAULT_VM_ADDITIONAL_RPMS,
                 },
-                'cloud_init_tpl': {
-                    'default': _DEFAULT_VM_CLOUD_INIT_TPL,
+                "cloud_init_tpl": {
+                    "default": _DEFAULT_VM_CLOUD_INIT_TPL,
                 },
-                'build_post_script': {
-                    'default': _DEFAULT_VM_BUILD_POST_SCRIPT,
+                "build_post_script": {
+                    "default": _DEFAULT_VM_BUILD_POST_SCRIPT,
                 },
-                'kernel': {},
-                'auth': {
-                    'check': 'enum',
-                    'values': ['idp_token'],
+                "kernel": {},
+                "auth": {
+                    "check": "enum",
+                    "values": ["idp_token"],
                 },
-                'enable_kvm': {
-                    'check': 'bool',
-                    'default': _DEFAULT_VM_ENABLE_KVM
-                }
-            }
+                "enable_kvm": {"check": "bool", "default": _DEFAULT_VM_ENABLE_KVM},
+            },
         },
-        'vm_image':    {
-            'deprecated': 'vm.image'
+        "vm_image": {"deprecated": "vm.image"},
+        "vm_image_copy": {"deprecated": "vm.image_copy"},
+        "vm_port_range": {"deprecated": "vm.port_range"},
+        "vm_cpu": {"deprecated": "vm.cpu"},
+        "vm_cpus": {"deprecated": "vm.cpus"},
+        "vm_memory": {"deprecated": "vm.memory"},
+        "vm_address": {"deprecated": "vm.address"},
+        "vm_images_cache": {"deprecated": "vm.images_cache"},
+        "vm_additional_rpms": {"deprecated": "vm.additional_rpms"},
+        "vm_cloud_init_tpl": {"deprecated": "vm.cloud_init_tpl"},
+        "vm_build_post_script": {"deprecated": "vm.build_post_script"},
+        "gerrit": {
+            "check": "dict",
+            "syntax": {
+                "realm": {},
+                "server": {},
+                "url": {},
+                "username": {},
+                "password": {},
+            },
         },
-        'vm_image_copy':    {
-            'deprecated': 'vm.image_copy'
-        },
-        'vm_port_range': {
-            'deprecated': 'vm.port_range'
-        },
-        'vm_cpu': {
-            'deprecated': 'vm.cpu'
-        },
-        'vm_cpus': {
-            'deprecated': 'vm.cpus'
-        },
-        'vm_memory': {
-            'deprecated': 'vm.memory'
-        },
-        'vm_address': {
-            'deprecated': 'vm.address'
-        },
-        'vm_images_cache': {
-            'deprecated': 'vm.images_cache'
-        },
-        'vm_additional_rpms': {
-            'deprecated': 'vm.additional_rpms'
-        },
-        'vm_cloud_init_tpl': {
-            'deprecated': 'vm.cloud_init_tpl'
-        },
-        'vm_build_post_script': {
-            'deprecated': 'vm.build_post_script'
-        },
-        'gerrit': {
-            'check': 'dict',
-            'syntax': {
-                'realm': {},
-                'server': {},
-                'url': {},
-                'username': {},
-                'password': {},
-            }
-        },
-        'gerrit_realm': {
-            'deprecated': 'gerrit.realm'
-        },
-        'gerrit_server': {
-            'deprecated': 'gerrit.server'
-        },
-        'gerrit_url': {
-            'deprecated': 'gerrit.url'
-        },
-        'gerrit_username': {
-            'deprecated': 'gerrit.username'
-        },
-        'gerrit_password': {
-            'deprecated': 'gerrit.password'
-        },
-        'containers': {
-            'check':    'dict',
-            'syntax': {
-                'command': {
-                    'default': _DEFAULT_CONTAINER_CMD,
+        "gerrit_realm": {"deprecated": "gerrit.realm"},
+        "gerrit_server": {"deprecated": "gerrit.server"},
+        "gerrit_url": {"deprecated": "gerrit.url"},
+        "gerrit_username": {"deprecated": "gerrit.username"},
+        "gerrit_password": {"deprecated": "gerrit.password"},
+        "containers": {
+            "check": "dict",
+            "syntax": {
+                "command": {
+                    "default": _DEFAULT_CONTAINER_CMD,
                 },
-                'linter': {
-                    'default': _DEFAULT_CONTAINER_LINTER_CMD,
+                "linter": {
+                    "default": _DEFAULT_CONTAINER_LINTER_CMD,
                 },
-            }
+            },
         },
-        'rpm_macros': {
-            'check':    'dict',
+        "rpm_macros": {
+            "check": "dict",
         },
-        'virtiofsd': {
-            'default': _DEFAULT_VIRTIOFSD,
+        "virtiofsd": {
+            "default": _DEFAULT_VIRTIOFSD,
         },
-        'shared_fs_type': {
-            'default': _DEFAULT_SHARED_FS_TYPE,
-            'check': 'enum',
-            'values': ['9p', 'virtiofs'],
+        "shared_fs_type": {
+            "default": _DEFAULT_SHARED_FS_TYPE,
+            "check": "enum",
+            "values": ["9p", "virtiofs"],
         },
-        'sync_output': {},
-        'dependency_tracking': {
-            'check': 'bool',
-            'default': _DEFAULT_DEPENDENCY_TRACKING,
+        "sync_output": {},
+        "dependency_tracking": {
+            "check": "bool",
+            "default": _DEFAULT_DEPENDENCY_TRACKING,
         },
         # XXX?: 'mock.name' ?
         # XXX?: 'mock.template' ?
@@ -426,7 +386,7 @@ class Config():
             if os.path.exists(filepath):
                 return dirname
 
-            while dirname != '/':
+            while dirname != "/":
                 dirname = os.path.split(dirname)[0]
                 filepath = os.path.join(dirname, filename)
                 if os.path.exists(filepath):
@@ -465,7 +425,7 @@ class Config():
         """
         # If arch argument is provided, check it is one of the project
         # supported architectures.
-        if arch is not None and arch not in self.get('arch'):
+        if arch is not None and arch not in self.get("arch"):
             raise DeclError(
                 "Unable to get configuration option for unsupported "
                 f"architecture '{arch}'"
@@ -473,11 +433,11 @@ class Config():
         # Except for arch option, if arch argument is provided, select the
         # architecture specific option (suffixed by the arch) in priority.
         if (
-                option != 'arch' and
-                arch is not None and
-                arch in self.options and
-                option in self.options[arch]
-            ):
+            option != "arch"
+            and arch is not None
+            and arch in self.options
+            and option in self.options[arch]
+        ):
             value = self.options[arch][option]
         elif option in self.options:
             value = self.options[option]
@@ -488,7 +448,7 @@ class Config():
 
         # Except for arch option, if arch argument is provided, replace $arch
         # placeholder by this value.
-        if option == 'arch' or arch is None:
+        if option == "arch" or arch is None:
             return value
         return self._replace_arch(value, arch)
 
@@ -502,12 +462,12 @@ class Config():
         syntax or provided default value.
         """
         if (
-                'default' not in syntax[option] and
-                syntax[option].get('check') == 'dict' and
-                'syntax' in syntax[option]
-            ):
-            return Config._extract_default_dict_syntax(syntax[option]['syntax'])
-        return syntax[option].get('default', default)
+            "default" not in syntax[option]
+            and syntax[option].get("check") == "dict"
+            and "syntax" in syntax[option]
+        ):
+            return Config._extract_default_dict_syntax(syntax[option]["syntax"])
+        return syntax[option].get("default", default)
 
     @staticmethod
     def _extract_default_dict_syntax(syntax):
@@ -516,12 +476,10 @@ class Config():
         """
         result = {}
         for key, option in syntax.items():
-            if 'default' in option:
-                result[key] = option['default']
-            elif option.get('check') == 'dict' and 'syntax' in option:
-                result[key] = Config._extract_default_dict_syntax(
-                    option['syntax']
-                )
+            if "default" in option:
+                result[key] = option["default"]
+            elif option.get("check") == "dict" and "syntax" in option:
+                result[key] = Config._extract_default_dict_syntax(option["syntax"])
         return result if result else None
 
     def _replace_arch(self, value, arch):
@@ -529,20 +487,14 @@ class Config():
         Replace $arch placeholder in all strings found in value recursively.
         """
         if isinstance(value, str):
-            return value.replace('$arch', arch)
+            return value.replace("$arch", arch)
         if isinstance(value, list):
             return [
-                item.replace('$arch', arch)
-                if isinstance(item, str)
-                else item
+                item.replace("$arch", arch) if isinstance(item, str) else item
                 for item in value
             ]
         if isinstance(value, dict):
-            return {
-                key: self._replace_arch(item, arch)
-                for key, item
-                in value.items()
-            }
+            return {key: self._replace_arch(item, arch) for key, item in value.items()}
         return value
 
     def load(self, filenames=None):
@@ -563,7 +515,7 @@ class Config():
                 if self.project_dir is None:
                     self.find_project_dir(filepath)
 
-                with open(self.project_path(filepath), encoding='utf-8') as fyaml:
+                with open(self.project_path(filepath), encoding="utf-8") as fyaml:
                     data = yaml.load(fyaml, Loader=OrderedLoader)
 
                 if data:
@@ -587,7 +539,7 @@ class Config():
         """
         if arch is None:
             return self.options
-        if arch not in self.get('arch'):
+        if arch not in self.get("arch"):
             raise DeclError(
                 "Unable to set configuration option for unsupported "
                 f"architecture '{arch}'"
@@ -606,22 +558,23 @@ class Config():
             raise DeclError(f"Unknown '{key}' key")
 
         # Check not deprecated
-        replacement = self.SYNTAX[key].get('deprecated')
+        replacement = self.SYNTAX[key].get("deprecated")
         if replacement:
-            raise DeclError(f"Parameter {key} is deprecated, use "
-                            f"{' > '.join(replacement.split('.'))} instead")
+            raise DeclError(
+                f"Parameter {key} is deprecated, use "
+                f"{' > '.join(replacement.split('.'))} instead"
+            )
 
         options = self._arch_options(arch)
         value = self._key_value(
             self.SYNTAX[key],
             key,
             value,
-            self.SYNTAX[key].get('check', 'string'),
+            self.SYNTAX[key].get("check", "string"),
         )
         # If the key is a dict or a record and it already has a value, merge it
         # with the new value.
-        if (self.SYNTAX[key].get('check') in ['dict', 'record']
-                and key in options):
+        if self.SYNTAX[key].get("check") in ["dict", "record"] and key in options:
             options[key].update(value)
         else:
             options[key] = value
@@ -631,8 +584,7 @@ class Config():
         Validate type of value against syntax definition and return its value.
         """
         # Check type
-        assert check in ('string', 'dict', 'record', 'list', 'digit', 'bool',
-                         'enum')
+        assert check in ("string", "dict", "record", "list", "digit", "bool", "enum")
 
         # All checks values which don't need conversion with their associated
         # python types
@@ -643,26 +595,20 @@ class Config():
             "bool": bool,
         }
 
-        if check == 'bool':
+        if check == "bool":
             if not isinstance(value, bool):
-                raise DeclError(
-                    f"Bad data type {value.__class__.__name__} for '{key}'"
-                )
+                raise DeclError(f"Bad data type {value.__class__.__name__} for '{key}'")
             return value
-        if check == 'dict':
+        if check == "dict":
             if not isinstance(value, dict):
-                raise DeclError(
-                    f"Bad data type {value.__class__.__name__} for '{key}'"
-                )
-            return self._dict_value(syntax.get('syntax'), key, value)
-        if check == 'record':
+                raise DeclError(f"Bad data type {value.__class__.__name__} for '{key}'")
+            return self._dict_value(syntax.get("syntax"), key, value)
+        if check == "record":
             if not isinstance(value, dict):
-                raise DeclError(
-                    f"Bad data type {value.__class__.__name__} for '{key}'"
-                )
+                raise DeclError(f"Bad data type {value.__class__.__name__} for '{key}'")
             return self._record_value(syntax, value)
-        if check == 'enum':
-            enum_values = syntax.get('values', [])
+        if check == "enum":
+            enum_values = syntax.get("values", [])
             if not value in enum_values:
                 raise DeclError(
                     f"Bad value {value} ({value.__class__.__name__}) for "
@@ -672,9 +618,7 @@ class Config():
         # At this stage, check is necessary one of the types which don't need
         # conversion.
         if not isinstance(value, types_no_conv[check]):
-            raise DeclError(
-                f"Bad data type {value.__class__.__name__} for '{key}'"
-            )
+            raise DeclError(f"Bad data type {value.__class__.__name__} for '{key}'")
         return value
 
     def _dict_value(self, syntax, key, value):
@@ -697,14 +641,13 @@ class Config():
         # Iterate over the keys defined in syntax. If the subvalue or default
         # value is defined, set it.
         for subkey in syntax.keys():
-            subkey_value = value.get(subkey,
-                                     Config._syntax_default(syntax, subkey))
+            subkey_value = value.get(subkey, Config._syntax_default(syntax, subkey))
             if subkey_value is not None:
                 result[subkey] = self._key_value(
                     syntax[subkey],
                     subkey,
                     subkey_value,
-                    syntax[subkey].get('check', 'string')
+                    syntax[subkey].get("check", "string"),
                 )
 
         return result
@@ -717,10 +660,7 @@ class Config():
         result = {}
         for _key, _value in value.items():
             result[_key] = self._key_value(
-                syntax,
-                _key,
-                _value,
-                syntax.get('content', 'string')
+                syntax, _key, _value, syntax.get("content", "string")
             )
         return result
 
@@ -731,7 +671,7 @@ class Config():
         and the key of this parameter in this dict.
         """
         sub = data
-        replacement_items = replacement.split('.')
+        replacement_items = replacement.split(".")
         # Browse in data dict depth until last replacement item.
         for index, item in enumerate(replacement_items, start=1):
             if index < len(replacement_items):
@@ -756,19 +696,25 @@ class Config():
         if replacement is None:
             return
         # Warn user with FutureWarning.
-        warnings.warn(f"Configuration parameter {param} is deprecated, use "
-                      f"{' > '.join(replacement.split('.'))} instead",
-                      RiftDeprecatedConfWarning)
+        warnings.warn(
+            f"Configuration parameter {param} is deprecated, use "
+            f"{' > '.join(replacement.split('.'))} instead",
+            RiftDeprecatedConfWarning,
+        )
         # Get position of replacement parameter.
         sub, item = Config._get_replacement_dict_key(data, replacement)
         # If both new and deprecated parameter are defined, emit warning log to
         # explain deprecated parameter is ignored. Else, move deprecated
         # parameter to its new place.
         if item in sub:
-            logging.warning("Both deprecated parameter %s and new parameter "
-                            "%s are declared in configuration, deprecated "
-                            "parameter %s is ignored",
-                            param, replacement, param)
+            logging.warning(
+                "Both deprecated parameter %s and new parameter "
+                "%s are declared in configuration, deprecated "
+                "parameter %s is ignored",
+                param,
+                replacement,
+                param,
+            )
         else:
             sub[item] = value
         del data[param]
@@ -781,12 +727,12 @@ class Config():
         # Load generic options (ie. not architecture specific)
         for param, value in data.copy().items():
             # Skip architecture specific options
-            if param in self.get('arch'):
+            if param in self.get("arch"):
                 continue
             self._move_deprecated_param(data, param, value)
 
         # Load architecture specific options
-        for arch in self.get('arch'):
+        for arch in self.get("arch"):
             if arch in data and isinstance(data[arch], dict):
                 for param, value in data.copy()[arch].items():
                     self._move_deprecated_param(data[arch], param, value)
@@ -797,9 +743,9 @@ class Config():
         SYNTAX spec.
         """
         # Set arch first
-        if 'arch' in data:
-            self.set('arch', data['arch'])
-            del data['arch']
+        if "arch" in data:
+            self.set("arch", data["arch"])
+            del data["arch"]
 
         # Look for deprecated parameters, and update dict with new parameters.
         self._move_deprecated(data)
@@ -807,17 +753,16 @@ class Config():
         # Load generic options (ie. not architecture specific)
         for key, value in data.items():
             # Skip architecture specific options
-            if key in self.get('arch'):
+            if key in self.get("arch"):
                 continue
             self.set(key, value)
 
         # Load architecture specific options
-        for arch in self.get('arch'):
+        for arch in self.get("arch"):
             if arch in data:
                 if not isinstance(data[arch], dict):
                     raise DeclError(
-                        f"Architecture specific override for {arch} must be a "
-                        "mapping"
+                        f"Architecture specific override for {arch} must be a mapping"
                     )
                 for key, value in data[arch].items():
                     self.set(key, value, arch=arch)
@@ -826,45 +771,39 @@ class Config():
         """Checks for required options in main syntax recursively."""
         self._check_syntax(self.SYNTAX, self.options)
 
-    def _check_syntax(self, syntax, options, param='__main__'):
+    def _check_syntax(self, syntax, options, param="__main__"):
         """Checks for mandatory options regarding the provided syntax recursively."""
         for key in syntax:
-            if (
-                    syntax[key].get('required', False) and
-                    'default' not in syntax[key]
-                ):
+            if syntax[key].get("required", False) and "default" not in syntax[key]:
                 # Check key is in options or defined in all supported arch
                 # specific options.
-                if (
-                        key not in options and
-                        not all(
-                            arch in options and key in options[arch]
-                            for arch in self.get('arch')
-                        )
-                    ):
-                    if param == '__main__':
+                if key not in options and not all(
+                    arch in options and key in options[arch]
+                    for arch in self.get("arch")
+                ):
+                    if param == "__main__":
                         raise DeclError(f"'{key}' is not defined")
-                    raise DeclError(
-                        f"Key {key} is required in dict parameter {param}"
-                    )
+                    raise DeclError(f"Key {key} is required in dict parameter {param}")
             # If the parameter is a dict with a syntax, check the value.
             if (
-                    syntax[key].get('check') == 'dict' and
-                    syntax[key].get('syntax') is not None and key in options
-                ):
-                self._check_syntax(syntax[key]['syntax'], options[key], key)
+                syntax[key].get("check") == "dict"
+                and syntax[key].get("syntax") is not None
+                and key in options
+            ):
+                self._check_syntax(syntax[key]["syntax"], options[key], key)
             # If the parameter is a record with dict values and a syntax, check
             # all values.
             if (
-                    syntax[key].get('check') == 'record' and
-                    syntax[key].get('content') == 'dict' and
-                    syntax[key].get('syntax') is not None and key in options
-                ):
+                syntax[key].get("check") == "record"
+                and syntax[key].get("content") == "dict"
+                and syntax[key].get("syntax") is not None
+                and key in options
+            ):
                 for value in options[key].values():
-                    self._check_syntax(syntax[key]['syntax'], value, key)
+                    self._check_syntax(syntax[key]["syntax"], value, key)
 
 
-class Staff():
+class Staff:
     """
     List of staff members of a rift project.
 
@@ -872,9 +811,9 @@ class Staff():
     """
 
     DEFAULT_PATH = _DEFAULT_STAFF_FILE
-    DATA_NAME = 'staff'
-    ITEMS_HEADER = 'staff'
-    ITEMS_KEYS = ['email']
+    DATA_NAME = "staff"
+    ITEMS_HEADER = "staff"
+    ITEMS_KEYS = ["email"]
 
     def __init__(self, config):
         self._data = {}
@@ -899,7 +838,7 @@ class Staff():
             filepath = self.DEFAULT_PATH
 
         try:
-            with open(self._config.project_path(filepath), encoding='utf-8') as fyaml:
+            with open(self._config.project_path(filepath), encoding="utf-8") as fyaml:
                 data = yaml.load(fyaml, Loader=OrderedLoader)
 
             self._data = data.pop(self.ITEMS_HEADER) or {}
@@ -909,7 +848,9 @@ class Staff():
         except AttributeError as exp:
             raise DeclError(f"Bad data format in {self.DATA_NAME} file") from exp
         except KeyError as exp:
-            raise DeclError(f"Missing {exp} at top level in {self.DATA_NAME} file") from exp
+            raise DeclError(
+                f"Missing {exp} at top level in {self.DATA_NAME} file"
+            ) from exp
         except yaml.error.YAMLError as exp:
             raise DeclError(str(exp)) from exp
         except IOError as exp:
@@ -927,13 +868,13 @@ class Staff():
             # Missing elements
             missing = set(self.ITEMS_KEYS) - set(data.keys())
             if missing:
-                items = ', '.join([f"'{item}'" for item in missing])
+                items = ", ".join([f"'{item}'" for item in missing])
                 raise DeclError(f"Missing {items} item(s) for {people}")
 
             # Unnecessary elements
             not_needed = set(data.keys()) - set(self.ITEMS_KEYS)
             if not_needed:
-                items = ', '.join(sorted([f"'{item}'" for item in not_needed]))
+                items = ", ".join(sorted([f"'{item}'" for item in not_needed]))
                 raise DeclError(f"Unknown {items} item(s) for {people}")
 
 
@@ -945,9 +886,9 @@ class Modules(Staff):
     """
 
     DEFAULT_PATH = _DEFAULT_MODULES_FILE
-    DATA_NAME = 'modules'
-    ITEMS_HEADER = 'modules'
-    ITEMS_KEYS = ['manager']
+    DATA_NAME = "modules"
+    ITEMS_HEADER = "modules"
+    ITEMS_KEYS = ["manager"]
 
     def __init__(self, config, staff):
         Staff.__init__(self, config)
@@ -963,9 +904,9 @@ class Modules(Staff):
 
         for module in self._data.values():
             # Maintainer exists
-            if isinstance(module['manager'], str):
-                module['manager'] = [module['manager']]
-            for mngr in module['manager']:
+            if isinstance(module["manager"], str):
+                module["manager"] = [module["manager"]]
+            for mngr in module["manager"]:
                 if mngr not in self.staff:
                     msg = f"Manager '{mngr}' does not exist in staff list"
                     raise DeclError(msg)

--- a/lib/rift/Controller.py
+++ b/lib/rift/Controller.py
@@ -33,34 +33,36 @@
 Controler.py:
     Core package to manage rift actions
 """
-import os
+
 import argparse
 import logging
-from operator import attrgetter
-import time
+import os
 import platform
+import time
+from operator import attrgetter
+
 # Since pylint can not found rpm.error, disable this check
-from rpm import error as RpmError # pylint: disable=no-name-in-module
-from unidiff import parse_unidiff
+from rpm import error as RpmError  # pylint: disable=no-name-in-module
 
 from rift import RiftError, __version__
 from rift.annex import Annex, is_binary, is_pointer
-from rift.Config import Config, Staff, Modules, _DEFAULT_VARIANT
-from rift.Gerrit import Review
 from rift.auth import Auth
-from rift.package import RIFT_SUPPORTED_FORMATS, ProjectPackages
-from rift.repository import ProjectArchRepositories, StagingRepository
+from rift.Config import _DEFAULT_VARIANT, Config, Modules, Staff
+from rift.container import ContainerArchive, ContainerFile
+from rift.Gerrit import Review
 from rift.graph import PackagesDependencyGraph
-from rift.RPM import RPM, Spec
 from rift.Mock import Mock
-from rift.container import ContainerFile, ContainerArchive
+from rift.package import RIFT_SUPPORTED_FORMATS, ProjectPackages
+from rift.patches import get_packages_from_patch
+from rift.repository import ProjectArchRepositories, StagingRepository
+from rift.RPM import RPM, Spec
+from rift.sync import RepoSyncFactory
 from rift.TestResults import TestCase, TestResults
 from rift.TextTable import TextTable
-from rift.VM import VM
-from rift.sync import RepoSyncFactory
-from rift.patches import get_packages_from_patch
 from rift.threads import RiftThread
-from rift.utils import message, banner
+from rift.utils import banner, message
+from rift.VM import VM
+from unidiff import parse_unidiff
 
 
 def make_parser():
@@ -68,366 +70,537 @@ def make_parser():
 
     parser = argparse.ArgumentParser()
     # Generic options
-    parser.add_argument('-v', '--verbose', action='count', default=0,
-                        help="increase output verbosity (twice for debug)")
-    parser.add_argument('--version', action='version',
-                        version=f"Rift {__version__}")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase output verbosity (twice for debug)",
+    )
+    parser.add_argument("--version", action="version", version=f"Rift {__version__}")
 
-    subparsers = parser.add_subparsers(dest='command', metavar='COMMAND')
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
 
     # Create options
-    subprs = subparsers.add_parser('create', help='create a new package')
-    subprs.add_argument('name', metavar='PKGNAME',
-                        help='package name to be created')
-    subprs.add_argument('-m', '--module', dest='module', required=True,
-                        help='module name this package will belong to')
-    subprs.add_argument('-r', '--reason', dest='reason', required=True,
-                        help='reason this package is added to project')
-    subprs.add_argument('-o', '--origin', dest='origin',
-                        help='source of original package')
-    subprs.add_argument('-t', '--maintainer', dest='maintainer',
-                        help='maintainer name from staff.yaml')
+    subprs = subparsers.add_parser("create", help="create a new package")
+    subprs.add_argument("name", metavar="PKGNAME", help="package name to be created")
+    subprs.add_argument(
+        "-m",
+        "--module",
+        dest="module",
+        required=True,
+        help="module name this package will belong to",
+    )
+    subprs.add_argument(
+        "-r",
+        "--reason",
+        dest="reason",
+        required=True,
+        help="reason this package is added to project",
+    )
+    subprs.add_argument(
+        "-o", "--origin", dest="origin", help="source of original package"
+    )
+    subprs.add_argument(
+        "-t", "--maintainer", dest="maintainer", help="maintainer name from staff.yaml"
+    )
 
     # Import options
-    subprs = subparsers.add_parser('import',
-                                   help='import a SRPM and create a package')
-    subprs.add_argument('file', metavar='FILE', help='source RPM to import')
-    subprs.add_argument('-m', '--module', dest='module', required=True,
-                        help='module name this package will belong to')
-    subprs.add_argument('-r', '--reason', dest='reason', required=True,
-                        help='reason this package is added to project')
-    subprs.add_argument('-o', '--origin', dest='origin',
-                        help='source of original package')
-    subprs.add_argument('-t', '--maintainer', dest='maintainer',
-                        help='maintainer name from staff.yaml')
+    subprs = subparsers.add_parser("import", help="import a SRPM and create a package")
+    subprs.add_argument("file", metavar="FILE", help="source RPM to import")
+    subprs.add_argument(
+        "-m",
+        "--module",
+        dest="module",
+        required=True,
+        help="module name this package will belong to",
+    )
+    subprs.add_argument(
+        "-r",
+        "--reason",
+        dest="reason",
+        required=True,
+        help="reason this package is added to project",
+    )
+    subprs.add_argument(
+        "-o", "--origin", dest="origin", help="source of original package"
+    )
+    subprs.add_argument(
+        "-t", "--maintainer", dest="maintainer", help="maintainer name from staff.yaml"
+    )
 
     # Reimport options
-    subprs = subparsers.add_parser('reimport',
-                                   help='update an existing package with a SRPM')
-    subprs.add_argument('file', metavar='FILE', help='source RPM to import')
-    subprs.add_argument('-m', '--module', dest='module',
-                        help='module name this package will belong to')
-    subprs.add_argument('-r', '--reason', dest='reason',
-                        help='reason this package is added to project')
-    subprs.add_argument('-o', '--origin', dest='origin',
-                        help='source of original package')
-    subprs.add_argument('-t', '--maintainer', dest='maintainer',
-                        help='maintainer name from staff.yaml')
+    subprs = subparsers.add_parser(
+        "reimport", help="update an existing package with a SRPM"
+    )
+    subprs.add_argument("file", metavar="FILE", help="source RPM to import")
+    subprs.add_argument(
+        "-m", "--module", dest="module", help="module name this package will belong to"
+    )
+    subprs.add_argument(
+        "-r", "--reason", dest="reason", help="reason this package is added to project"
+    )
+    subprs.add_argument(
+        "-o", "--origin", dest="origin", help="source of original package"
+    )
+    subprs.add_argument(
+        "-t", "--maintainer", dest="maintainer", help="maintainer name from staff.yaml"
+    )
 
     # Check options
-    subprs = subparsers.add_parser('check',
-                                   help='verify various config file syntaxes')
-    subprs.add_argument('type', choices=['staff', 'modules', 'info',
-                                         'spec', 'containerfile'],
-                        metavar='CHKTYPE', help='type of check')
-    subprs.add_argument('-f', '--file', metavar='FILE',
-                        help='path of file to check')
+    subprs = subparsers.add_parser("check", help="verify various config file syntaxes")
+    subprs.add_argument(
+        "type",
+        choices=["staff", "modules", "info", "spec", "containerfile"],
+        metavar="CHKTYPE",
+        help="type of check",
+    )
+    subprs.add_argument("-f", "--file", metavar="FILE", help="path of file to check")
 
     # Build options
-    subprs = subparsers.add_parser('build', help='build package')
-    subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
-                        help='package name to build')
-    subprs.add_argument('-p', '--publish', action='store_true',
-                        help='publish package to repository')
-    subprs.add_argument('-s', '--sign', action='store_true',
-                        help='sign built packages with GPG key '
-                             '(implies -p, --publish)')
-    subprs.add_argument('-S', '--skip-deps', action='store_true',
-                        help='Skip automatic rebuild of reverse dependencies')
-    subprs.add_argument('--junit', metavar='FILENAME',
-                        help='write junit result file')
-    subprs.add_argument('--dont-update-repo', dest='updaterepo', action='store_false',
-                        help='do not update repository metadata when publishing a package')
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict build to specific package formats')
-    subprs.add_argument('-q', '--quiet', action='store_true',
-                        help='omit build output when it succeeds')
-    subprs.add_argument('--seq', action='store_true',
-                        help='run one architecture at a time with live output '
-                             '(no parallel threads)')
+    subprs = subparsers.add_parser("build", help="build package")
+    subprs.add_argument(
+        "packages", metavar="PACKAGE", nargs="*", help="package name to build"
+    )
+    subprs.add_argument(
+        "-p", "--publish", action="store_true", help="publish package to repository"
+    )
+    subprs.add_argument(
+        "-s",
+        "--sign",
+        action="store_true",
+        help="sign built packages with GPG key (implies -p, --publish)",
+    )
+    subprs.add_argument(
+        "-S",
+        "--skip-deps",
+        action="store_true",
+        help="Skip automatic rebuild of reverse dependencies",
+    )
+    subprs.add_argument("--junit", metavar="FILENAME", help="write junit result file")
+    subprs.add_argument(
+        "--dont-update-repo",
+        dest="updaterepo",
+        action="store_false",
+        help="do not update repository metadata when publishing a package",
+    )
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict build to specific package formats",
+    )
+    subprs.add_argument(
+        "-q", "--quiet", action="store_true", help="omit build output when it succeeds"
+    )
+    subprs.add_argument(
+        "--seq",
+        action="store_true",
+        help="run one architecture at a time with live output (no parallel threads)",
+    )
 
     # Sign options
-    subprs = subparsers.add_parser('sign', help='Sign RPM package with GPG key.')
-    subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
-                        help='package to sign.')
+    subprs = subparsers.add_parser("sign", help="Sign RPM package with GPG key.")
+    subprs.add_argument(
+        "packages", metavar="PACKAGE", nargs="*", help="package to sign."
+    )
 
     # Test options
-    subprs = subparsers.add_parser('test', help='execute package tests')
-    subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
-                        help='package name to test')
-    subprs.add_argument('--noquit', action='store_true',
-                        help='do not stop VM at the end')
-    subprs.add_argument('--noauto', action='store_true',
-                        help='do not run auto tests')
-    subprs.add_argument('--junit', metavar='FILENAME',
-                        help='write junit result file')
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict tests to specific package formats')
+    subprs = subparsers.add_parser("test", help="execute package tests")
+    subprs.add_argument(
+        "packages", metavar="PACKAGE", nargs="*", help="package name to test"
+    )
+    subprs.add_argument(
+        "--noquit", action="store_true", help="do not stop VM at the end"
+    )
+    subprs.add_argument("--noauto", action="store_true", help="do not run auto tests")
+    subprs.add_argument("--junit", metavar="FILENAME", help="write junit result file")
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict tests to specific package formats",
+    )
 
     # Validate options
-    subprs = subparsers.add_parser('validate', help='Fully validate package')
-    subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
-                        help='package name to validate')
-    subprs.add_argument('-s', '--sign', action='store_true',
-                        help='sign built packages with GPG key '
-                             '(implies -p, --publish)')
-    subprs.add_argument('--noquit', action='store_true',
-                        help='do not stop VM at the end')
-    subprs.add_argument('--noauto', action='store_true',
-                        help='do not run auto tests')
-    subprs.add_argument('--notest', dest='test', action='store_false', default=True,
-                        help='do not run ANY tests')
-    subprs.add_argument('--junit', metavar='FILENAME',
-                        help='write junit result file')
-    subprs.add_argument('-p', '--publish', action='store_true',
-                        help='publish built package to repository')
-    subprs.add_argument('-S', '--skip-deps', action='store_true',
-                        help='Skip automatic validation of reverse dependencies')
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict validation to specific package formats')
-    subprs.add_argument('-q', '--quiet', action='store_true',
-                        help='omit validate output when it succeeds')
-    subprs.add_argument('--seq', action='store_true',
-                        help='run one architecture at a time with live output '
-                             '(no parallel threads)')
+    subprs = subparsers.add_parser("validate", help="Fully validate package")
+    subprs.add_argument(
+        "packages", metavar="PACKAGE", nargs="*", help="package name to validate"
+    )
+    subprs.add_argument(
+        "-s",
+        "--sign",
+        action="store_true",
+        help="sign built packages with GPG key (implies -p, --publish)",
+    )
+    subprs.add_argument(
+        "--noquit", action="store_true", help="do not stop VM at the end"
+    )
+    subprs.add_argument("--noauto", action="store_true", help="do not run auto tests")
+    subprs.add_argument(
+        "--notest",
+        dest="test",
+        action="store_false",
+        default=True,
+        help="do not run ANY tests",
+    )
+    subprs.add_argument("--junit", metavar="FILENAME", help="write junit result file")
+    subprs.add_argument(
+        "-p",
+        "--publish",
+        action="store_true",
+        help="publish built package to repository",
+    )
+    subprs.add_argument(
+        "-S",
+        "--skip-deps",
+        action="store_true",
+        help="Skip automatic validation of reverse dependencies",
+    )
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict validation to specific package formats",
+    )
+    subprs.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="omit validate output when it succeeds",
+    )
+    subprs.add_argument(
+        "--seq",
+        action="store_true",
+        help="run one architecture at a time with live output (no parallel threads)",
+    )
 
     # Validate diff
-    subprs = subparsers.add_parser('validdiff')
-    subprs.add_argument('patch', metavar='PATCH', type=argparse.FileType('r'))
-    subprs.add_argument('-s', '--sign', action='store_true',
-                        help='sign built packages with GPG key '
-                             '(implies -p, --publish)')
-    subprs.add_argument('--noquit', action='store_true',
-                        help='do not stop VM at the end')
-    subprs.add_argument('--noauto', action='store_true',
-                        help='do not run auto tests')
-    subprs.add_argument('--notest', dest='test', action='store_false', default=True,
-                        help='do not run ANY tests')
-    subprs.add_argument('--junit', metavar='FILENAME',
-                        help='write junit result file')
-    subprs.add_argument('-p', '--publish', action='store_true',
-                        help='publish built packages to repository')
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict validdiff to specific package formats')
-    subprs.add_argument('-q', '--quiet', action='store_true',
-                        help='omit validate diff output when it succeeds')
-    subprs.add_argument('--seq', action='store_true',
-                        help='run one architecture at a time with live output '
-                             '(no parallel threads)')
+    subprs = subparsers.add_parser("validdiff")
+    subprs.add_argument("patch", metavar="PATCH", type=argparse.FileType("r"))
+    subprs.add_argument(
+        "-s",
+        "--sign",
+        action="store_true",
+        help="sign built packages with GPG key (implies -p, --publish)",
+    )
+    subprs.add_argument(
+        "--noquit", action="store_true", help="do not stop VM at the end"
+    )
+    subprs.add_argument("--noauto", action="store_true", help="do not run auto tests")
+    subprs.add_argument(
+        "--notest",
+        dest="test",
+        action="store_false",
+        default=True,
+        help="do not run ANY tests",
+    )
+    subprs.add_argument("--junit", metavar="FILENAME", help="write junit result file")
+    subprs.add_argument(
+        "-p",
+        "--publish",
+        action="store_true",
+        help="publish built packages to repository",
+    )
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict validdiff to specific package formats",
+    )
+    subprs.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="omit validate diff output when it succeeds",
+    )
+    subprs.add_argument(
+        "--seq",
+        action="store_true",
+        help="run one architecture at a time with live output (no parallel threads)",
+    )
 
     # Annex options
-    subprs = subparsers.add_parser('annex', help='Manipulate annex cache')
+    subprs = subparsers.add_parser("annex", help="Manipulate annex cache")
 
-    subprs_annex = subprs.add_subparsers(dest='annex_cmd',
-                                         title='possible commands')
+    subprs_annex = subprs.add_subparsers(dest="annex_cmd", title="possible commands")
     subsubprs_annex_backup = subprs_annex.add_parser(
-        'backup', help='backup the annex to a tar.gz archive'
+        "backup", help="backup the annex to a tar.gz archive"
     )
     subsubprs_annex_backup.add_argument(
-        '--output-file', metavar='PATH', required=False,
-        help='annex backup output file'
+        "--output-file", metavar="PATH", required=False, help="annex backup output file"
     )
 
-    subprs_annex.add_parser('list', help='list cache content')
-    subsubprs = subprs_annex.add_parser('push', help='move a file into cache')
-    subsubprs.add_argument('files', metavar='FILENAME', nargs='+',
-                           help='file path to be move')
-    subsubprs = subprs_annex.add_parser('restore',
-                                        help='restore file content previously pushed to annex')
-    subsubprs.add_argument('files', metavar='FILENAME', nargs='+',
-                           help='file path to be restored')
-    subsubprs = subprs_annex.add_parser('delete',
-                                        help='remove a file from cache')
-    subsubprs.add_argument('id', metavar='ID', help='digest ID to delete')
-    subsubprs = subprs_annex.add_parser('get', help='Copy a file from cache')
-    subsubprs.add_argument('--id', metavar='DIGEST', required=True,
-                           help='digest ID to read')
-    subsubprs.add_argument('--dest', metavar='PATH', required=True,
-                           help='destination path')
+    subprs_annex.add_parser("list", help="list cache content")
+    subsubprs = subprs_annex.add_parser("push", help="move a file into cache")
+    subsubprs.add_argument(
+        "files", metavar="FILENAME", nargs="+", help="file path to be move"
+    )
+    subsubprs = subprs_annex.add_parser(
+        "restore", help="restore file content previously pushed to annex"
+    )
+    subsubprs.add_argument(
+        "files", metavar="FILENAME", nargs="+", help="file path to be restored"
+    )
+    subsubprs = subprs_annex.add_parser("delete", help="remove a file from cache")
+    subsubprs.add_argument("id", metavar="ID", help="digest ID to delete")
+    subsubprs = subprs_annex.add_parser("get", help="Copy a file from cache")
+    subsubprs.add_argument(
+        "--id", metavar="DIGEST", required=True, help="digest ID to read"
+    )
+    subsubprs.add_argument(
+        "--dest", metavar="PATH", required=True, help="destination path"
+    )
 
     # Auth options
-    subprs = subparsers.add_parser('auth', help='Authenticate to an IDP for privileged actions')
+    subprs = subparsers.add_parser(
+        "auth", help="Authenticate to an IDP for privileged actions"
+    )
 
     # VM options
-    subprs = subparsers.add_parser('vm', help='Manipulate VM process')
-    subprs.add_argument('-a', '--arch', help='CPU architecture of the VM')
-    subprs_vm = subprs.add_subparsers(dest='vm_cmd', title='possible commands')
-    subprs_vm.add_parser('connect', help='connect to running VM')
-    subsubprs = subprs_vm.add_parser('start', help='launch a new VM')
-    subsubprs.add_argument('--force', action='store_true',
-                           help='ignore local copy and force download of remote image')
-    subsubprs.add_argument('--notemp', action='store_false', dest='tmpimg',
-                           default=True, help='modify the real VM image')
-    subprs_vm.add_parser('stop', help='stop the running VM')
-    subprs_vm.add_parser('console', help='console of the running VM')
-    subsubprs = subprs_vm.add_parser('cmd', help='run a command inside the VM')
-    subsubprs.add_argument('commandline', help='command line arguments',
-                           nargs=argparse.REMAINDER)
-    subsubprs = subprs_vm.add_parser('copy', help='copy files with VM')
-    subsubprs.add_argument('source', help='source files')
-    subsubprs.add_argument('dest', help='destination files')
-    subsubprs = subprs_vm.add_parser('build', help='build image of test VM')
-    subsubprs.add_argument('--url', help='URL of base cloud image')
-    subsubprs.add_argument('--force', action='store_true',
-                           help='ignore cache and force download of cloud image')
-    subsubprs.add_argument('-o', '--output',
-                           help='path of generated virtual machine image')
-    subsubprs.add_argument('--deploy', action='store_true',
-                           help='deploy project image defined in configuration')
-    subsubprs.add_argument('--keep', action='store_true',
-                           help='keep virtual machine alive in case of boot failure')
+    subprs = subparsers.add_parser("vm", help="Manipulate VM process")
+    subprs.add_argument("-a", "--arch", help="CPU architecture of the VM")
+    subprs_vm = subprs.add_subparsers(dest="vm_cmd", title="possible commands")
+    subprs_vm.add_parser("connect", help="connect to running VM")
+    subsubprs = subprs_vm.add_parser("start", help="launch a new VM")
+    subsubprs.add_argument(
+        "--force",
+        action="store_true",
+        help="ignore local copy and force download of remote image",
+    )
+    subsubprs.add_argument(
+        "--notemp",
+        action="store_false",
+        dest="tmpimg",
+        default=True,
+        help="modify the real VM image",
+    )
+    subprs_vm.add_parser("stop", help="stop the running VM")
+    subprs_vm.add_parser("console", help="console of the running VM")
+    subsubprs = subprs_vm.add_parser("cmd", help="run a command inside the VM")
+    subsubprs.add_argument(
+        "commandline", help="command line arguments", nargs=argparse.REMAINDER
+    )
+    subsubprs = subprs_vm.add_parser("copy", help="copy files with VM")
+    subsubprs.add_argument("source", help="source files")
+    subsubprs.add_argument("dest", help="destination files")
+    subsubprs = subprs_vm.add_parser("build", help="build image of test VM")
+    subsubprs.add_argument("--url", help="URL of base cloud image")
+    subsubprs.add_argument(
+        "--force",
+        action="store_true",
+        help="ignore cache and force download of cloud image",
+    )
+    subsubprs.add_argument(
+        "-o", "--output", help="path of generated virtual machine image"
+    )
+    subsubprs.add_argument(
+        "--deploy",
+        action="store_true",
+        help="deploy project image defined in configuration",
+    )
+    subsubprs.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep virtual machine alive in case of boot failure",
+    )
 
     # query
-    subprs = subparsers.add_parser('query', help='Show packages metadata')
-    subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
-                        help='package name to validate')
-    subprs.add_argument('--format', dest='fmt', help='Display format')
-    subprs.add_argument('--nospec', dest='spec',
-                        action='store_false', help="Don't load specfile info")
-    subprs.add_argument('-H', '--no-header', dest='headers',
-                        action='store_false', help='Hide table headers')
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='Restrict query to specific package formats')
+    subprs = subparsers.add_parser("query", help="Show packages metadata")
+    subprs.add_argument(
+        "packages", metavar="PACKAGE", nargs="*", help="package name to validate"
+    )
+    subprs.add_argument("--format", dest="fmt", help="Display format")
+    subprs.add_argument(
+        "--nospec", dest="spec", action="store_false", help="Don't load specfile info"
+    )
+    subprs.add_argument(
+        "-H",
+        "--no-header",
+        dest="headers",
+        action="store_false",
+        help="Hide table headers",
+    )
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="Restrict query to specific package formats",
+    )
 
     # Add changelog entry
-    subprs = subparsers.add_parser('changelog',
-                                   help='Add a new changelog entry')
-    subprs.add_argument('package', metavar='PACKAGE',
-                        help='package name to add changelog entry to')
-    subprs.add_argument('-c', '--comment', metavar='COMMENT', required=True,
-                        help='Changelog comment')
-    subprs.add_argument('-t', '--maintainer', dest='maintainer',
-                        help='maintainer name from staff.yaml')
-    subprs.add_argument('--bump', dest='bump', action='store_true',
-                        help='also bump the release number')
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict command to specific package formats')
+    subprs = subparsers.add_parser("changelog", help="Add a new changelog entry")
+    subprs.add_argument(
+        "package", metavar="PACKAGE", help="package name to add changelog entry to"
+    )
+    subprs.add_argument(
+        "-c", "--comment", metavar="COMMENT", required=True, help="Changelog comment"
+    )
+    subprs.add_argument(
+        "-t", "--maintainer", dest="maintainer", help="maintainer name from staff.yaml"
+    )
+    subprs.add_argument(
+        "--bump", dest="bump", action="store_true", help="also bump the release number"
+    )
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict command to specific package formats",
+    )
 
     # GitLab review
-    subprs = subparsers.add_parser('gitlab', add_help=False,
-                                   help='Check specfiles for GitLab')
-    subprs.add_argument('patch', metavar='PATCH', type=argparse.FileType('r'))
+    subprs = subparsers.add_parser(
+        "gitlab", add_help=False, help="Check specfiles for GitLab"
+    )
+    subprs.add_argument("patch", metavar="PATCH", type=argparse.FileType("r"))
 
     # Gerrit review
-    subprs = subparsers.add_parser('gerrit', add_help=False,
-                                   help='Make Gerrit automatic review')
-    subprs.add_argument('--change', help="Gerrit Change-Id", required=True)
-    subprs.add_argument('--patchset', help="Gerrit patchset ID", required=True)
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict command to specific package formats')
-    subprs.add_argument('patch', metavar='PATCH', type=argparse.FileType('r'))
+    subprs = subparsers.add_parser(
+        "gerrit", add_help=False, help="Make Gerrit automatic review"
+    )
+    subprs.add_argument("--change", help="Gerrit Change-Id", required=True)
+    subprs.add_argument("--patchset", help="Gerrit patchset ID", required=True)
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict command to specific package formats",
+    )
+    subprs.add_argument("patch", metavar="PATCH", type=argparse.FileType("r"))
 
     # sync
-    subprs = subparsers.add_parser('sync', help='Synchronize remote repositories')
-    subprs.add_argument('-o', '--output', help='Synchronization output directory')
-    subprs.add_argument('-m', '--max-size', type=int,
-                        help='Max size authorized for the download of each file, in bytes')
-    subprs.add_argument('-r', '--retries', type=int, default=0,
-                        help='Allowed retries when a package download failed')
-    subprs.add_argument('-l', '--log-file', action='store_true',
-                        help='Log the sync process to a log file in the current directory')
-    subprs.add_argument('repositories', metavar='REPOSITORY', nargs='*',
-                        help='repositories to synchronize (default: all)')
+    subprs = subparsers.add_parser("sync", help="Synchronize remote repositories")
+    subprs.add_argument("-o", "--output", help="Synchronization output directory")
+    subprs.add_argument(
+        "-m",
+        "--max-size",
+        type=int,
+        help="Max size authorized for the download of each file, in bytes",
+    )
+    subprs.add_argument(
+        "-r",
+        "--retries",
+        type=int,
+        default=0,
+        help="Allowed retries when a package download failed",
+    )
+    subprs.add_argument(
+        "-l",
+        "--log-file",
+        action="store_true",
+        help="Log the sync process to a log file in the current directory",
+    )
+    subprs.add_argument(
+        "repositories",
+        metavar="REPOSITORY",
+        nargs="*",
+        help="repositories to synchronize (default: all)",
+    )
 
     # graph
-    subprs = subparsers.add_parser('graph',
-                                   help='Draw graph of packages dependencies')
-    subprs.add_argument('--with-external', action='store_true',
-                        help="add project external dependencies in the graph")
-    subprs.add_argument('--module',
-                        help="represent packages from this module in the graph")
-    subprs.add_argument('-F', '--formats', nargs='+',
-                        choices=RIFT_SUPPORTED_FORMATS,
-                        help='restrict command to specific package formats')
-    subprs.add_argument('packages', metavar='PACKAGE', nargs='*',
-                        help='packages to represent in the graph')
+    subprs = subparsers.add_parser("graph", help="Draw graph of packages dependencies")
+    subprs.add_argument(
+        "--with-external",
+        action="store_true",
+        help="add project external dependencies in the graph",
+    )
+    subprs.add_argument(
+        "--module", help="represent packages from this module in the graph"
+    )
+    subprs.add_argument(
+        "-F",
+        "--formats",
+        nargs="+",
+        choices=RIFT_SUPPORTED_FORMATS,
+        help="restrict command to specific package formats",
+    )
+    subprs.add_argument(
+        "packages",
+        metavar="PACKAGE",
+        nargs="*",
+        help="packages to represent in the graph",
+    )
 
     # Parse options
     return parser
 
+
 def action_check(args, config):
     """Action for 'check' sub-commands."""
 
-    if args.type == 'staff':
-
+    if args.type == "staff":
         staff = Staff(config)
-        staff.load(args.file or config.get('staff_file'))
-        logging.info('Staff file is OK.')
+        staff.load(args.file or config.get("staff_file"))
+        logging.info("Staff file is OK.")
 
-    elif args.type == 'modules':
-
+    elif args.type == "modules":
         staff = Staff(config)
-        staff.load(config.get('staff_file'))
+        staff.load(config.get("staff_file"))
         modules = Modules(config, staff)
-        modules.load(args.file or config.get('modules_file'))
-        logging.info('Modules file is OK.')
+        modules.load(args.file or config.get("modules_file"))
+        logging.info("Modules file is OK.")
 
-    elif args.type == 'info':
-
+    elif args.type == "info":
         staff = Staff(config)
-        staff.load(config.get('staff_file'))
+        staff.load(config.get("staff_file"))
         modules = Modules(config, staff)
-        modules.load(config.get('modules_file'))
+        modules.load(config.get("modules_file"))
 
         if args.file is None:
             raise RiftError("You must specify a file path (-f)")
 
         # If the package supports multiple format, check only the first as
         # the info file is the name for all formats.
-        pkg = ProjectPackages.get('dummy', config, staff, modules)[0]
-        pkg.sourcesdir = '/'
+        pkg = ProjectPackages.get("dummy", config, staff, modules)[0]
+        pkg.sourcesdir = "/"
         pkg.load_info(args.file)
-        logging.info('Info file is OK.')
+        logging.info("Info file is OK.")
 
-    elif args.type == 'spec':
-
+    elif args.type == "spec":
         if args.file is None:
             raise RiftError("You must specify a file path (-f)")
 
         mock = Mock(config, platform.machine())
-        repos = ProjectArchRepositories(config, platform.machine()).for_format('rpm')
+        repos = ProjectArchRepositories(config, platform.machine()).for_format("rpm")
         spec = Spec(args.file, mock, repos.all, config=config)
         spec.check()
-        logging.info('Spec file is OK.')
+        logging.info("Spec file is OK.")
 
-    elif args.type == 'containerfile':
-
+    elif args.type == "containerfile":
         if args.file is None:
             raise RiftError("You must specify a file path (-f)")
 
         container_file = ContainerFile(config, args.file)
         container_file.check()
-        logging.info('Containerfile is OK.')
+        logging.info("Containerfile is OK.")
 
 
 def action_annex(args, config, staff, modules):
     """Action for 'annex' sub-commands."""
     annex = Annex(config)
 
-    assert args.annex_cmd in (
-        'backup', 'list', 'get',
-        'push', 'delete', 'restore'
-    )
-    if args.annex_cmd == 'list':
+    assert args.annex_cmd in ("backup", "list", "get", "push", "delete", "restore")
+    if args.annex_cmd == "list":
         fmt = "%-32s %10s  %-18s %s"
-        print(fmt % ('ID', 'SIZE', 'DATE', 'FILENAMES'))
-        print(fmt % ('--', '----', '----', '---------'))
+        print(fmt % ("ID", "SIZE", "DATE", "FILENAMES"))
+        print(fmt % ("--", "----", "----", "---------"))
         for filename, size, mtime, names in annex.list():
             try:
-                timestr = time.strftime('%x %X', time.localtime(mtime))
-                print(fmt % (filename, size, timestr, ','.join(names)))
+                timestr = time.strftime("%x %X", time.localtime(mtime))
+                print(fmt % (filename, size, timestr, ",".join(names)))
 
             except TypeError:
-                print(fmt % (filename, size, mtime, ','.join(names)))
+                print(fmt % (filename, size, mtime, ",".join(names)))
 
-    elif args.annex_cmd == 'push':
+    elif args.annex_cmd == "push":
         for srcfile in args.files:
             if is_pointer(srcfile):
                 message(f"{srcfile}: already pointing to annex")
@@ -437,7 +610,7 @@ def action_annex(args, config, staff, modules):
             else:
                 message(f"{srcfile}: not binary, ignoring")
 
-    elif args.annex_cmd == 'restore':
+    elif args.annex_cmd == "restore":
         for srcfile in args.files:
             if is_pointer(srcfile):
                 annex.get_by_path(srcfile, srcfile)
@@ -445,21 +618,22 @@ def action_annex(args, config, staff, modules):
             else:
                 message(f"{srcfile}: not an annex pointer, ignoring")
 
-    elif args.annex_cmd == 'delete':
+    elif args.annex_cmd == "delete":
         if annex.delete(args.id):
             message(f"{args.id} has been deleted")
 
-    elif args.annex_cmd == 'get':
+    elif args.annex_cmd == "get":
         annex.get(args.id, args.dest)
         message(f"{args.dest} has been created")
 
-    elif args.annex_cmd == 'backup':
+    elif args.annex_cmd == "backup":
         message("Annex backup in progress...")
         output_file = annex.backup(
             ProjectPackages.list(config, staff, modules), args.output_file
         )
 
         message(f"Annex backup is available here: {output_file}")
+
 
 def action_auth(config):
     """Action for 'auth' sub-commands."""
@@ -504,12 +678,13 @@ def validate_pkgs(config, args, pkgs, arch):
             logging.info(
                 "Skipping validation of %s package %s due to restriction on "
                 "package formats",
-                pkg.format, pkg.name
+                pkg.format,
+                pkg.name,
             )
             continue
 
         # Load package and report possible failure
-        case = TestCase('build', pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
+        case = TestCase("build", pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
         now = time.time()
         try:
             pkg.load()
@@ -520,23 +695,22 @@ def validate_pkgs(config, args, pkgs, arch):
 
         if not pkg.supports_arch(arch):
             logging.info(
-                "Skipping validation on architecture %s not supported by "
-                "%s package %s",
+                "Skipping validation on architecture %s not supported by %s package %s",
                 arch,
                 pkg.format,
-                pkg.name
+                pkg.name,
             )
             continue
 
-        banner(f"Checking {pkg.format} package '{pkg.name}' on architecture "
-            f"{arch}")
+        banner(f"Checking {pkg.format} package '{pkg.name}' on architecture {arch}")
 
         now = time.time()
         try:
             pkg.check()
         except RiftError as ex:
-            logging.error("Static analysis of %s package failed: %s",
-                pkg.format, str(ex))
+            logging.error(
+                "Static analysis of %s package failed: %s", pkg.format, str(ex)
+            )
             results.add_failure(case, time.time() - now, err=str(ex))
             continue  # skip current package
 
@@ -545,7 +719,7 @@ def validate_pkgs(config, args, pkgs, arch):
 
         try:
             now = time.time()
-            case = TestCase('build', pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
+            case = TestCase("build", pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
             pkg_arch.build(sign=args.sign, staging=staging)
         except RiftError as ex:
             logging.error("%s build failure: %s", pkg.format, str(ex))
@@ -561,9 +735,8 @@ def validate_pkgs(config, args, pkgs, arch):
         # Check tests
         if args.test:
             pkg_results = pkg_arch.test(
-                noauto=args.noauto,
-                staging=staging,
-                noquit=args.noquit)
+                noauto=args.noauto, staging=staging, noquit=args.noquit
+            )
             results.extend(pkg_results)
 
         # Also publish on working repo if requested
@@ -581,16 +754,13 @@ def validate_pkgs(config, args, pkgs, arch):
 
     return results
 
+
 def vm_build(config, vm, args):
     """Build VM image."""
     if not args.deploy and args.output is None:
-        raise RiftError(
-            "Either --deploy or -o,--output option must be used"
-        )
+        raise RiftError("Either --deploy or -o,--output option must be used")
     if args.deploy and args.output is not None:
-        raise RiftError(
-            "Both --deploy and -o,--output options cannot be used together"
-        )
+        raise RiftError("Both --deploy and -o,--output options cannot be used together")
     if args.deploy:
         if vm.image_is_remote():
             raise RiftError(
@@ -601,12 +771,12 @@ def vm_build(config, vm, args):
     else:
         output = args.output
 
-    vm_source_url = ''
+    vm_source_url = ""
     if args.url is not None:
         vm_source_url = args.url
 
-    elif "image_source" in config.get(args.arch)['vm']:
-        vm_source_url = config.get(args.arch)['vm']['image_source']
+    elif "image_source" in config.get(args.arch)["vm"]:
+        vm_source_url = config.get(args.arch)["vm"]["image_source"]
 
     else:
         raise RiftError(
@@ -620,6 +790,7 @@ def vm_build(config, vm, args):
     vm.build(vm_source_url, args.force, args.keep, output)
     banner(f"New vm image {output} is ready")
     return 0
+
 
 def remove_packages(config, args, pkgs_to_remove, arch):
     """
@@ -640,8 +811,16 @@ def action_vm(args, config):
 
     ret = 1
 
-    assert args.vm_cmd in ('connect', 'console', 'start', 'stop', 'cmd', 'copy', 'build')
-    supported_archs = config.get('arch')
+    assert args.vm_cmd in (
+        "connect",
+        "console",
+        "start",
+        "stop",
+        "cmd",
+        "copy",
+        "build",
+    )
+    supported_archs = config.get("arch")
     if args.arch is None:
         # If --arch argument is not set and there is more than one supported
         # architecture, raise error to ask user to set the argument. If only one
@@ -652,27 +831,28 @@ def action_vm(args, config):
                 f"(possible values: {', '.join(supported_archs)})"
             )
         args.arch = supported_archs[0]
-    if args.arch not in config.get('arch'):
+    if args.arch not in config.get("arch"):
         raise RiftError(f"Project does not support architecture '{args.arch}'")
     vm = VM(config, args.arch)
-    if args.vm_cmd == 'connect':
+    if args.vm_cmd == "connect":
         ret = vm.cmd(options=None, manage_output=False).returncode
-    elif args.vm_cmd == 'console':
+    elif args.vm_cmd == "console":
         ret = vm.console()
-    elif args.vm_cmd == 'cmd':
-        ret = vm.cmd(' '.join(args.commandline), options=None).returncode
-    elif args.vm_cmd == 'copy':
+    elif args.vm_cmd == "cmd":
+        ret = vm.cmd(" ".join(args.commandline), options=None).returncode
+    elif args.vm_cmd == "copy":
         ret = vm.copy(args.source, args.dest)
-    elif args.vm_cmd == 'start':
+    elif args.vm_cmd == "start":
         vm.tmpmode = args.tmpimg
         if vm.start(args.force):
             message("VM started. Use: rift vm connect")
             ret = 0
-    elif args.vm_cmd == 'stop':
-        ret = vm.cmd('poweroff').returncode
-    elif args.vm_cmd == 'build':
+    elif args.vm_cmd == "stop":
+        ret = vm.cmd("poweroff").returncode
+    elif args.vm_cmd == "build":
         ret = vm_build(config, vm, args)
     return ret
+
 
 def build_pkgs(args, pkgs, arch, staging):
     """
@@ -681,35 +861,32 @@ def build_pkgs(args, pkgs, arch, staging):
     results = TestResults()
 
     for pkg in pkgs:
-
         # Skip package if format is not selected by user
         if args.formats and pkg.format not in args.formats:
             logging.info(
-                "Skipping build of %s package %s due to restriction on package "
-                "formats",
-                pkg.format, pkg.name
+                "Skipping build of %s package %s due to restriction on package formats",
+                pkg.format,
+                pkg.name,
             )
             continue
 
         # Load package and report possible failure
-        case = TestCase('build', pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
+        case = TestCase("build", pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
         now = time.time()
         try:
             pkg.load()
         except RiftError as ex:
-            logging.error("Unable to load %s package: %s",
-                pkg.format, str(ex))
+            logging.error("Unable to load %s package: %s", pkg.format, str(ex))
             results.add_failure(case, time.time() - now, err=str(ex))
             continue  # skip current package
 
         # Check architecture is supported or skip package
         if not pkg.supports_arch(arch):
             logging.info(
-                "Skipping build on architecture %s not supported by %s package "
-                "%s",
+                "Skipping build on architecture %s not supported by %s package %s",
                 arch,
                 pkg.format,
-                pkg.name
+                pkg.name,
             )
             continue
 
@@ -743,6 +920,7 @@ def build_pkgs(args, pkgs, arch, staging):
 
     return results
 
+
 def build_architecture(config, args, pkgs, arch):
     """Build pkgs for a specific architecture and return results."""
 
@@ -752,7 +930,7 @@ def build_architecture(config, args, pkgs, arch):
     # dependency tracking is disabled in project configuration or user set
     # --skip-deps argument.
     staging = None
-    if config.get('dependency_tracking') and not args.skip_deps:
+    if config.get("dependency_tracking") and not args.skip_deps:
         staging = StagingRepository(config)
 
     results.extend(build_pkgs(args, pkgs, arch, staging))
@@ -774,20 +952,19 @@ def action_build(args, config):
 
     # Check working repo is properly defined if publish arg is used or raise
     # RiftError
-    if args.publish and config.get('working_repo') is None:
+    if args.publish and config.get("working_repo") is None:
         raise RiftError("Cannot publish if 'working_repo' is undefined")
 
-    results = TestResults('build')
+    results = TestResults("build")
 
     staff, modules = staff_modules(config)
     pkgs = get_packages_to_build(config, staff, modules, args)
     logging.info(
-        "Ordered list of packages to build: %s",
-        str([pkg.name for pkg in pkgs])
+        "Ordered list of packages to build: %s", str([pkg.name for pkg in pkgs])
     )
 
     if args.seq:
-        for arch in config.get('arch'):
+        for arch in config.get("arch"):
             message(f"Starting build on architecture {arch}")
             results.extend(build_architecture(config, args, pkgs, arch))
     else:
@@ -796,7 +973,7 @@ def action_build(args, config):
 
         # Create parallel threads to build all packages for all project supported
         # architectures.
-        for arch in config.get('arch'):
+        for arch in config.get("arch"):
             threads.append(
                 RiftThread(
                     build_architecture, f"build-{arch}", args=(config, args, pkgs, arch)
@@ -814,49 +991,51 @@ def action_build(args, config):
             results.extend(thread.results)
             if not args.quiet or not thread.results.global_result:
                 banner(f"Build thread {thread.name} output:")
-                print(thread.output.getvalue(), end='')
+                print(thread.output.getvalue(), end="")
 
-    banner('All architectures processed')
+    banner("All architectures processed")
 
     if len(results) > 1:
         print(results.summary())
 
-    if getattr(args, 'junit', False):
-        logging.info('Writing test results in %s', args.junit)
+    if getattr(args, "junit", False):
+        logging.info("Writing test results in %s", args.junit)
         results.junit(args.junit)
 
     if not results.global_result:
         return 2
     return 0
 
+
 def action_sign(args, config):
     """Action for 'sign' command."""
     for package in args.packages:
-        if package.endswith('.rpm'):
+        if package.endswith(".rpm"):
             banner(f"Signing RPM package {package} with GPG key")
             rpm = RPM(package, config)
             rpm.sign()
-        elif package.endswith('.tar'):
+        elif package.endswith(".tar"):
             banner(f"Signing OCI archive {package} with GPG key")
             container_archive = ContainerArchive(config, package)
             container_archive.sign()
     return 0
 
+
 def action_test(args, config):
     """Action for 'test' command."""
     staff, modules = staff_modules(config)
-    results = TestResults('test')
+    results = TestResults("test")
     # Test package on all project supported architectures
 
-    for arch in config.get('arch'):
+    for arch in config.get("arch"):
         for pkg in ProjectPackages.list(config, staff, modules, args.packages):
-
             # Skip package if format is not selected by user
             if args.formats and pkg.format not in args.formats:
                 logging.info(
                     "Skipping tests %s package %s due to restriction on "
                     "package formats",
-                    pkg.format, pkg.name
+                    pkg.format,
+                    pkg.name,
                 )
                 continue
 
@@ -869,18 +1048,16 @@ def action_test(args, config):
                 # specifically. When parsing succeeds, this test case is not
                 # reported in test results.
                 case = TestCase("load", pkg.name, _DEFAULT_VARIANT, arch, pkg.format)
-                logging.error("Unable to load %s package: %s",
-                    pkg.format, str(ex))
+                logging.error("Unable to load %s package: %s", pkg.format, str(ex))
                 results.add_failure(case, time.time() - now, err=str(ex))
                 continue  # skip current package
 
             if not pkg.supports_arch(arch):
                 logging.info(
-                    "Skipping test on architecture %s not supported by "
-                    "%s package %s",
+                    "Skipping test on architecture %s not supported by %s package %s",
                     arch,
                     pkg.format,
-                    pkg.name
+                    pkg.name,
                 )
                 continue
 
@@ -890,8 +1067,8 @@ def action_test(args, config):
             pkg_results = pkg_arch.test(noauto=args.noauto, noquit=args.noquit)
             results.extend(pkg_results)
 
-    if getattr(args, 'junit', False):
-        logging.info('Writing test results in %s', args.junit)
+    if getattr(args, "junit", False):
+        logging.info("Writing test results in %s", args.junit)
         results.junit(args.junit)
 
     if len(results) > 1:
@@ -903,15 +1080,16 @@ def action_test(args, config):
     banner("Test suite FAILED!")
     return 2
 
+
 def _validate_packages_on_arch(config, args, pkgs):
     """
     Run package validation on all configured architectures, either sequentially
     or in parallel threads.
     """
-    results = TestResults('validate')
+    results = TestResults("validate")
 
     if args.seq:
-        for arch in config.get('arch'):
+        for arch in config.get("arch"):
             message(f"Starting validate on architecture {arch}")
             results.extend(validate_pkgs(config, args, pkgs, arch))
         return results
@@ -921,7 +1099,7 @@ def _validate_packages_on_arch(config, args, pkgs):
 
     # Create parallel threads to validate packages on all project supported
     # architectures.
-    for arch in config.get('arch'):
+    for arch in config.get("arch"):
         threads.append(
             RiftThread(
                 validate_pkgs, f"validate-{arch}", args=(config, args, pkgs, arch)
@@ -939,7 +1117,7 @@ def _validate_packages_on_arch(config, args, pkgs):
         results.extend(thread.results)
         if not args.quiet or not thread.results.global_result:
             banner(f"Validate thread {thread.name} output:")
-            print(thread.output.getvalue(), end='')
+            print(thread.output.getvalue(), end="")
     return results
 
 
@@ -953,16 +1131,15 @@ def action_validate(args, config):
     staff, modules = staff_modules(config)
     pkgs = get_packages_to_build(config, staff, modules, args)
     logging.info(
-        "Ordered list of packages to validate: %s",
-        str([pkg.name for pkg in pkgs])
+        "Ordered list of packages to validate: %s", str([pkg.name for pkg in pkgs])
     )
 
     results = _validate_packages_on_arch(config, args, pkgs)
 
-    banner('All packages checked on all architectures')
+    banner("All packages checked on all architectures")
 
-    if getattr(args, 'junit', False):
-        logging.info('Writing test results in %s', args.junit)
+    if getattr(args, "junit", False):
+        logging.info("Writing test results in %s", args.junit)
         results.junit(args.junit)
 
     if len(results) > 1:
@@ -973,6 +1150,7 @@ def action_validate(args, config):
         return 0
     banner("Test suite FAILED!")
     return 2
+
 
 def action_validdiff(args, config):
     """Action for 'validdiff' command."""
@@ -989,8 +1167,8 @@ def action_validdiff(args, config):
 
     results = _validate_packages_on_arch(config, args, updated)
 
-    if getattr(args, 'junit', False):
-        logging.info('Writing test results in %s', args.junit)
+    if getattr(args, "junit", False):
+        logging.info("Writing test results in %s", args.junit)
         results.junit(args.junit)
 
     if len(results) > 1:
@@ -1005,10 +1183,11 @@ def action_validdiff(args, config):
 
     # Remove from working repository packages detected as removed in patch for
     # all architectures supported by the project.
-    for arch in config.get('arch'):
+    for arch in config.get("arch"):
         remove_packages(config, args, removed, arch)
 
     return rc
+
 
 def action_gitlab(args, config, staff, modules):
     """Review a patchset for GitLab (specfiles)"""
@@ -1017,12 +1196,13 @@ def action_gitlab(args, config, staff, modules):
     for f in parse_unidiff(args.patch):
         path = f.path
         names = path.split(os.path.sep)
-        if names[0] == config.get('packages_dir'):
+        if names[0] == config.get("packages_dir"):
             pkgs = ProjectPackages.get(names[1], config, staff, modules)
             for pkg in pkgs:
                 if os.path.abspath(path) == pkg.buildfile and not f.is_deleted_file:
                     pkg.load()
                     pkg.check()
+
 
 def action_gerrit(args, config, staff, modules):
     """Review a patchset for Gerrit (specfiles)"""
@@ -1033,7 +1213,7 @@ def action_gerrit(args, config, staff, modules):
     for patchedfile in parse_unidiff(args.patch):
         filepath = patchedfile.path
         names = filepath.split(os.path.sep)
-        if names[0] == config.get('packages_dir'):
+        if names[0] == config.get("packages_dir"):
             pkgs = ProjectPackages.get(names[1], config, staff, modules)
             for pkg in pkgs:
                 # Skip package if format is not selected by user
@@ -1041,27 +1221,34 @@ def action_gerrit(args, config, staff, modules):
                     logging.info(
                         "Skipping gerrit review on %s package %s due to "
                         "restriction on package formats",
-                        pkg.format, pkg.name
+                        pkg.format,
+                        pkg.name,
                     )
                     continue
-                if (filepath == os.path.relpath(pkg.buildfile) and
-                    not patchedfile.is_deleted_file):
+                if (
+                    filepath == os.path.relpath(pkg.buildfile)
+                    and not patchedfile.is_deleted_file
+                ):
                     pkg.load()
                     try:
                         pkg.analyze(review, pkg.dir)
                     except NotImplementedError:
-                        logging.info("Skipping package format %s which does "
-                                     "not support static analysis", pkg.format)
+                        logging.info(
+                            "Skipping package format %s which does "
+                            "not support static analysis",
+                            pkg.format,
+                        )
 
     # Push review
-    review.msg_header = 'rift static analysis'
+    review.msg_header = "rift static analysis"
     review.push(config, args.change, args.patchset)
+
 
 def action_sync(args, config):
     """Action for 'sync' command."""
     synchronized_sources = []
 
-    # If output is set in command line arguments, use it or use sync_output
+    # If output is set in command line arguments, use it or use sync_output
     # configuration parameter as default value.
     if args.output:
         output = args.output
@@ -1069,7 +1256,7 @@ def action_sync(args, config):
         retries = args.retries
         enable_log_file = args.log_file
     else:
-        output = config.get('sync_output')
+        output = config.get("sync_output")
         max_size = None
         retries = 0
         enable_log_file = False
@@ -1090,36 +1277,37 @@ def action_sync(args, config):
                 f"{output}, parent directory {os.path.dirname(output)} does "
                 "not exist."
             ) from exc
-    for arch in config.get('arch'):
-        for name, repo in config.get('repos', default={}, arch=arch).items():
+    for arch in config.get("arch"):
+        for name, repo in config.get("repos", default={}, arch=arch).items():
             if args.repositories and name not in args.repositories:
                 logging.info(
                     "%s: Skipping repository %s not selected by user",
-                    arch, name,
+                    arch,
+                    name,
                 )
                 continue
-            sync = repo.get('sync')
+            sync = repo.get("sync")
             if sync is None:
                 logging.warning(
-                        "%s: Skipping repository %s: no synchronization "
-                        "parameters found", arch, name
+                    "%s: Skipping repository %s: no synchronization parameters found",
+                    arch,
+                    name,
                 )
                 continue
             # Use repo URL as fallback source when source is not defined in
             # sync config.
-            if sync.get('source') is None:
+            if sync.get("source") is None:
                 logging.debug(
-                    "Using repository URL %s as synchronization source",
-                    repo.get('url')
+                    "Using repository URL %s as synchronization source", repo.get("url")
                 )
-                sync['source'] = repo.get('url')
-            synchronizer = RepoSyncFactory.get(config, name, output, sync,
-                max_size, retries, enable_log_file, arch
+                sync["source"] = repo.get("url")
+            synchronizer = RepoSyncFactory.get(
+                config, name, output, sync, max_size, retries, enable_log_file, arch
             )
             if synchronizer.source in synchronized_sources:
                 logging.debug(
                     "Skipping already synchronized source %s",
-                    synchronizer.source.geturl()
+                    synchronizer.source.geturl(),
                 )
                 continue
             synchronized_sources.append(synchronizer.source)
@@ -1128,6 +1316,7 @@ def action_sync(args, config):
                 f"{synchronizer.source.geturl()}"
             )
             synchronizer.run()
+
 
 def action_changelog(args, config):
     """Action for 'changelog' command."""
@@ -1138,13 +1327,13 @@ def action_changelog(args, config):
     pkgs = ProjectPackages.get(args.package, config, staff, modules)
     package_found = False
     for pkg in pkgs:
-
         # Skip package if format is not selected by user
         if args.formats and pkg.format not in args.formats:
             logging.info(
                 "Skipping changelog update on %s package %s due to restriction "
                 "on package formats",
-                pkg.format, pkg.name
+                pkg.format,
+                pkg.name,
             )
             continue
 
@@ -1155,15 +1344,17 @@ def action_changelog(args, config):
         except NotImplementedError:
             logging.info(
                 "Skipping package format %s which does not support changelog",
-                pkg.format
+                pkg.format,
             )
 
     if not package_found:
-        logging.error("Unable to find package %s with changelog to update",
-                      args.package)
+        logging.error(
+            "Unable to find package %s with changelog to update", args.package
+        )
         return 1
 
     return 0
+
 
 def action_graph(args, config, staff, modules):
     """Action for 'graph' command."""
@@ -1173,6 +1364,7 @@ def action_graph(args, config, staff, modules):
         args.with_external, get_packages_in_graph(args, config, staff, modules)
     )
     return 0
+
 
 def get_packages_in_graph(args, config, staff, modules):
     """
@@ -1195,18 +1387,18 @@ def get_packages_in_graph(args, config, staff, modules):
     # all packages are selected eventually).
     return args.packages
 
+
 def action_create_import(args, config):
     """Action for 'create', 'import' and 'reimport' commands."""
-    if args.command == 'create':
+    if args.command == "create":
         pkgname = args.name
-    elif args.command in ('import', 'reimport'):
+    elif args.command in ("import", "reimport"):
         rpm = RPM(args.file, config)
         if not rpm.is_source:
             raise RiftError(f"{args.file} is not a source RPM")
         pkgname = rpm.name
     else:
-        raise RiftError(
-            f"Unsupported command {args.command} for action_create_import")
+        raise RiftError(f"Unsupported command {args.command} for action_create_import")
 
     if args.maintainer is None:
         raise RiftError("You must specify a maintainer")
@@ -1214,7 +1406,7 @@ def action_create_import(args, config):
     pkgs = ProjectPackages.get(pkgname, config, *staff_modules(config))
 
     for pkg in pkgs:
-        if args.command == 'reimport':
+        if args.command == "reimport":
             pkg.load()
 
         if args.module:
@@ -1228,52 +1420,72 @@ def action_create_import(args, config):
 
         pkg.check_info()
 
-        if args.command in ('create', 'import'):
+        if args.command in ("create", "import"):
             # Write package metadata file only with create and import commands.
             # Do not overwrite the file with reimport because it may discard
             # metadata for other formats.
             pkg.write()
             message(f"Package '{pkg.name}' has been created")
 
-        if args.command in ('import', 'reimport'):
+        if args.command in ("import", "reimport"):
             rpm.extract_srpm(pkg.dir, pkg.sourcesdir)
             message(f"Package '{pkg.name}' has been {args.command}ed")
 
     return 0
 
+
 def action_query(args, config):
     """Action for 'query' command."""
     staff, modules = staff_modules(config)
-    pkglist = sorted(ProjectPackages.list(config, staff, modules, args.packages),
-                        key=attrgetter('name'))
+    pkglist = sorted(
+        ProjectPackages.list(config, staff, modules, args.packages),
+        key=attrgetter("name"),
+    )
 
     tbl = TextTable()
-    tbl.fmt = args.fmt or '%name %module %maintainers %format %version '\
-                            '%release %modulemanager'
+    tbl.fmt = (
+        args.fmt
+        or "%name %module %maintainers %format %version %release %modulemanager"
+    )
     tbl.show_header = args.headers
     tbl.color = True
 
-    supported_keys = set(('name', 'module', 'origin', 'reason', 'format',
-                            'tests', 'version', 'arch', 'release',
-                            'changelogname', 'changelogtime', 'maintainers',
-                            'modulemanager', 'buildrequires'))
+    supported_keys = set(
+        (
+            "name",
+            "module",
+            "origin",
+            "reason",
+            "format",
+            "tests",
+            "version",
+            "arch",
+            "release",
+            "changelogname",
+            "changelogtime",
+            "maintainers",
+            "modulemanager",
+            "buildrequires",
+        )
+    )
     diff_keys = set(tbl.pattern_fields()) - supported_keys
     if diff_keys:
-        raise RiftError(f"Unknown placeholder(s): {', '.join(diff_keys)} "
-                        f"(supported keys are: {', '.join(supported_keys)})")
+        raise RiftError(
+            f"Unknown placeholder(s): {', '.join(diff_keys)} "
+            f"(supported keys are: {', '.join(supported_keys)})"
+        )
 
     for pkg in pkglist:
-
         # Skip package if format is not selected by user
         if args.formats and pkg.format not in args.formats:
             logging.info(
-                "Skipping query %s package %s due to restriction on "
-                "package formats",
-                pkg.format, pkg.name
+                "Skipping query %s package %s due to restriction on package formats",
+                pkg.format,
+                pkg.name,
             )
             continue
 
-        logging.debug('Loading package %s', pkg.name)
+        logging.debug("Loading package %s", pkg.name)
         try:
             pkg.load()
         except RiftError as exp:
@@ -1285,24 +1497,29 @@ def action_query(args, config):
             date = str(time.strftime("%Y-%m-%d", time.localtime(pkg.changelog_time)))
         else:
             date = None
-        modulemanager = staff.get(modules.get(pkg.module).get('manager')[0])
-        tbl.append({'name': pkg.name,
-                    'module': pkg.module,
-                    'origin': pkg.origin,
-                    'reason': pkg.reason,
-                    'format': pkg.format,
-                    'tests': str(len(list(pkg.tests()))),
-                    'version': pkg.version,
-                    'arch': pkg.arch,
-                    'release': pkg.release,
-                    'changelogname': pkg.changelog_name,
-                    'changelogtime': date,
-                    'buildrequires': pkg.buildrequires,
-                    'modulemanager': modulemanager['email'],
-                    'maintainers': ', '.join(pkg.maintainers)})
+        modulemanager = staff.get(modules.get(pkg.module).get("manager")[0])
+        tbl.append(
+            {
+                "name": pkg.name,
+                "module": pkg.module,
+                "origin": pkg.origin,
+                "reason": pkg.reason,
+                "format": pkg.format,
+                "tests": str(len(list(pkg.tests()))),
+                "version": pkg.version,
+                "arch": pkg.arch,
+                "release": pkg.release,
+                "changelogname": pkg.changelog_name,
+                "changelogtime": date,
+                "buildrequires": pkg.buildrequires,
+                "modulemanager": modulemanager["email"],
+                "maintainers": ", ".join(pkg.maintainers),
+            }
+        )
     print(tbl)
 
     return 0
+
 
 def get_packages_to_build(config, staff, modules, args):
     """
@@ -1312,7 +1529,7 @@ def get_packages_to_build(config, staff, modules, args):
     graph of all packages in the project to determine the list of packages that
     reverse depends on the list of packages in arguments, recursively.
     """
-    if not config.get('dependency_tracking') or args.skip_deps:
+    if not config.get("dependency_tracking") or args.skip_deps:
         return list(ProjectPackages.list(config, staff, modules, args.packages))
 
     # Build dependency graph with all projects packages.
@@ -1338,7 +1555,7 @@ def get_packages_to_build(config, staff, modules, args):
                 continue
             # Search the position in result before all its own reverse
             # dependencies.
-            position = result_position(required_builds[index+1:])
+            position = result_position(required_builds[index + 1 :])
             logging.info(
                 "Package %s:%s must be built: %s",
                 required_build.package.format,
@@ -1353,91 +1570,93 @@ def get_packages_to_build(config, staff, modules, args):
                 result.insert(position, required_build.package)
     return result
 
+
 def staff_modules(config):
     """
     Return tuple with staff and modules objects.
     """
     staff = Staff(config)
-    staff.load(config.get('staff_file'))
+    staff.load(config.get("staff_file"))
 
     modules = Modules(config, staff)
-    modules.load(config.get('modules_file'))
+    modules.load(config.get("modules_file"))
 
     return staff, modules
+
 
 def action(config, args):
     """
     Manage rift actions on annex, vm, packages or repositories
     """
 
-    if getattr(args, 'file', None) is not None:
+    if getattr(args, "file", None) is not None:
         args.file = os.path.abspath(args.file)
 
     # CHECK
-    if args.command == 'check':
+    if args.command == "check":
         action_check(args, config)
         return 0
 
     # ANNEX
-    if args.command == 'annex':
+    if args.command == "annex":
         action_annex(args, config, *staff_modules(config))
         return 0
 
     # AUTH
-    if args.command == 'auth':
+    if args.command == "auth":
         action_auth(config)
         return 0
 
     # VM
-    if args.command == 'vm':
+    if args.command == "vm":
         return action_vm(args, config)
 
     # CREATE/IMPORT/REIMPORT
-    if args.command in ['create', 'import', 'reimport']:
+    if args.command in ["create", "import", "reimport"]:
         return action_create_import(args, config)
 
     # BUILD
-    if args.command == 'build':
+    if args.command == "build":
         return action_build(args, config)
 
     # SIGN
-    if args.command == 'sign':
+    if args.command == "sign":
         return action_sign(args, config)
 
     # TEST
-    if args.command == 'test':
+    if args.command == "test":
         return action_test(args, config)
 
     # VALIDATE
-    if args.command == 'validate':
+    if args.command == "validate":
         return action_validate(args, config)
 
     # VALIDDIFF
-    if args.command == 'validdiff':
+    if args.command == "validdiff":
         return action_validdiff(args, config)
 
     # QUERY
-    if args.command == 'query':
+    if args.command == "query":
         return action_query(args, config)
 
     # CHANGELOG
-    if args.command == 'changelog':
+    if args.command == "changelog":
         return action_changelog(args, config)
 
     # GITLAB
-    if args.command == 'gitlab':
+    if args.command == "gitlab":
         return action_gitlab(args, config, *staff_modules(config))
 
     # GERRIT
-    if args.command == 'gerrit':
+    if args.command == "gerrit":
         return action_gerrit(args, config, *staff_modules(config))
 
     # SYNC
-    if args.command == 'sync':
+    if args.command == "sync":
         return action_sync(args, config)
 
     # GRAPH
-    if args.command == 'graph':
+    if args.command == "graph":
         return action_graph(args, config, *staff_modules(config))
 
     return 0
@@ -1449,15 +1668,16 @@ def main(args=None):
     # Parse options
     args = make_parser().parse_args(args)
 
-    logging.basicConfig(format="%(levelname)-8s %(message)s",
-                        level=logging.WARNING - args.verbose * 10)
+    logging.basicConfig(
+        format="%(levelname)-8s %(message)s", level=logging.WARNING - args.verbose * 10
+    )
 
     try:
         # Load configuration
         config = Config()
         config.load()
-        if hasattr(args, 'maintainer'):
-            args.maintainer = args.maintainer or config.get('maintainer')
+        if hasattr(args, "maintainer"):
+            args.maintainer = args.maintainer or config.get("maintainer")
 
         # Do the job
         return action(config, args)
@@ -1468,7 +1688,7 @@ def main(args=None):
         logging.error(str(exp))
         return 1
     except KeyboardInterrupt:
-        message('Keyboard interrupt. Exiting...')
+        message("Keyboard interrupt. Exiting...")
         return 1
 
     return 0

--- a/lib/rift/Gerrit.py
+++ b/lib/rift/Gerrit.py
@@ -36,21 +36,24 @@ Helper to push REST review to Gerrit Code Reviewer server.
 
 import json
 import logging
+
 try:
     import urllib2 as urllib
 except ImportError:
     import urllib.request as urllib
 
 import ssl
+
 from rift import RiftError
 
-class Review():
+
+class Review:
     """Gerrit review."""
 
     def __init__(self):
-        self.labels = {'W': 'warning', 'E': 'error'}
-        self.stats = {'E': 0}
-        self.msg_header = 'Rift review'
+        self.labels = {"W": "warning", "E": "error"}
+        self.stats = {"E": 0}
+        self.msg_header = "Rift review"
         self.comments = {}
         self.validated = True
 
@@ -61,15 +64,14 @@ class Review():
 
         msg = f"({self.labels[label]}) {message}"
         comment = {
-            'message': msg,
+            "message": msg,
         }
         if line is not None:
-            comment['line'] = line
+            comment["line"] = line
         self.comments.setdefault(filepath, []).append(comment)
 
     def _message(self):
-        stats = ((cnt, self.labels[code])
-                 for code, cnt in list(self.stats.items()))
+        stats = ((cnt, self.labels[code]) for code, cnt in list(self.stats.items()))
         msg = ", ".join(f"{cnt} {label}(s)" for cnt, label in stats)
         return f"{self.msg_header}: {msg}"
 
@@ -79,44 +81,46 @@ class Review():
 
     def push(self, config, changeid, revid):
         """Send REST request to Gerrit server from config"""
-        auth_methods = ('digest', 'basic')
+        auth_methods = ("digest", "basic")
 
-        gerrit_config = config.get('gerrit')
+        gerrit_config = config.get("gerrit")
         if gerrit_config is None:
             raise RiftError("Gerrit configuration is not defined")
 
-        realm = gerrit_config.get('realm')
-        server = gerrit_config.get('server')
-        username = gerrit_config.get('username')
-        password = gerrit_config.get('password')
-        auth_method = gerrit_config.get('auth_method', 'basic')
+        realm = gerrit_config.get("realm")
+        server = gerrit_config.get("server")
+        username = gerrit_config.get("username")
+        password = gerrit_config.get("password")
+        auth_method = gerrit_config.get("auth_method", "basic")
 
         if realm is None:
             raise RiftError("Gerrit realm is not defined")
-        if server is None and gerrit_config.get('url') is None:
+        if server is None and gerrit_config.get("url") is None:
             raise RiftError("Gerrit url is not defined")
         if username is None:
             raise RiftError("Gerrit username is not defined")
         if password is None:
             raise RiftError("Gerrit password is not defined")
         if auth_method not in auth_methods:
-            raise RiftError(f"Gerrit auth_method is not correct (supported {auth_methods})")
+            raise RiftError(
+                f"Gerrit auth_method is not correct (supported {auth_methods})"
+            )
 
         # Set a default url if only gerrit_server was defined
-        url = gerrit_config.get('url', f"https://{server}")
+        url = gerrit_config.get("url", f"https://{server}")
 
         # FIXME: Don't check certificate
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        #https_sslv3_handler = urllib.HTTPSHandler(context=ssl.SSLContext(ssl.PROTOCOL_SSLv3))
+        # https_sslv3_handler = urllib.HTTPSHandler(context=ssl.SSLContext(ssl.PROTOCOL_SSLv3))
         https_sslv3_handler = urllib.HTTPSHandler(context=ctx)
 
         api_url = f"{url}/gerrit/a/changes/{changeid}/revisions/{revid}/review"
-        if auth_method == 'digest':
+        if auth_method == "digest":
             authhandler = urllib.HTTPDigestAuthHandler()
             authhandler.add_password(realm, server, username, password)
-        elif auth_method == 'basic':
+        elif auth_method == "basic":
             pw_mgr = urllib.HTTPPasswordMgrWithDefaultRealm()
             # this creates a password manager
             pw_mgr.add_password(None, url, username, password)
@@ -132,14 +136,14 @@ class Review():
             "comments": self.comments,
         }
         if self.validated:
-            request['labels'] = {"Code-Review": '+1'}
+            request["labels"] = {"Code-Review": "+1"}
         data = json.dumps(request, indent=2)
-
 
         logging.debug("Sending review request to %s", api_url)
         logging.debug("Request content: %s", data)
 
-        req = urllib.Request(api_url, data.encode("utf8"),
-                             {'Content-Type': 'application/json'})
-        req.get_method = lambda: 'POST'
+        req = urllib.Request(
+            api_url, data.encode("utf8"), {"Content-Type": "application/json"}
+        )
+        req.get_method = lambda: "POST"
         urllib.urlopen(req).read()

--- a/lib/rift/Gerrit.py
+++ b/lib/rift/Gerrit.py
@@ -113,7 +113,9 @@ class Review:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        # https_sslv3_handler = urllib.HTTPSHandler(context=ssl.SSLContext(ssl.PROTOCOL_SSLv3))
+        # https_sslv3_handler = urllib.HTTPSHandler(
+        #     context=ssl.SSLContext(ssl.PROTOCOL_SSLv3)
+        # )
         https_sslv3_handler = urllib.HTTPSHandler(context=ctx)
 
         api_url = f"{url}/gerrit/a/changes/{changeid}/revisions/{revid}/review"

--- a/lib/rift/Mock.py
+++ b/lib/rift/Mock.py
@@ -35,31 +35,32 @@ Contains helper class to work with 'mock' tool, used to build RPMS in a chroot
 environment.
 """
 
-import os
-import shutil
-import glob
 import getpass
+import glob
 import logging
+import os
+import shlex
+import shutil
 import threading
 from contextlib import contextmanager
-import shlex
 from textwrap import dedent
+
 from jinja2 import Template
 
 from rift import RiftError
-from rift.TempDir import TempDir
-from rift.RPM import RPM
-from rift.run import run_command
 from rift.Config import _DEFAULT_VARIANT
 from rift.proxy import AuthenticatedRepositoryProxyRuntime
+from rift.RPM import RPM
+from rift.run import run_command
+from rift.TempDir import TempDir
 
 # Global dictionary of re-entrant locks for each mock name.
 _mock_chroot_locks = {}
 # Mutex to serialize access to _mock_chroot_locks dictionary.
 _mock_chroot_global_mutex = threading.Lock()
 
-RPMLINT_CONFIG_V1 = 'rpmlint'
-RPMLINT_CONFIG_V2 = 'rpmlint.toml'
+RPMLINT_CONFIG_V1 = "rpmlint"
+RPMLINT_CONFIG_V2 = "rpmlint.toml"
 
 
 def rpmlint_env(configdir=None):
@@ -71,7 +72,7 @@ def rpmlint_env(configdir=None):
     if not configdir:
         return None
     env = os.environ.copy()
-    env['XDG_CONFIG_HOME'] = os.path.realpath(configdir)
+    env["XDG_CONFIG_HOME"] = os.path.realpath(configdir)
     return env
 
 
@@ -103,16 +104,16 @@ def rpmlint_chroot_script(spec_filepath):
     """).strip()
 
 
-class Mock():
+class Mock:
     """
     Interact with 'mock' command, manage its config files and created RPMS.
     """
 
-    MOCK_DIR = '/etc/mock'
-    MOCK_TEMPLATE = 'mock.tpl'
-    MOCK_DEFAULT = 'default.cfg'
-    MOCK_FILES = ['logging.ini', 'site-defaults.cfg']
-    MOCK_RESULT = '/var/lib/mock/%s/result'
+    MOCK_DIR = "/etc/mock"
+    MOCK_TEMPLATE = "mock.tpl"
+    MOCK_DEFAULT = "default.cfg"
+    MOCK_FILES = ["logging.ini", "site-defaults.cfg"]
+    MOCK_RESULT = "/var/lib/mock/%s/result"
 
     def __init__(self, config, arch, proj_vers=None):
         self._config = config
@@ -143,8 +144,8 @@ class Mock():
             _lock.release()
 
     def _build_template_ctx(self, repolist):
-        """ Create a context to build mock template """
-        context = {'name': self._mockname, 'arch': self._arch, 'repos': []}
+        """Create a context to build mock template"""
+        context = {"name": self._mockname, "arch": self._arch, "repos": []}
         # Populate with repolist
         prio = 1000
         for idx, repo in enumerate(repolist, start=1):
@@ -154,30 +155,29 @@ class Mock():
             if self._repo_proxy and repo.authenticated():
                 repo_url = self._repo_proxy.repo_url(repo, "127.0.0.1")
             repo_ctx = {
-                'name': repo.name or f"repo{idx}",
-                'priority': prio,
-                'url': repo_url,
-                'variants': repo.variants,
-                'authenticated': repo.authenticated(),
-                }
+                "name": repo.name or f"repo{idx}",
+                "priority": prio,
+                "url": repo_url,
+                "variants": repo.variants,
+                "authenticated": repo.authenticated(),
+            }
             if repo.module_hotfixes:
-                repo_ctx['module_hotfixes'] = repo.module_hotfixes
+                repo_ctx["module_hotfixes"] = repo.module_hotfixes
             if repo.excludepkgs:
-                repo_ctx['excludepkgs'] = repo.excludepkgs
+                repo_ctx["excludepkgs"] = repo.excludepkgs
             if repo.proxy:
-                repo_ctx['proxy'] = repo.proxy
-            context['repos'].append(repo_ctx)
+                repo_ctx["proxy"] = repo.proxy
+            context["repos"].append(repo_ctx)
         return context
-
 
     def _create_template(self, repolist, dstpath):
         """Create 'default.cfg' config file based on a template."""
         # Read template
         tplfile = self._config.project_path(self.MOCK_TEMPLATE)
-        with open(tplfile, encoding='utf-8') as fh:
+        with open(tplfile, encoding="utf-8") as fh:
             tpl = Template(fh.read())
         # Write file content
-        with open(dstpath, 'w', encoding='utf-8') as fmock:
+        with open(dstpath, "w", encoding="utf-8") as fmock:
             fmock.write(tpl.render(self._build_template_ctx(repolist)))
         # We have to keep template timestamp to avoid being detected as a new
         # one each time.
@@ -197,7 +197,7 @@ class Mock():
         if repolist is None:
             repolist = []
 
-        self._tmpdir = TempDir('mock')
+        self._tmpdir = TempDir("mock")
         self._tmpdir.create()
         dstpath = os.path.join(self._tmpdir.path, self.MOCK_DEFAULT)
         self._create_template(repolist, dstpath)
@@ -212,14 +212,15 @@ class Mock():
                     f"Repository {repo.path} does not exist, unable to "
                     "initialize Mock environment"
                 )
+
     def _build_macro_args(self):
-        """ Return mock argument to define rpm_macros file """
-        rpm_macros = self._config.get('rpm_macros', {})
+        """Return mock argument to define rpm_macros file"""
+        rpm_macros = self._config.get("rpm_macros", {})
         if not rpm_macros:
             return []
         # Generate rpm.macro file
-        macropath = os.path.join(self._tmpdir.path, 'rpm.macro')
-        with open(macropath, 'w', encoding='utf-8') as fmacro:
+        macropath = os.path.join(self._tmpdir.path, "rpm.macro")
+        with open(macropath, "w", encoding="utf-8") as fmacro:
             for key, value in rpm_macros.items():
                 logging.debug("> adding macro %s=%s", key, value)
                 fmacro.write(f"%{key} {value}\n")
@@ -227,17 +228,17 @@ class Mock():
 
     def _mock_base(self):
         """Return base argument to launch mock"""
-        args = [f'--configdir={self._tmpdir.path}'] + self._build_macro_args()
+        args = [f"--configdir={self._tmpdir.path}"] + self._build_macro_args()
         logging.debug("> adding mock arguments %s", args)
         # Force mock to print build commands output with print_main_output=yes,
         # no matter if stdout/stderr is a TTY. It is required to capture this
         # output and have the possibility to report it junit files in case of
         # failure, in all execution environments.
         return [
-            'mock',
-            '--config-opts',
-            'print_main_output=yes',
-            f"--configdir={self._tmpdir.path}"
+            "mock",
+            "--config-opts",
+            "print_main_output=yes",
+            f"--configdir={self._tmpdir.path}",
         ] + self._build_macro_args()
 
     def _exec(self, cmd, merge_out_err=True):
@@ -246,13 +247,13 @@ class Mock():
         RiftError with its output in case of error.
         """
         cmd = self._mock_base() + cmd
-        logging.debug('Running mock: %s', ' '.join(cmd))
+        logging.debug("Running mock: %s", " ".join(cmd))
         proc = run_command(
             cmd,
             live_output=logging.getLogger().isEnabledFor(logging.INFO),
             capture_output=True,
             merge_out_err=merge_out_err,
-            cwd='/'
+            cwd="/",
         )
         if proc.returncode != 0:
             raise RiftError(proc.out if merge_out_err else proc.err)
@@ -268,13 +269,13 @@ class Mock():
         self._repo_proxy = AuthenticatedRepositoryProxyRuntime(self._config, repolist)
         self._repo_proxy.start()
         self._init_tmp_conf(repolist)
-        self._exec(['--init'])
+        self._exec(["--init"])
 
     def _bind_mount_dirs_opt(self, paths):
         """Return mock bind_mount plugin option for dirs (host path = chroot path)."""
         unique = sorted({os.path.realpath(p) for p in paths})
         pairs = ",".join(f"('{p}', '{p}')" for p in unique)
-        return f'--plugin-option=bind_mount:dirs=[{pairs}]'
+        return f"--plugin-option=bind_mount:dirs=[{pairs}]"
 
     def read_spec(self, filepath):
         """
@@ -286,12 +287,12 @@ class Mock():
         proc = self._exec(
             [
                 self._bind_mount_dirs_opt([filepath_rp]),
-                'chroot',
-                'rpmspec',
-                '--parse',
-                filepath_rp
+                "chroot",
+                "rpmspec",
+                "--parse",
+                filepath_rp,
             ],
-            merge_out_err=False
+            merge_out_err=False,
         )
 
         lines = []
@@ -329,14 +330,14 @@ class Mock():
         # Install rpmlint and kernel-devel in the chroot (removed by --clean).
         self._exec(
             [
-                '--no-clean',
-                '--no-cleanup-after',
-                '--quiet',
-                '--pm-cmd',
-                'install',
-                '-y',
-                'rpmlint',
-                'kernel-devel',
+                "--no-clean",
+                "--no-cleanup-after",
+                "--quiet",
+                "--pm-cmd",
+                "install",
+                "-y",
+                "rpmlint",
+                "kernel-devel",
             ]
         )
 
@@ -344,27 +345,27 @@ class Mock():
         # because callers need return code and output of rpmlint command.
         cmd = self._mock_base() + [
             bind_opt,
-            '--quiet',
-            'chroot',
-            '--',
-            'bash',
-            '-c',
+            "--quiet",
+            "chroot",
+            "--",
+            "bash",
+            "-c",
             rpmlint_chroot_script(spec_fp),
         ]
-        logging.debug('Running mock rpmlint chroot: %s', ' '.join(cmd[:8]))
+        logging.debug("Running mock rpmlint chroot: %s", " ".join(cmd[:8]))
         try:
             return run_command(
                 cmd,
                 capture_output=True,
                 merge_out_err=False,
-                cwd='/',
+                cwd="/",
                 env=rpmlint_env(configdir),
             )
         finally:
             # Clean the chroot to remove rpmlint, kernel-devel, and deps.
-            self._exec(['--quiet', '--clean'])
+            self._exec(["--quiet", "--clean"])
 
-    def resultrpms(self, pattern='*.rpm', sources=True):
+    def resultrpms(self, pattern="*.rpm", sources=True):
         """
         Iterate over built RPMS matching `pattern' in mock result directory.
         """
@@ -389,7 +390,7 @@ class Mock():
         """Remove Mock environments (ie. chroots directories) from disk."""
         with self.lock():
             self._init_tmp_conf()
-            self._exec(['--scrub=all'])
+            self._exec(["--scrub=all"])
 
     def _stop_repo_proxy(self):
         """Stop repository proxy runtime if currently active."""
@@ -404,11 +405,11 @@ class Mock():
         """
         specpath = os.path.realpath(specpath)
         sourcedir = os.path.realpath(sourcedir)
-        cmd = ['--buildsrpm']
-        cmd += ['--no-clean', '--no-cleanup-after']
-        cmd += ['--spec', specpath, '--source', sourcedir]
+        cmd = ["--buildsrpm"]
+        cmd += ["--no-clean", "--no-cleanup-after"]
+        cmd += ["--spec", specpath, "--source", sourcedir]
         self._exec(cmd)
-        package = list(self.resultrpms('*.src.rpm'))[0]
+        package = list(self.resultrpms("*.src.rpm"))[0]
         # Sign source package
         if sign:
             package.sign()
@@ -417,16 +418,16 @@ class Mock():
 
     def build_rpms(self, srpm, variant, repos, sign):
         """Build binary RPMS using the provided Source RPM pointed by `srpm'"""
-        cmd = ['--no-clean', '--no-cleanup-after']
+        cmd = ["--no-clean", "--no-cleanup-after"]
 
         cmd += [srpm.filepath]
         if variant != _DEFAULT_VARIANT:
-            cmd += ['--with', variant]
+            cmd += ["--with", variant]
             for repo in repos.for_variant(variant):
-                cmd += ['--enablerepo', repo.name]
+                cmd += ["--enablerepo", repo.name]
         self._exec(cmd)
 
-        packages = list(self.resultrpms('*.rpm', sources=False))
+        packages = list(self.resultrpms("*.rpm", sources=False))
         # Sign all built binary packages
         if sign:
             for package in packages:

--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -34,28 +34,27 @@
 Helper classes to manipulate RPM files and SPEC files.
 """
 
+import datetime
+import itertools
+import locale
 import logging
 import os
 import re
 import shutil
-from subprocess import Popen, PIPE, STDOUT, run, CalledProcessError
-import time
-import itertools
-import datetime
-import locale
 import tempfile
+import time
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen, run
 
 import rpm
 
-
+import rift.utils
 from rift import RiftError
 from rift.annex import Annex, is_binary
 from rift.Config import _DEFAULT_VARIANT
-import rift.utils
 
 
 def _header_values(values):
-    """ Convert values from header specfile to strings """
+    """Convert values from header specfile to strings"""
     if isinstance(values, list):
         return [_header_values(val) for val in values]
     if isinstance(values, bytes):
@@ -63,7 +62,7 @@ def _header_values(values):
     return str(values)
 
 
-class RPM():
+class RPM:
     """Manipulate a source or binary RPM."""
 
     def __init__(self, filepath, config=None):
@@ -121,9 +120,9 @@ class RPM():
         srcdir = os.path.realpath(srcdir)
 
         # Extract (install) source file and spec file from source rpm
-        cmd = ['rpm', '-iv']
-        cmd += ['--define', f"_sourcedir {srcdir}"]
-        cmd += ['--define', f"_specdir {os.path.realpath(specdir)}"]
+        cmd = ["rpm", "-iv"]
+        cmd += ["--define", f"_sourcedir {srcdir}"]
+        cmd += ["--define", f"_specdir {os.path.realpath(specdir)}"]
         cmd += [self.filepath]
         with Popen(cmd, stdout=PIPE, stderr=STDOUT, universal_newlines=True) as popen:
             stdout = popen.communicate()[0]
@@ -147,14 +146,14 @@ class RPM():
         parameters are missing in project configuration or GPG key is not found.
         """
         # GPG parameters not defined in project config, raise RiftError.
-        if self._config is None or self._config.get('gpg') is None:
+        if self._config is None or self._config.get("gpg") is None:
             raise RiftError(
                 "Unable to retrieve GPG configuration, unable to sign package "
                 f"{self.filepath}",
             )
 
-        gpg = self._config.get('gpg')
-        keyring = os.path.expanduser(gpg.get('keyring'))
+        gpg = self._config.get("gpg")
+        keyring = os.path.expanduser(gpg.get("keyring"))
 
         # Check gpg_keyring path exists or raise error
         if not os.path.exists(keyring):
@@ -164,33 +163,32 @@ class RPM():
             )
 
         cmd = [
-            'rpmsign',
-            '--define',
+            "rpmsign",
+            "--define",
             f"%_gpg_name {gpg.get('key')}",
-            '--define',
+            "--define",
             f"%_gpg_path {keyring}",
-            '--addsign',
-            self.filepath
+            "--addsign",
+            self.filepath,
         ]
         # If passphrase is defined, add the passphrase to gpg sign command
         # parameters and make it non-interactive.
-        if gpg.get('passphrase') is not None:
+        if gpg.get("passphrase") is not None:
             cmd[6:6] = [
-                '--define',
+                "--define",
                 "%_gpg_sign_cmd_extra_args --batch "
-                f"--passphrase '{gpg.get('passphrase')}' --pinentry-mode loopback"
+                f"--passphrase '{gpg.get('passphrase')}' --pinentry-mode loopback",
             ]
         # Run rpmsign command and raise error in case of failure.
         try:
             run(cmd, check=True)
         except CalledProcessError as err:
             raise RiftError(
-                f"Error with signing package {self.filepath} command: "
-                f"{str(err)}"
+                f"Error with signing package {self.filepath} command: {str(err)}"
             ) from err
 
 
-class Spec():
+class Spec:
     """Access information from a Specfile and build SRPMS."""
 
     def __init__(self, filepath, mock, repos, config=None, variant=None):
@@ -221,7 +219,7 @@ class Spec():
 
     def _set_macros(self):
         """Set macros specified in configuration file"""
-        macros = self._config.get('rpm_macros', {})
+        macros = self._config.get("rpm_macros", {})
         for macro, value in macros.items():
             rpm.delMacro(macro)
             if value:
@@ -239,14 +237,13 @@ class Spec():
         for index, line in enumerate(self.lines):
             match = re.match(pattern, line)
             if match:
-                name = match.group('name')
-                value = match.group('value')
-                keyword = match.group('keyword')
+                name = match.group("name")
+                value = match.group("value")
+                keyword = match.group("keyword")
                 if name and value:
-                    self.variables[name] = Variable(index=index,
-                                                    name=name,
-                                                    value=value,
-                                                    keyword=keyword)
+                    self.variables[name] = Variable(
+                        index=index, name=name, value=value, keyword=keyword
+                    )
 
     def load(self):
         """Extract interesting information from spec file."""
@@ -259,7 +256,7 @@ class Spec():
                 self.mock.init(self.repos)
                 content = self.mock.read_spec(self.filepath)
                 self.mock.clean()
-            with tempfile.NamedTemporaryFile(mode='w+') as fp:
+            with tempfile.NamedTemporaryFile(mode="w+") as fp:
                 fp.write(content)
                 fp.seek(0)
                 rpm.reloadConfig()
@@ -274,41 +271,39 @@ class Spec():
                 # https://github.com/rpm-software-management/rpm/issues/1821,
                 # restore timezone after it has been changed to parse changelog.
                 # Note this is fixed in RPM >= 4.19.
-                os.environ['TZ'] = str(current_timezone)
+                os.environ["TZ"] = str(current_timezone)
                 time.tzset()
         except ValueError as exp:
             raise RiftError(f"{self.filepath}: {str(exp).strip()}") from exp
-        self.pkgnames = [_header_values(pkg.header['name']) for pkg in spec.packages]
+        self.pkgnames = [_header_values(pkg.header["name"]) for pkg in spec.packages]
         # Global unique list of provides. Here dict.fromkeys() is used to remove
         # duplicates as an alternative to set() for the sake of preserving order.
-        self.provides = list(dict.fromkeys(
-            itertools.chain(
-                *[_header_values(pkg.header['provides'])
-                  for pkg in spec.packages])))
+        self.provides = list(
+            dict.fromkeys(
+                itertools.chain(
+                    *[_header_values(pkg.header["provides"]) for pkg in spec.packages]
+                )
+            )
+        )
         hdr = spec.sourceHeader
-        self.srpmname = hdr.sprintf('%{NAME}-%{VERSION}-%{RELEASE}.src.rpm')
-        self.basename = hdr.sprintf('%{NAME}')
-        self.version = hdr.sprintf('%{VERSION}')
-        self.arch = hdr.sprintf('%{ARCH}')
+        self.srpmname = hdr.sprintf("%{NAME}-%{VERSION}-%{RELEASE}.src.rpm")
+        self.basename = hdr.sprintf("%{NAME}")
+        self.version = hdr.sprintf("%{VERSION}")
+        self.arch = hdr.sprintf("%{ARCH}")
         self.exclusive_archs = _header_values(hdr[rpm.RPMTAG_EXCLUSIVEARCH])
         if hdr[rpm.RPMTAG_CHANGELOGNAME]:
-            self.changelog_name = _header_values(
-                hdr[rpm.RPMTAG_CHANGELOGNAME][0])
+            self.changelog_name = _header_values(hdr[rpm.RPMTAG_CHANGELOGNAME][0])
         if hdr[rpm.RPMTAG_CHANGELOGTIME]:
-            self.changelog_time = int(_header_values(
-                hdr[rpm.RPMTAG_CHANGELOGTIME][0]))
-        self.sources.extend(_header_values(
-            hdr[rpm.RPMTAG_SOURCE]))
-        self.sources.extend(_header_values(
-            hdr[rpm.RPMTAG_PATCH]))
-        self.buildrequires = ' '.join(_header_values(
-            hdr[rpm.RPMTAG_REQUIRENEVRS]))
-        self.release = hdr.sprintf('%{RELEASE}')
-        self.epoch = hdr.sprintf('%|epoch?{%{epoch}:}:{}|')
-        self.dist = rpm.expandMacro('%dist')
+            self.changelog_time = int(_header_values(hdr[rpm.RPMTAG_CHANGELOGTIME][0]))
+        self.sources.extend(_header_values(hdr[rpm.RPMTAG_SOURCE]))
+        self.sources.extend(_header_values(hdr[rpm.RPMTAG_PATCH]))
+        self.buildrequires = " ".join(_header_values(hdr[rpm.RPMTAG_REQUIRENEVRS]))
+        self.release = hdr.sprintf("%{RELEASE}")
+        self.epoch = hdr.sprintf("%|epoch?{%{epoch}:}:{}|")
+        self.dist = rpm.expandMacro("%dist")
         self.update_evr()
 
-        with open(self.filepath, 'r', encoding='utf-8') as fspec:
+        with open(self.filepath, "r", encoding="utf-8") as fspec:
             self.lines = fspec.readlines()
 
         self._parse_vars()
@@ -317,9 +312,7 @@ class Spec():
         """
         Update epoch:version-release
         """
-        self.evr = (
-            f"{self.epoch}{self.version}-{rift.utils.removesuffix(self.release, self.dist)}"
-        )
+        self.evr = f"{self.epoch}{self.version}-{rift.utils.removesuffix(self.release, self.dist)}"
 
     def _inc_release(self, release):
         dist = self.dist
@@ -329,29 +322,27 @@ class Spec():
         if release.endswith(self.dist):
             pattern += f"({dist})"
         elif dist_match:
-            dist = dist_match.group('dist')
-            pattern += "(" + dist.replace('?', r'\?') + ")"
+            dist = dist_match.group("dist")
+            pattern += "(" + dist.replace("?", r"\?") + ")"
         else:
-            dist = ''
-        pattern += '$'
+            dist = ""
+        pattern += "$"
         release_id = re.match(pattern, release)
         if release_id is None:
             raise RiftError(f"Cannot parse package release: {release}")
-        newrelease = int(release_id.group('num')) + 1
-        logging.debug("New release from %s to %s", release_id.group('num'),
-                      newrelease)
-        baserelease = release_id.group('baserelease')
+        newrelease = int(release_id.group("num")) + 1
+        logging.debug("New release from %s to %s", release_id.group("num"), newrelease)
+        baserelease = release_id.group("baserelease")
         return f"{baserelease}{newrelease}{dist}"
 
-
-    def _match_var(self, expression, pattern='.*[0-9]$'):
-        """ Get variable with value matching pattern in expression """
-        match = re.match(r'(?P<leftbehind>.*)%{?\??(?P<varname>[^}]*)}?', expression)
+    def _match_var(self, expression, pattern=".*[0-9]$"):
+        """Get variable with value matching pattern in expression"""
+        match = re.match(r"(?P<leftbehind>.*)%{?\??(?P<varname>[^}]*)}?", expression)
         if match:
-            name = match.group('varname')
-            left = match.group('leftbehind')
+            name = match.group("varname")
+            left = match.group("leftbehind")
             if name:
-                logging.debug('Spec._match_var: found %s', name)
+                logging.debug("Spec._match_var: found %s", name)
                 try:
                     if re.match(pattern, str(self.variables[name])):
                         return self.variables[name]
@@ -373,7 +364,6 @@ class Spec():
         self.release = self._inc_release(self.release)
         self.update_evr()
 
-
     def add_changelog_entry(self, userstring, comment, bump=False):
         """
         Add a new entry to changelog.
@@ -387,7 +377,7 @@ class Spec():
         # Temporarily set basic C locale to generate date representation in
         # changelog.
         current_locale = locale.getlocale(locale.LC_TIME)
-        locale.setlocale(locale.LC_TIME, 'C')
+        locale.setlocale(locale.LC_TIME, "C")
         date = time.strftime("%a %b %d %Y", time.gmtime())
         # Immediately restore previous locale.
         locale.setlocale(locale.LC_TIME, current_locale)
@@ -396,10 +386,11 @@ class Spec():
         chlg_match = None
         for i, _ in enumerate(self.lines):
             if bump:
-                release_match = re.match(r'^[Rr]elease:(?P<spaces>\s+)(?P<release>.*$)',
-                                         self.lines[i])
+                release_match = re.match(
+                    r"^[Rr]elease:(?P<spaces>\s+)(?P<release>.*$)", self.lines[i]
+                )
                 if release_match:
-                    release_str = release_match.group('release')
+                    release_str = release_match.group("release")
                     # If Release field contains only variables, we may need to
                     # resolv and increment last variable:
                     # Release: %{something}%{?dist}
@@ -415,7 +406,7 @@ class Spec():
                             var.value = self._inc_release(var.value)
                             var.spec_output(self.lines)
 
-            chlg_match = re.match(r'^%changelog(\s|$)', self.lines[i])
+            chlg_match = re.match(r"^%changelog(\s|$)", self.lines[i])
             if chlg_match:
                 if len(self.lines) > i + 1 and self.lines[i + 1].strip() != "":
                     newchangelogentry += "\n"
@@ -428,7 +419,7 @@ class Spec():
             self.lines.append("%changelog\n")
             self.lines.append(newchangelogentry)
 
-        with open(self.filepath, 'w', encoding='utf-8') as fspec:
+        with open(self.filepath, "w", encoding="utf-8") as fspec:
             fspec.writelines(self.lines)
 
         # Reload
@@ -440,9 +431,9 @@ class Spec():
 
         Return a RPM instance of this source RPM.
         """
-        cmd = ['rpmbuild', '-bs']
-        cmd += ['--define', f"_sourcedir {srcdir}"]
-        cmd += ['--define', f"_srcrpmdir {destdir}"]
+        cmd = ["rpmbuild", "-bs"]
+        cmd += ["--define", f"_sourcedir {srcdir}"]
+        cmd += ["--define", f"_srcrpmdir {destdir}"]
         cmd += [self.filepath]
 
         with Popen(cmd, stdout=PIPE, stderr=STDOUT, universal_newlines=True) as popen:
@@ -466,7 +457,7 @@ class Spec():
 
             # Changelog section is mandatory
             if not (self.changelog_name or self.changelog_time):
-                raise RiftError('Proper changelog section is needed in specfile')
+                raise RiftError("Proper changelog section is needed in specfile")
 
             # Check if all sources are declared and present in package directory
             if pkg.sources - set(self.sources):
@@ -483,7 +474,7 @@ class Spec():
             finally:
                 self.mock.clean()
         if proc.returncode:
-            raise RiftError(proc.err or 'rpmlint reported errors')
+            raise RiftError(proc.err or "rpmlint reported errors")
 
     def analyze(self, review, configdir=None):
         """Run `rpmlint' for this specfile and fill provided `review'."""
@@ -496,18 +487,19 @@ class Spec():
         if proc.returncode not in (0, 64, 66):
             raise RiftError(proc.err or f"rpmlint returned {proc.returncode}")
 
-        stdout = proc.out or ''
+        stdout = proc.out or ""
         for line in stdout.splitlines():
-            if line.startswith(self.filepath + ':'):
-                line = line[len(self.filepath + ':'):]
+            if line.startswith(self.filepath + ":"):
+                line = line[len(self.filepath + ":") :]
                 try:
                     linenbr = None
-                    code, txt = line.split(':', 1)
+                    code, txt = line.split(":", 1)
                     if code.isdigit():
                         linenbr = int(code)
-                        code, txt = txt.split(':', 1)
-                    review.add_comment(self.filepath, linenbr,
-                                       code.strip(), txt.strip())
+                        code, txt = txt.split(":", 1)
+                    review.add_comment(
+                        self.filepath, linenbr, code.strip(), txt.strip()
+                    )
                 except (ValueError, KeyError):
                     pass
 
@@ -522,22 +514,22 @@ class Spec():
         return not self.exclusive_archs or arch in self.exclusive_archs
 
 
-class Variable():
-
+class Variable:
     """
-        This class represents specfile variables
-        Args:
-            index (int): Line where variable is defined in specfile
-            name: The variable name
-            value: The variable value
-            keyword: The keyword used to define the variable
+    This class represents specfile variables
+    Args:
+        index (int): Line where variable is defined in specfile
+        name: The variable name
+        value: The variable value
+        keyword: The keyword used to define the variable
 
-        Attributes:
-            index (int): Line where variable is defined in specfile
-            name: The variable name
-            value: The variable value
-            keyword: The keyword used to define the variable
+    Attributes:
+        index (int): Line where variable is defined in specfile
+        name: The variable name
+        value: The variable value
+        keyword: The keyword used to define the variable
     """
+
     def __init__(self, index, name, value, keyword):
         self.index = index
         self.name = name
@@ -549,15 +541,15 @@ class Variable():
 
     def spec_output(self, buffer=None):
         """
-            Return variable definition with specfile syntax.
-            Args:
-                buffer (list): Buffer containing specfile content
+        Return variable definition with specfile syntax.
+        Args:
+            buffer (list): Buffer containing specfile content
 
-            Raises:
-                IndexError: If buffer is not large enough
+        Raises:
+            IndexError: If buffer is not large enough
 
-            Returns:
-                define_str: String syntax to define the variable
+        Returns:
+            define_str: String syntax to define the variable
         """
         define_str = f"%{self.keyword} {self.name} {self.value}"
         if buffer:

--- a/lib/rift/RPM.py
+++ b/lib/rift/RPM.py
@@ -312,7 +312,10 @@ class Spec:
         """
         Update epoch:version-release
         """
-        self.evr = f"{self.epoch}{self.version}-{rift.utils.removesuffix(self.release, self.dist)}"
+        self.evr = (
+            f"{self.epoch}{self.version}-"
+            f"{rift.utils.removesuffix(self.release, self.dist)}"
+        )
 
     def _inc_release(self, release):
         dist = self.dist
@@ -461,10 +464,12 @@ class Spec:
 
             # Check if all sources are declared and present in package directory
             if pkg.sources - set(self.sources):
-                msg = f"Unused source file(s): {' '.join(pkg.sources - set(self.sources))}"
+                unused = pkg.sources - set(self.sources)
+                msg = f"Unused source file(s): {' '.join(unused)}"
                 raise RiftError(msg)
             if set(self.sources) - pkg.sources:
-                msg = f"Missing source file(s): {' '.join(set(self.sources) - pkg.sources)}"
+                missing = set(self.sources) - pkg.sources
+                msg = f"Missing source file(s): {' '.join(missing)}"
                 raise RiftError(msg)
 
         with self.mock.lock():

--- a/lib/rift/TempDir.py
+++ b/lib/rift/TempDir.py
@@ -34,11 +34,12 @@
 Help working with temporary directories.
 """
 
-import shutil
 import logging
+import shutil
 import tempfile
 
-class TempDir():
+
+class TempDir:
     """
     Create and manipulate a temporary directory.
 
@@ -52,16 +53,16 @@ class TempDir():
 
     def create(self):
         """Create a unique temporary directory."""
-        prefix = 'rift-' + (self.name and f"{self.name}-" or '')
+        prefix = "rift-" + (self.name and f"{self.name}-" or "")
         self.path = tempfile.mkdtemp(prefix=prefix)
-        name = f" {self.name}" if self.name else ''
-        logging.debug('Creating%s temporary directory %s', name, self.path)
+        name = f" {self.name}" if self.name else ""
+        logging.debug("Creating%s temporary directory %s", name, self.path)
 
     def delete(self):
         """Recursively delete the temporary directory."""
         if self.path:
-            name = f" {self.name}" if self.name else ''
-            logging.debug('Deleting%s temporary directory %s', name, self.path)
+            name = f" {self.name}" if self.name else ""
+            logging.debug("Deleting%s temporary directory %s", name, self.path)
             shutil.rmtree(self.path)
             self.path = None
 

--- a/lib/rift/TestResults.py
+++ b/lib/rift/TestResults.py
@@ -30,12 +30,13 @@
 # knowledge of the CeCILL license and that you accept its terms.
 #
 
-import re
 import collections
+import re
 import xml.etree.cElementTree as ET
 
 from rift.Config import _DEFAULT_VARIANT
 from rift.TextTable import TextTable
+
 
 def str_xml_escape(arg):
     r"""Visually escape invalid XML characters.
@@ -62,13 +63,12 @@ def str_xml_escape(arg):
     #          | [#x10000-#x10FFFF]
     # For an unknown(?) reason, we disallow #x7F (DEL) as well.
     illegal_xml_re = (
-        "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\u10000-"
-        "\u10ffff]"
+        "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\u10000-\u10ffff]"
     )
     return re.sub(illegal_xml_re, repl, arg)
 
 
-class TestCase():
+class TestCase:
     """
     TestCase: oject for to manage a Test to format ajunit file in TestResult
     """
@@ -97,11 +97,11 @@ class TestCase():
 
 
 TestResult = collections.namedtuple(
-    'TestResult', ['case', 'value', 'time', 'out', 'err']
+    "TestResult", ["case", "value", "time", "out", "err"]
 )
 
 
-class TestResults():
+class TestResults:
     """
     TestResults: gather and mange TestCase results
     """
@@ -126,14 +126,14 @@ class TestResults():
         """
         Add a failed TestCase
         """
-        self._add_result(TestResult(case, 'Failure', time, out, err))
+        self._add_result(TestResult(case, "Failure", time, out, err))
         self.global_result = False
 
     def add_success(self, case, time, out=None, err=None):
         """
         Add a successful TestCase
         """
-        self._add_result(TestResult(case, 'Success', time, out, err))
+        self._add_result(TestResult(case, "Success", time, out, err))
 
     def _add_result(self, result):
         """
@@ -156,7 +156,7 @@ class TestResults():
         """
         for result in other.results:
             self.results.append(result)
-            if result.value == 'Failure':
+            if result.value == "Failure":
                 self.global_result = False
 
     def junit(self, filename):
@@ -169,29 +169,29 @@ class TestResults():
         failed.
         """
 
-        suite = ET.Element('testsuite', tests=str(len(self.results)))
+        suite = ET.Element("testsuite", tests=str(len(self.results)))
         if self.name:
-            suite.set('name', self.name)
+            suite.set("name", self.name)
 
         for result in self.results:
-            sub = ET.SubElement(suite, 'testcase', name=result.case.name)
+            sub = ET.SubElement(suite, "testcase", name=result.case.name)
             if result.case.classname:
-                sub.set('classname', f"rift.{result.case.classname}")
+                sub.set("classname", f"rift.{result.case.classname}")
             if result.time:
-                sub.set('time', f"{result.time:.2f}")
-            if result.value == 'Failure':
-                failure = ET.SubElement(sub, 'failure')
+                sub.set("time", f"{result.time:.2f}")
+            if result.value == "Failure":
+                failure = ET.SubElement(sub, "failure")
                 if result.out is None and result.err:
                     failure.text = str_xml_escape(result.err)
             if result.out:
-                system_out = ET.SubElement(sub, 'system-out')
+                system_out = ET.SubElement(sub, "system-out")
                 system_out.text = str_xml_escape(result.out)
                 if result.err:
-                    system_err = ET.SubElement(sub, 'system-err')
+                    system_err = ET.SubElement(sub, "system-err")
                     system_err.text = str_xml_escape(result.err)
 
         tree = ET.ElementTree(suite)
-        tree.write(filename, encoding='UTF-8', xml_declaration=True)
+        tree.write(filename, encoding="UTF-8", xml_declaration=True)
 
     def summary(self):
         """
@@ -203,17 +203,15 @@ class TestResults():
             tbl = TextTable("%name %arch %format %>duration %result")
         for result in self.results:
             entry = {
-                'name': result.case.fullname,
-                'arch': result.case.arch,
-                'format': result.case.format,
-                'duration': f"{result.time:.0f}s",
-                'result': (
-                    result.value.upper()
-                    if result.value == 'Failure'
-                    else result.value
-                )
+                "name": result.case.fullname,
+                "arch": result.case.arch,
+                "format": result.case.format,
+                "duration": f"{result.time:.0f}s",
+                "result": (
+                    result.value.upper() if result.value == "Failure" else result.value
+                ),
             }
             if self._has_real_variants():
-                entry['variant'] = result.case.variant
+                entry["variant"] = result.case.variant
             tbl.append(entry)
         return str(tbl)

--- a/lib/rift/TextTable.py
+++ b/lib/rift/TextTable.py
@@ -21,11 +21,13 @@ Table formatting classes for text-based interface.
 
 import re
 
-COLORS = {'header': '\033[34m',
-          'stop': '\033[0m',
-         }
+COLORS = {
+    "header": "\033[34m",
+    "stop": "\033[0m",
+}
 
-class TextTable():
+
+class TextTable:
     """
     Display a list of dict into a ASCII table, based an a printf-like format.
 
@@ -58,7 +60,7 @@ class TextTable():
         optional_cols     Column list to not display if they are empty.
     """
 
-    RE_PATTERN = r'%(>)?(\d+)?(?P<name>[a-z]+)'
+    RE_PATTERN = r"%(>)?(\d+)?(?P<name>[a-z]+)"
 
     def __init__(self, fmt=""):
         self._rows = []
@@ -93,23 +95,23 @@ class TextTable():
         return self.header_labels.get(name, name)
 
     def pattern_fields(self):
-        """Return the list of all field place holder name used in fmt.  """
-        return [match.group('name')
-                for match in re.finditer(self.RE_PATTERN, self.fmt)]
+        """Return the list of all field place holder name used in fmt."""
+        return [match.group("name") for match in re.finditer(self.RE_PATTERN, self.fmt)]
 
     def append(self, row):
         """Append a new row to be displayed. `row' should be a dict."""
         # Keep track of wider value for each field
         for key, value in row.items():
-            real_value_len = len(str(value or ''))
+            real_value_len = len(str(value or ""))
             if self.show_header:
                 header_length = len(self._header(key))
             else:
                 header_length = 0
 
             # Keep track of the wider value in each col (header or value)
-            self._max_width[key] = max(self._max_width.get(key, header_length),
-                                       real_value_len)
+            self._max_width[key] = max(
+                self._max_width.get(key, header_length), real_value_len
+            )
 
             # Keep track of cols with at least one non empty row
             if real_value_len > 0 and key not in self._non_empty_cols:
@@ -146,7 +148,7 @@ class TextTable():
             # If the value is too long, cut it
             if len(value) > length:
                 length = max(4, length)
-                value = f"{value[:length - 3]}..."
+                value = f"{value[: length - 3]}..."
             if matchobj.group(1):
                 return f"{value:>{length}}"
             return f"{value:{length}}"
@@ -158,7 +160,7 @@ class TextTable():
     def _str_header(self):
         """Build the header string"""
         headline = self._str_common(self._header).upper().rstrip()
-        underline = re.sub("[^ ]", '-', headline)
+        underline = re.sub("[^ ]", "-", headline)
         if self.color:
             headline = f"{COLORS['header']}{headline}{COLORS['stop']}"
         if underline:

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -174,7 +174,7 @@ class VM:
         # default emulated cpu architecture
         if self.arch == "aarch64":
             self.cpu_type = vm_config.get("cpu", "cortex-a72")
-        elif self.enable_kvm == False:
+        elif not self.enable_kvm:
             self.cpu_type = vm_config.get("cpu", "qemu64")
         else:
             self.cpu_type = vm_config.get("cpu", "host")

--- a/lib/rift/VM.py
+++ b/lib/rift/VM.py
@@ -34,64 +34,63 @@
 Class to start, stop and manipulate VM used mostly for testing.
 """
 
-import os
-import pwd
-import grp
-import sys
-import time
-import datetime
-import shlex
-import platform
-import logging
-import tempfile
-import textwrap
-import termios
-import select
-import struct
-import socket
-import uuid
-import urllib
-import shutil
 import atexit
+import datetime
+import grp
 import hashlib
-from subprocess import Popen, PIPE, STDOUT, check_output, run, CalledProcessError
+import logging
+import os
+import platform
+import pwd
+import select
+import shlex
+import shutil
+import socket
+import struct
+import sys
+import tempfile
+import termios
+import textwrap
+import time
+import urllib
+import uuid
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen, check_output, run
 
 from jinja2 import Template
 
 from rift import RiftError
 from rift.auth import Auth
-from rift.Config import _DEFAULT_VIRTIOFSD, _DEFAULT_VARIANT
-from rift.repository import ProjectArchRepositories
-from rift.TempDir import TempDir
-from rift.utils import last_modified, download_file, setup_dl_opener, message
-from rift.run import run_command
+from rift.Config import _DEFAULT_VARIANT, _DEFAULT_VIRTIOFSD
 from rift.proxy import AuthenticatedRepositoryProxyRuntime
+from rift.repository import ProjectArchRepositories
+from rift.run import run_command
+from rift.TempDir import TempDir
+from rift.utils import download_file, last_modified, message, setup_dl_opener
 
-__all__ = ['VM']
+__all__ = ["VM"]
 
 ARCH_EFI_BIOS = "./usr/share/edk2/aarch64/QEMU_EFI.silent.fd"
-CLOUD_INIT_SEED_ISO = 'seed.iso'
+CLOUD_INIT_SEED_ISO = "seed.iso"
+
 
 def is_virtiofs_qemu(virtiofsd=_DEFAULT_VIRTIOFSD):
     """
     This function checks if virtiofsd is from qemu package or a standalone rust
     version
     """
-    output = b''
+    output = b""
     try:
-        output = check_output(f"{virtiofsd} --version",
-                              stderr=STDOUT,
-                              shell=True)
+        output = check_output(f"{virtiofsd} --version", stderr=STDOUT, shell=True)
     except CalledProcessError:
         try:
             # virtiofsd from qemu need to be lauched as 'root'...
-            output = check_output(f"sudo {virtiofsd} --version",
-                                  stderr=STDOUT,
-                                  shell=True)
+            output = check_output(
+                f"sudo {virtiofsd} --version", stderr=STDOUT, shell=True
+            )
         except CalledProcessError:
             logging.error("Cannot get %s version", virtiofsd)
 
-    if 'qemu' in output.decode() or 'FUSE' in output.decode():
+    if "qemu" in output.decode() or "FUSE" in output.decode():
         logging.debug("%s: Qemu version detected", virtiofsd)
         return True
 
@@ -106,35 +105,49 @@ def gen_virtiofs_args(socket_path, directory, qemu=False, virtiofsd=_DEFAULT_VIR
     the correct arguments for the two versions.
     """
     if qemu:
-        return ['sudo', virtiofsd,
-                f"--socket-path={socket_path}",
-                '-o', f"source={directory}",
-                '-o', 'cache=auto', '--syslog', '--daemonize']
-    return [virtiofsd,
-            '--socket-path', socket_path,
-            '--sandbox=none', '--shared-dir', directory,
-            '--cache', 'auto']
+        return [
+            "sudo",
+            virtiofsd,
+            f"--socket-path={socket_path}",
+            "-o",
+            f"source={directory}",
+            "-o",
+            "cache=auto",
+            "--syslog",
+            "--daemonize",
+        ]
+    return [
+        virtiofsd,
+        "--socket-path",
+        socket_path,
+        "--sandbox=none",
+        "--shared-dir",
+        directory,
+        "--cache",
+        "auto",
+    ]
 
-class VM():
+
+class VM:
     """Manipulate VM process and related temporary files."""
 
-    _PROJ_MOUNTPOINT = '/rift.project'
-    NAME = 'rift1.domain'
+    _PROJ_MOUNTPOINT = "/rift.project"
+    NAME = "rift1.domain"
     # Host IP address for QEMU user-mode networking available inside the guest.
     QEMU_USERNET_HOST = "10.0.2.2"
-    SUPPORTED_FS = ('9p', 'virtiofs')
+    SUPPORTED_FS = ("9p", "virtiofs")
 
     def __init__(self, config, arch, tmpmode=True, extra_repos=None):
-        self.version = config.get('version', '0')
+        self.version = config.get("version", "0")
         self.arch = arch
 
-        vm_config = config.get('vm', arch=arch)
-        image = vm_config.get('image')
+        vm_config = config.get("vm", arch=arch)
+        image = vm_config.get("image")
         if image:
             self._image_src = urllib.parse.urlparse(image)
         else:
             self._image_src = None
-        self._image_auth = vm_config.get('auth')
+        self._image_auth = vm_config.get("auth")
         if self._image_auth:
             self._auth = Auth(config)
         else:
@@ -145,57 +158,51 @@ class VM():
         if extra_repos is None:
             extra_repos = []
 
-        self._repos = ProjectArchRepositories(
-            config, arch
-        ).for_format('rpm').all + extra_repos
+        self._repos = (
+            ProjectArchRepositories(config, arch).for_format("rpm").all + extra_repos
+        )
         self._auth_proxy = AuthenticatedRepositoryProxyRuntime(config, self._repos)
 
-        self.address = vm_config.get('address')
-        self.port = self.default_port(vm_config.get('port_range'))
-        self.cpus = vm_config.get('cpus', 1)
-        self.memory = vm_config.get('memory')
-        self.qemu = config.get('qemu', arch=arch)
+        self.address = vm_config.get("address")
+        self.port = self.default_port(vm_config.get("port_range"))
+        self.cpus = vm_config.get("cpus", 1)
+        self.memory = vm_config.get("memory")
+        self.qemu = config.get("qemu", arch=arch)
 
-        self.enable_kvm = vm_config.get('enable_kvm')
+        self.enable_kvm = vm_config.get("enable_kvm")
 
         # default emulated cpu architecture
-        if self.arch == 'aarch64':
-            self.cpu_type = vm_config.get('cpu', 'cortex-a72')
+        if self.arch == "aarch64":
+            self.cpu_type = vm_config.get("cpu", "cortex-a72")
         elif self.enable_kvm == False:
-            self.cpu_type = vm_config.get('cpu', 'qemu64')
+            self.cpu_type = vm_config.get("cpu", "qemu64")
         else:
-            self.cpu_type = vm_config.get('cpu', 'host')
+            self.cpu_type = vm_config.get("cpu", "host")
 
         # Specific aarch64 options
-        self.arch_efi_bios = config.get('arch_efi_bios', ARCH_EFI_BIOS)
+        self.arch_efi_bios = config.get("arch_efi_bios", ARCH_EFI_BIOS)
         ##
 
         # Get guest shared fstype
-        self.virtiofsd = config.get('virtiofsd', _DEFAULT_VIRTIOFSD)
-        self.shared_fs_type = config.get('shared_fs_type', '9p')
+        self.virtiofsd = config.get("virtiofsd", _DEFAULT_VIRTIOFSD)
+        self.shared_fs_type = config.get("shared_fs_type", "9p")
         if self.shared_fs_type not in self.SUPPORTED_FS:
             raise RiftError(f"{self.shared_fs_type} not supported to share filesystems")
         ##
 
-
         self.tmpmode = tmpmode
-        self.copymode = vm_config.get('image_copy')
+        self.copymode = vm_config.get("image_copy")
         self._vm = None
         self._helpers = []
         self._tmpimg = None
         self.consolesock = f"/tmp/rift-vm-console-{self.vmid}.sock"
-        self.proxy = config.get('proxy')
-        self.no_proxy = config.get('no_proxy')
-        self.additional_rpms = vm_config.get('additional_rpms')
-        self.cloud_init_tpl = config.project_path(
-            vm_config.get('cloud_init_tpl')
-        )
-        self.build_post_script = config.project_path(
-            vm_config.get('build_post_script')
-        )
-        self.images_cache = vm_config.get('images_cache')
-        self.kernel = vm_config.get('kernel')
-
+        self.proxy = config.get("proxy")
+        self.no_proxy = config.get("no_proxy")
+        self.additional_rpms = vm_config.get("additional_rpms")
+        self.cloud_init_tpl = config.project_path(vm_config.get("cloud_init_tpl"))
+        self.build_post_script = config.project_path(vm_config.get("build_post_script"))
+        self.images_cache = vm_config.get("images_cache")
+        self.kernel = vm_config.get("kernel")
 
     @property
     def vmid(self):
@@ -218,7 +225,7 @@ class VM():
             return self._image_src.path
         return os.path.join(
             tempfile.gettempdir(),
-            f"rift-vm-local-image-{self.vmid}_{os.path.basename(self._image_src.path)}"
+            f"rift-vm-local-image-{self.vmid}_{os.path.basename(self._image_src.path)}",
         )
 
     def image_is_remote(self) -> bool:
@@ -226,9 +233,9 @@ class VM():
         Return True if VM image URL is an HTTP(S) URL, False if local file or raise
         RiftError is URL scheme is not supported.
         """
-        if self._image_src.scheme in ['', 'file']:
+        if self._image_src.scheme in ["", "file"]:
             return False
-        if self._image_src.scheme in ['http', 'https']:
+        if self._image_src.scheme in ["http", "https"]:
             return True
         raise RiftError(f"Unsupported VM image URL scheme {self._image_src.scheme}")
 
@@ -238,18 +245,18 @@ class VM():
         identifier and the given port range.
         """
         try:
-            assert port_range['max'] > port_range['min']
+            assert port_range["max"] > port_range["min"]
         except AssertionError as exc:
             raise RiftError(
                 "VM port range maximum must be greater than the minimum"
             ) from exc
         return (
-            int(self.vmid, 16) % (port_range['max'] - port_range['min'])
-        ) + port_range['min']
+            int(self.vmid, 16) % (port_range["max"] - port_range["min"])
+        ) + port_range["min"]
 
     def _vm_image_bearer_token(self):
         """Return bearer token for remote VM image HTTP(S) requests, or None."""
-        if self._image_auth != 'idp_token' or self._auth is None:
+        if self._image_auth != "idp_token" or self._auth is None:
             return None
         return self._auth.get_idp_token_noninteractive()
 
@@ -259,20 +266,20 @@ class VM():
         # Create a temporary file for VM image
         # XXX: Maybe a mkstemp() is better here to avoid removing file
         # when VM process is not stopped in purpose
-        self._tmpimg = tempfile.NamedTemporaryFile(prefix='rift-vm-img-')
+        self._tmpimg = tempfile.NamedTemporaryFile(prefix="rift-vm-img-")
 
         if self.copymode:
             # Copy qcow image for VM, based on temp file
-            cmd = ['dd', 'status=progress', 'conv=sparse', 'bs=1M']
+            cmd = ["dd", "status=progress", "conv=sparse", "bs=1M"]
             cmd += [f"if={os.path.realpath(image)}"]
             cmd += [f"of={self._tmpimg.name}"]
         else:
             # Create qcow image for VM, based on temp file
-            cmd = ['qemu-img', 'create', '-f', 'qcow2', '-F', 'qcow2']
-            cmd += ['-o', f"backing_file={os.path.realpath(image)}"]
+            cmd = ["qemu-img", "create", "-f", "qcow2", "-F", "qcow2"]
+            cmd += ["-o", f"backing_file={os.path.realpath(image)}"]
             cmd += [self._tmpimg.name]
 
-        logging.debug("Creating VM image file: %s", ' '.join(cmd))
+        logging.debug("Creating VM image file: %s", " ".join(cmd))
         with Popen(cmd, stdout=PIPE, stderr=STDOUT, universal_newlines=True) as popen:
             stdout = popen.communicate()[0]
             if popen.returncode != 0:
@@ -281,59 +288,70 @@ class VM():
     def _make_drive_cmd(self):
         cmd = []
         helper_cmd = []
-        if self.shared_fs_type == '9p':
-            cmd += ['-virtfs', f"local,id=project,path={self._project_dir},"
-                    'mount_tag=project,security_model=none']
+        if self.shared_fs_type == "9p":
+            cmd += [
+                "-virtfs",
+                f"local,id=project,path={self._project_dir},"
+                "mount_tag=project,security_model=none",
+            ]
             for repo in self._repos:
                 if repo.is_file():
                     if not repo.exists():
                         raise RiftError(
-                            f"Repository {repo.path} does not exist, unable to "
-                            "start VM"
+                            f"Repository {repo.path} does not exist, unable to start VM"
                         )
-                    cmd += ['-virtfs',
-                            f"local,id={repo.name},path={repo.path},"
-                            f"mount_tag={repo.name},security_model=none"]
-        elif self.shared_fs_type == 'virtiofs':
+                    cmd += [
+                        "-virtfs",
+                        f"local,id={repo.name},path={repo.path},"
+                        f"mount_tag={repo.name},security_model=none",
+                    ]
+        elif self.shared_fs_type == "virtiofs":
             # Add a shared memory object to allow virtiofsd shares
-            cmd += ['-object',
-                    f'memory-backend-file,id=mem,size={str(self.memory)}M,mem-path=/tmp,share=on']
+            cmd += [
+                "-object",
+                f"memory-backend-file,id=mem,size={str(self.memory)}M,mem-path=/tmp,share=on",
+            ]
             # Use platform.machine() instead of platform.proccessor to be container
             # compatible.
             if self.arch == platform.machine() and self.enable_kvm:
-                cmd += ['-machine', 'memory-backend=mem,accel=kvm']
+                cmd += ["-machine", "memory-backend=mem,accel=kvm"]
             else:
-                cmd += ['-machine', 'memory-backend=mem']
-            cmd += ['-chardev', 'socket,id=project,path=/tmp/.virtio_fs_project',
-                    '-device', 'vhost-user-fs-pci,queue-size=1024,chardev=project,tag=project']
+                cmd += ["-machine", "memory-backend=mem"]
+            cmd += [
+                "-chardev",
+                "socket,id=project,path=/tmp/.virtio_fs_project",
+                "-device",
+                "vhost-user-fs-pci,queue-size=1024,chardev=project,tag=project",
+            ]
 
             qemu_version = is_virtiofs_qemu(self.virtiofsd)
             helper_cmd.append(
                 gen_virtiofs_args(
-                    socket_path='/tmp/.virtio_fs_project',
+                    socket_path="/tmp/.virtio_fs_project",
                     directory=self._project_dir,
                     qemu=qemu_version,
-                    virtiofsd=self.virtiofsd
+                    virtiofsd=self.virtiofsd,
                 )
             )
             for repo in self._repos:
                 if repo.is_file():
                     if not repo.exists():
                         raise RiftError(
-                            f"Repository {repo.path} does not exist, unable to "
-                            "start VM"
+                            f"Repository {repo.path} does not exist, unable to start VM"
                         )
-                    cmd += ['-chardev',
-                            f"socket,id={repo.name},path=/tmp/.virtio_fs_{repo.name}",
-                            '-device',
-                            "vhost-user-fs-pci,queue-size=1024,"
-                            f"chardev={repo.name},tag={repo.name}"]
+                    cmd += [
+                        "-chardev",
+                        f"socket,id={repo.name},path=/tmp/.virtio_fs_{repo.name}",
+                        "-device",
+                        "vhost-user-fs-pci,queue-size=1024,"
+                        f"chardev={repo.name},tag={repo.name}",
+                    ]
                     helper_cmd.append(
                         gen_virtiofs_args(
                             socket_path=f"/tmp/.virtio_fs_{repo.name}",
                             directory=repo.path,
                             qemu=qemu_version,
-                            virtiofsd=self.virtiofsd
+                            virtiofsd=self.virtiofsd,
                         )
                     )
         return cmd, helper_cmd
@@ -343,16 +361,16 @@ class VM():
         Ugly hack to have root accessible sockets for virtiofsd...
         """
         sockets = []
-        if self.shared_fs_type == 'virtiofs':
-            sockets = ['/tmp/.virtio_fs_project']
+        if self.shared_fs_type == "virtiofs":
+            sockets = ["/tmp/.virtio_fs_project"]
             for repo in self._repos:
                 if repo.is_file():
                     sockets.append(f"/tmp/.virtio_fs_{repo.name}")
-            with Popen(['sudo', '/bin/chmod', '777'] + sockets) as popen:
+            with Popen(["sudo", "/bin/chmod", "777"] + sockets) as popen:
                 popen.wait()
 
     def _gen_qemu_args(self, image_file, seed):
-        """ Generate qemu command line arguments """
+        """Generate qemu command line arguments"""
         # Start VM process
         cmd = shlex.split(self.qemu)
 
@@ -361,46 +379,48 @@ class VM():
         # Use platform.machine() instead of platform.proccessor to be container
         # compatible.
         if self.arch == platform.machine() and self.enable_kvm:
-            cmd += ['-enable-kvm']
+            cmd += ["-enable-kvm"]
         elif self.arch != platform.machine():
-            cmd += ['-machine', 'virt']
+            cmd += ["-machine", "virt"]
 
-        cmd += ['-cpu', self.cpu_type]
+        cmd += ["-cpu", self.cpu_type]
 
-        cmd += ['-name', 'rift', '-display', 'none']
-        cmd += ['-m', str(self.memory), '-smp', str(self.cpus)]
-
+        cmd += ["-name", "rift", "-display", "none"]
+        cmd += ["-m", str(self.memory), "-smp", str(self.cpus)]
 
         # UEFI for aarch64
-        if self.arch == 'aarch64':
-            cmd += ['-bios', self.arch_efi_bios]
+        if self.arch == "aarch64":
+            cmd += ["-bios", self.arch_efi_bios]
 
         # Drive
         # TODO: switch to --device syntax
-        cmd += ['-drive', f"file={image_file},if=virtio,format=qcow2,cache=unsafe"]
+        cmd += ["-drive", f"file={image_file},if=virtio,format=qcow2,cache=unsafe"]
 
         # Console
-        cmd += ['-chardev', f"socket,id=charserial0,path={self.consolesock},"
-                "server=on,wait=off"]
+        cmd += [
+            "-chardev",
+            f"socket,id=charserial0,path={self.consolesock},server=on,wait=off",
+        ]
         # aarch64 platform need specific serial configuration
-        if self.arch == 'aarch64':
-            cmd += ['-device', 'virtio-serial,id=ser0,max_ports=8']
-            cmd += ['-serial', 'chardev:charserial0']
+        if self.arch == "aarch64":
+            cmd += ["-device", "virtio-serial,id=ser0,max_ports=8"]
+            cmd += ["-serial", "chardev:charserial0"]
         else:
-            cmd += ['-device', 'isa-serial,chardev=charserial0,id=serial0']
-
+            cmd += ["-device", "isa-serial,chardev=charserial0,id=serial0"]
 
         # NIC
-        cmd += ['-netdev', f"user,id=hostnet0,hostname={self.NAME},"
-                f"hostfwd=tcp::{self.port}-:22"]
+        cmd += [
+            "-netdev",
+            f"user,id=hostnet0,hostname={self.NAME},hostfwd=tcp::{self.port}-:22",
+        ]
         # aarch64 platform don't support PCI
-        if self.arch == 'aarch64':
-            cmd += ['-device', 'virtio-net-device,netdev=hostnet0']
+        if self.arch == "aarch64":
+            cmd += ["-device", "virtio-net-device,netdev=hostnet0"]
         else:
-            cmd += ['-device', 'virtio-net-pci,netdev=hostnet0,bus=pci.0,addr=0x3']
+            cmd += ["-device", "virtio-net-pci,netdev=hostnet0,bus=pci.0,addr=0x3"]
 
         if seed is not None:
-            cmd += ['-drive', f"driver=raw,file={seed},if=virtio"]
+            cmd += ["-drive", f"driver=raw,file={seed},if=virtio"]
 
         return cmd
 
@@ -445,8 +465,7 @@ class VM():
         if os.path.exists(self.image_local):
             if force:
                 logging.info(
-                    "Remove VM image local copy and force re-download for remote "
-                    "image"
+                    "Remove VM image local copy and force re-download for remote image"
                 )
                 os.unlink(self.image_local)
             else:
@@ -460,7 +479,7 @@ class VM():
                         "Local copy of VM image is present, unable to get remote image "
                         "modification date because of error (%s), skipping download of "
                         "remote image",
-                        err
+                        err,
                     )
                     return
                 # Compare local copy mtime with remote image Last-Modified header.
@@ -470,12 +489,10 @@ class VM():
                         "Local copy of VM image is already updated (%d > %d), "
                         "skipping download of remote image",
                         int(local_copy_mtime),
-                        int(last_remote_modification)
+                        int(last_remote_modification),
                     )
                     return
-                logging.info(
-                    "Remote VM image has been updated, removing local copy"
-                )
+                logging.info("Remote VM image has been updated, removing local copy")
                 os.unlink(self.image_local)
 
         message(f"Download remote VM image {self._image_src.geturl()}")
@@ -508,7 +525,6 @@ class VM():
         fs_cmds, helper_cmds = self._make_drive_cmd()
         cmd += fs_cmds
 
-
         logging.info("Qemu shared fs type: %s", self.shared_fs_type)
         for helper_cmd in helper_cmds:
             logging.info("Starting helper process (%s)", helper_cmd)
@@ -520,9 +536,8 @@ class VM():
         self._fix_socket_rights()
 
         logging.info("Starting VM process")
-        logging.debug("Running VM command: %s", ' '.join(cmd))
+        logging.debug("Running VM command: %s", " ".join(cmd))
         self._vm = Popen(cmd, stderr=PIPE)
-
 
     def prepare(self):
         """
@@ -531,36 +546,41 @@ class VM():
         This configure user, group, hosts, yum repos and mount points.
         """
         # Be sure current user/group exists in VM
-        userline = ':'.join([str(item) for item in pwd.getpwuid(os.getuid())])
+        userline = ":".join([str(item) for item in pwd.getpwuid(os.getuid())])
         (g_name, g_passwd, g_gid, g_mem) = grp.getgrgid(os.getgid())
         groupline = f"{g_name}:{g_passwd}:{g_gid}:{','.join(g_mem)}"
 
-        if self.shared_fs_type == '9p':
-            options = 'trans=virtio,version=9p2000.L,msize=131096'
+        if self.shared_fs_type == "9p":
+            options = "trans=virtio,version=9p2000.L,msize=131096"
         else:
-            options = 'defaults'
+            options = "defaults"
             # For guest kernel > 5.6
-            #options = 'defaults'
+            # options = 'defaults'
         # Build shared mount point info.
         mkdirs = [self._PROJ_MOUNTPOINT]
-        fstab = [f"project {self._PROJ_MOUNTPOINT} {self.shared_fs_type} {options},ro 0 0"]
+        fstab = [
+            f"project {self._PROJ_MOUNTPOINT} {self.shared_fs_type} {options},ro 0 0"
+        ]
         repos = []
         prio = 1000
         for repo in self._repos:
             if repo.is_file():
                 mkdirs.append(f"/rift.{repo.name}")
-                fstab.append(f"{repo.name} /rift.{repo.name} {self.shared_fs_type} "
-                             f"{options} 0 0")
+                fstab.append(
+                    f"{repo.name} /rift.{repo.name} {self.shared_fs_type} {options} 0 0"
+                )
             url = self._repo_url_for_guest(repo, self.QEMU_USERNET_HOST)
             prio = repo.priority or (prio - 1)
-            repos.append(textwrap.dedent(f"""\
+            repos.append(
+                textwrap.dedent(f"""\
                 [{repo.name}]
                 name={repo.name}
                 baseurl={url}
                 gpgcheck=0
                 priority={prio}
                 enabled={1 if _DEFAULT_VARIANT in repo.variants else 0}
-                """))
+                """)
+            )
             if repo.excludepkgs:
                 repos.append(f"excludepkgs={repo.excludepkgs}\n")
             if repo.module_hotfixes:
@@ -590,7 +610,7 @@ class VM():
             echo '{groupline}' >> /etc/group
 
             # Mount shared fs (9p, virtiofs,...)
-            mkdir {' '.join(mkdirs)}
+            mkdir {" ".join(mkdirs)}
             {fstab_cmd}
             mount -t {self.shared_fs_type} -a
 
@@ -608,30 +628,42 @@ class VM():
         """)
         self.cmd(cmd)
 
-    def cmd(self, command=None, options=('-T',), **kwargs):
+    def cmd(self, command=None, options=("-T",), **kwargs):
         """Run specified command inside this VM"""
-        cmd = ['ssh', '-oStrictHostKeyChecking=no', '-oLogLevel=ERROR',
-               '-oUserKnownHostsFile=/dev/null',
-               '-oBatchMode=yes', '-p', str(self.port),
-               'root@127.0.0.1']
+        cmd = [
+            "ssh",
+            "-oStrictHostKeyChecking=no",
+            "-oLogLevel=ERROR",
+            "-oUserKnownHostsFile=/dev/null",
+            "-oBatchMode=yes",
+            "-p",
+            str(self.port),
+            "root@127.0.0.1",
+        ]
         if options:
             cmd += options
         if command:
             cmd.append(command)
-        logging.debug("Running command in VM: %s", ' '.join(cmd))
+        logging.debug("Running command in VM: %s", " ".join(cmd))
         return run_command(cmd, **kwargs)
 
     def copy(self, source, dest, stderr=None):
         """Copy files from or to VM"""
-        cmd = ['scp', '-oStrictHostKeyChecking=no', '-oLogLevel=ERROR',
-               '-oUserKnownHostsFile=/dev/null', '-r', '-P', str(self.port)]
-        cmd.append(source.replace('rift:', 'root@127.0.0.1:'))
-        cmd.append(dest.replace('rift:', 'root@127.0.0.1:'))
-        logging.debug("Copy files with VM: %s", ' '.join(cmd))
+        cmd = [
+            "scp",
+            "-oStrictHostKeyChecking=no",
+            "-oLogLevel=ERROR",
+            "-oUserKnownHostsFile=/dev/null",
+            "-r",
+            "-P",
+            str(self.port),
+        ]
+        cmd.append(source.replace("rift:", "root@127.0.0.1:"))
+        cmd.append(dest.replace("rift:", "root@127.0.0.1:"))
+        logging.debug("Copy files with VM: %s", " ".join(cmd))
         with Popen(cmd, stderr=stderr) as popen:
             popen.wait()
             return popen.returncode
-
 
     def console(self):
         """Console of VM Hit Ctrl-C 3 times to exit"""
@@ -654,14 +686,14 @@ class VM():
         while 1:
             rdy = select.select([sys.stdin, console_socket], [], [console_socket])
             if console_socket in rdy[2]:
-                sys.stderr.write('Connection closed\n')
+                sys.stderr.write("Connection closed\n")
                 retcode = 1
                 break
             # Exit if Ctrl-C is pressed repeatedly
             if sys.stdin in rdy[0]:
                 buf = os.read(self_stdin, 4)
                 # Here 3 == ^C
-                if len(buf) > 0 and struct.unpack('b', buf[0:1])[0] == 3:
+                if len(buf) > 0 and struct.unpack("b", buf[0:1])[0] == 3:
                     if (datetime.datetime.now() - last_int).total_seconds() > 2:
                         last_int = datetime.datetime.now()
                         int_count = 1
@@ -669,7 +701,7 @@ class VM():
                         int_count += 1
 
                     if int_count == 3:
-                        print('\nDetaching ...')
+                        print("\nDetaching ...")
                         break
                 console_socket.sendall(buf)
 
@@ -677,7 +709,7 @@ class VM():
             if console_socket in rdy[0]:
                 msg_len = console_socket.recv_into(output, 32)
                 # Write to bytes array converted into strings
-                sys.stdout.write(''.join([f"{m:c}" for m in output[:msg_len]]))
+                sys.stdout.write("".join([f"{m:c}" for m in output[:msg_len]]))
                 sys.stdout.flush()
 
         # Restore terminal now to let user interrupt the wait if needed
@@ -690,11 +722,11 @@ class VM():
         running on hosts for handling this VM.
         """
         return {
-            'vm_cmd': (
+            "vm_cmd": (
                 "ssh -oUserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no "
-                f"-oLogLevel=ERROR -T -p {self.port} root@127.0.0.1 \"$@\""
+                f'-oLogLevel=ERROR -T -p {self.port} root@127.0.0.1 "$@"'
             ),
-            'vm_wait': textwrap.dedent("""\
+            "vm_wait": textwrap.dedent("""\
                 rc=1
                 for i in {1..7}
                 do
@@ -703,13 +735,11 @@ class VM():
                 vm_cmd echo -e '\\\\nConnection is OK' && rc=0 && break
                 done
                 return $rc\
-                """
-            ),
-            'vm_reboot': textwrap.dedent("""\
+                """),
+            "vm_reboot": textwrap.dedent("""\
                 echo -n 'Restarting VM...'
                 vm_cmd 'reboot' || true; sleep 5 && vm_wait || return 1\
-                """
-            )
+                """),
         }
 
     def run_test(self, test, variant):
@@ -717,10 +747,10 @@ class VM():
         Run specified test inside the VM.
         """
         # Set environment variable for package variant to allow conditionals
-        # in test scripts.
+        # in test scripts.
         cmd = f"export RIFT_VARIANT={variant}; "
         if test.command.startswith(self._project_dir):
-            testcmd = test.command[len(self._project_dir) + 1:]
+            testcmd = test.command[len(self._project_dir) + 1 :]
         else:
             testcmd = test.command
         cmd += f"cd {self._PROJ_MOUNTPOINT}; {testcmd}"
@@ -728,7 +758,7 @@ class VM():
 
     def running(self):
         """Check if VM is already running."""
-        return self.cmd('/bin/true', live_output=False).returncode == 0
+        return self.cmd("/bin/true", live_output=False).returncode == 0
 
     def ready(self):
         """
@@ -738,17 +768,19 @@ class VM():
         seconds for aarch64.
         """
         sleeping_time = 5
-        if self.arch == 'aarch64': # VM very long to boot in emulation mode
+        if self.arch == "aarch64":  # VM very long to boot in emulation mode
             sleeping_time = 20
 
         for _ in range(1, 10):
             # Check if Qemu process is really running
             if self._vm.poll() is not None:
-                raise RiftError(f"Unable to get VM running {self._vm.stderr.read().decode()}")
+                raise RiftError(
+                    f"Unable to get VM running {self._vm.stderr.read().decode()}"
+                )
             time.sleep(sleeping_time)
             if self.running():
                 return True
-            sys.stdout.write('.')
+            sys.stdout.write(".")
             sys.stdout.flush()
         return False
 
@@ -793,8 +825,7 @@ class VM():
         Remove temporary image if used.
         """
         if self._tmpimg and not self._tmpimg.closed:
-            logging.debug("Unlink VM temporary image file '%s'",
-                          self._tmpimg.name)
+            logging.debug("Unlink VM temporary image file '%s'", self._tmpimg.name)
             self._tmpimg.close()
             self._tmpimg = None
 
@@ -804,13 +835,13 @@ class VM():
         False if already running.
         """
         if self.running():
-            message('VM is already running')
+            message("VM is already running")
             return False
 
         # Download VM image if necessary
         self._download(force)
 
-        message('Launching VM ...')
+        message("Launching VM ...")
         # Start authenticated repositories proxy
         self._auth_proxy.start()
         self.spawn()
@@ -845,13 +876,11 @@ class VM():
             tmp_cache_dir.create()
             self.images_cache = tmp_cache_dir.path
             atexit.register(tmp_cache_dir.delete)
-        elif (
-                not os.path.exists(self.images_cache) or
-                not os.path.isdir(self.images_cache)
-            ):
+        elif not os.path.exists(self.images_cache) or not os.path.isdir(
+            self.images_cache
+        ):
             raise RiftError(
-                f"Cloud images cache directory {self.images_cache} does not "
-                "exist"
+                f"Cloud images cache directory {self.images_cache} does not exist"
             )
 
         base_image_path = os.path.join(self.images_cache, os.path.basename(url))
@@ -861,14 +890,11 @@ class VM():
         if os.path.exists(base_image_path):
             if force:
                 logging.info(
-                    "Download is forced, removing cached file %s",
-                    base_image_path)
+                    "Download is forced, removing cached file %s", base_image_path
+                )
                 os.remove(base_image_path)
             else:
-                logging.info(
-                    "Using cached file %s, skipping download",
-                    base_image_path
-                )
+                logging.info("Using cached file %s, skipping download", base_image_path)
                 return base_image_path
 
         logging.info("Downloading file %s", url)
@@ -892,29 +918,23 @@ class VM():
         tmp_seed_dir.create()
         atexit.register(tmp_seed_dir.delete)
 
-        seed_iso_file = os.path.join(
-            tmp_seed_dir.path,
-            CLOUD_INIT_SEED_ISO
-        )
+        seed_iso_file = os.path.join(tmp_seed_dir.path, CLOUD_INIT_SEED_ISO)
         # Generate cloud-init meta_data file
         meta_data_file = os.path.join(tmp_seed_dir.path, "meta-data")
-        with open(meta_data_file, 'w', encoding='utf-8') as fh_meta:
-            fh_meta.write(
-                f"instance-id: {uuid.uuid4()}\nlocal-hostname: rift\n"
-            )
+        with open(meta_data_file, "w", encoding="utf-8") as fh_meta:
+            fh_meta.write(f"instance-id: {uuid.uuid4()}\nlocal-hostname: rift\n")
 
         # Generate cloud-init user_data file
         user_data_file = os.path.join(tmp_seed_dir.path, "user-data")
 
         try:
-            with open(self.cloud_init_tpl, encoding='utf-8') as fh:
+            with open(self.cloud_init_tpl, encoding="utf-8") as fh:
                 tpl = Template(fh.read())
         except FileNotFoundError as err:
             raise RiftError(
-                "Unable to find cloud-init template file "
-                f"{self.cloud_init_tpl}"
+                f"Unable to find cloud-init template file {self.cloud_init_tpl}"
             ) from err
-        with open(user_data_file, 'w', encoding='utf-8') as fh_user:
+        with open(user_data_file, "w", encoding="utf-8") as fh_user:
             fh_user.write(
                 tpl.render(
                     proxy=self.proxy,
@@ -926,15 +946,24 @@ class VM():
         logging.info("Generating cloud-init seed ISO %s", seed_iso_file)
         try:
             run(
-                ['genisoimage', '-output', seed_iso_file,
-                 '-input-charset', 'utf-8', '-volid', 'cidata', '-joliet',
-                 '-rock', user_data_file, meta_data_file],
+                [
+                    "genisoimage",
+                    "-output",
+                    seed_iso_file,
+                    "-input-charset",
+                    "utf-8",
+                    "-volid",
+                    "cidata",
+                    "-joliet",
+                    "-rock",
+                    user_data_file,
+                    meta_data_file,
+                ],
                 cwd=tmp_seed_dir.path,
-                check=True)
+                check=True,
+            )
         except CalledProcessError as error:
-            raise RiftError(
-                f"Error while generating seed iso: {str(error)}"
-            ) from error
+            raise RiftError(f"Error while generating seed iso: {str(error)}") from error
 
         return seed_iso_file
 
@@ -947,7 +976,7 @@ class VM():
         if not os.path.exists(self.build_post_script):
             logging.info(
                 "Build post script %s not found, skipping its execution…",
-                self.build_post_script
+                self.build_post_script,
             )
             return
 
@@ -959,11 +988,8 @@ class VM():
             f"RIFT_REPOS={':'.join([repo.name for repo in self._repos])} "
             f"RIFT_KERNEL={self.kernel or ''}"
         )
-        with open(self.build_post_script, encoding='utf-8') as fh:
-            if self.cmd(
-                    f"{env_str} bash -",
-                    stdin=fh
-                ).returncode:
+        with open(self.build_post_script, encoding="utf-8") as fh:
+            if self.cmd(f"{env_str} bash -", stdin=fh).returncode:
                 self.stop()
                 raise RiftError("Error while running build post script")
 
@@ -979,9 +1005,17 @@ class VM():
             # image with qemu-img.
             try:
                 run(
-                    ['qemu-img', 'convert', '-c', '-O', 'qcow2',
-                     self._tmpimg.name, output],
-                    check=True)
+                    [
+                        "qemu-img",
+                        "convert",
+                        "-c",
+                        "-O",
+                        "qcow2",
+                        self._tmpimg.name,
+                        output,
+                    ],
+                    check=True,
+                )
             except CalledProcessError as error:
                 raise RiftError(
                     f"Error while converting resulting image: {str(error)}"
@@ -995,8 +1029,7 @@ class VM():
         # Check the VM is not already running or fail.
         if self.running():
             raise RiftError(
-                'VM is already running then unable to build image, stop the VM '
-                'first.'
+                "VM is already running then unable to build image, stop the VM first."
             )
 
         # Download image if necessary

--- a/lib/rift/__init__.py
+++ b/lib/rift/__init__.py
@@ -30,10 +30,12 @@
 # knowledge of the CeCILL license and that you accept its terms.
 #
 
-__version__ = '0.12'
+__version__ = "0.12"
+
 
 class RiftError(Exception):
     """Generic error in Rift"""
+
 
 class DeclError(RiftError):
     """A configuration file has a declaration error"""

--- a/lib/rift/annex/__init__.py
+++ b/lib/rift/annex/__init__.py
@@ -31,5 +31,6 @@
 #
 
 """Module to handle different annexes target."""
+
 from rift.annex._base import Annex
 from rift.annex.utils import is_binary, is_pointer

--- a/lib/rift/annex/__init__.py
+++ b/lib/rift/annex/__init__.py
@@ -34,3 +34,9 @@
 
 from rift.annex._base import Annex
 from rift.annex.utils import is_binary, is_pointer
+
+__all__ = [
+    "Annex",
+    "is_binary",
+    "is_pointer",
+]

--- a/lib/rift/annex/_base.py
+++ b/lib/rift/annex/_base.py
@@ -42,11 +42,11 @@ import sys
 import tempfile
 
 from rift import RiftError
-from rift.TempDir import TempDir
 from rift.annex.directory import DirectoryAnnex
-from rift.annex.server import ServerAnnex
 from rift.annex.s3 import S3Annex
-from rift.annex.utils import hashfile, is_pointer, get_digest_from_path
+from rift.annex.server import ServerAnnex
+from rift.annex.utils import get_digest_from_path, hashfile, is_pointer
+from rift.TempDir import TempDir
 
 
 class Annex:
@@ -59,24 +59,25 @@ class Annex:
 
     For now, files are stored in a flat namespace.
     """
+
     # Read and Write file modes
     RMODE = 0o644
 
     def __init__(self, config, set_annex=None, staging_annex=None):
-        self.restore_cache = config.get('annex_restore_cache')
+        self.restore_cache = config.get("annex_restore_cache")
         if self.restore_cache is not None:
             self.restore_cache = os.path.expanduser(self.restore_cache)
 
-         # Set/Staging annex paths
+        # Set/Staging annex paths
         if set_annex is None:
-            set_annex = config.get('set_annex')
+            set_annex = config.get("set_annex")
 
         self.set_annex = self.annex_from_type(config, set_annex)
         if self.set_annex is None:
             self.set_annex = DirectoryAnnex(config, set_annex)
 
         if staging_annex is None:
-            staging_annex = config.get('staging_annex')
+            staging_annex = config.get("staging_annex")
             if staging_annex is None:
                 staging_annex = set_annex
 
@@ -89,13 +90,13 @@ class Annex:
         Return an instance of GenericAnnex based on the given annex address and
         type
         """
-        annex_type = annex.get('type')
-        if annex_type == 'directory':
-            return DirectoryAnnex(config, annex.get('address'))
-        if annex_type == 'server':
-            return ServerAnnex(config, annex.get('address'), annex.get('auth'))
-        if annex_type == 's3':
-            return S3Annex(config, annex.get('address'))
+        annex_type = annex.get("type")
+        if annex_type == "directory":
+            return DirectoryAnnex(config, annex.get("address"))
+        if annex_type == "server":
+            return ServerAnnex(config, annex.get("address"), annex.get("auth"))
+        if annex_type == "s3":
+            return S3Annex(config, annex.get("address"))
 
         return None
 
@@ -127,8 +128,9 @@ class Annex:
             self.make_restore_cache()
             cached_path = self.get_cached_path(identifier)
             if os.path.isfile(cached_path):
-                logging.debug('Extract %s to %s using restore cache',
-                              identifier, destpath)
+                logging.debug(
+                    "Extract %s to %s using restore cache", identifier, destpath
+                )
                 shutil.copyfile(cached_path, destpath)
                 return
 
@@ -173,7 +175,7 @@ class Annex:
         If `force_temp' is True, temporary is always created and source files
         copied in it even if there is no binary files.
         """
-        tmpdir = TempDir('sources')
+        tmpdir = TempDir("sources")
         if force_temp:
             tmpdir.create()
 
@@ -187,7 +189,6 @@ class Annex:
 
             # Is a pointer to a binary file?
             if is_pointer(filepath):
-
                 # We have our first binary file, we need a temp directory
                 if tmpdir.path is None:
                     tmpdir.create()
@@ -231,7 +232,7 @@ class Annex:
         os.chmod(filepath, self.RMODE)
 
         # Create fake pointer file
-        with open(filepath, 'w', encoding='utf-8') as fakefile:
+        with open(filepath, "w", encoding="utf-8") as fakefile:
             fakefile.write(digest)
 
     def backup(self, packages, output_file=None):
@@ -248,8 +249,8 @@ class Annex:
                     filelist.append(source_file)
 
         if output_file is None:
-            output_file = tempfile.NamedTemporaryFile(delete=False,
-                                                      prefix='rift-annex-backup',
-                                                      suffix='.tar.gz').name
+            output_file = tempfile.NamedTemporaryFile(
+                delete=False, prefix="rift-annex-backup", suffix=".tar.gz"
+            ).name
 
         return self.set_annex.backup(filelist, output_file)

--- a/lib/rift/annex/directory.py
+++ b/lib/rift/annex/directory.py
@@ -32,21 +32,24 @@
 """
 Implementation of the Annex class for a directory annex
 """
+
 import logging
 import os
 import shutil
 import tarfile
 import time
-
 from datetime import datetime as dt
 from urllib.parse import urlparse
 
 import yaml
 
 from rift.annex.generic_annex import GenericAnnex
-from rift.annex.utils import ( get_digest_from_path, get_info_from_digest,
-                               print_annex_tar_progress,
-                               _INFOSUFFIX )
+from rift.annex.utils import (
+    _INFOSUFFIX,
+    get_digest_from_path,
+    get_info_from_digest,
+    print_annex_tar_progress,
+)
 from rift.Config import OrderedLoader
 
 
@@ -60,6 +63,7 @@ class DirectoryAnnex(GenericAnnex):
 
     For now, files are stored in a flat namespace.
     """
+
     # Read and Write file modes
     WMODE = 0o664
 
@@ -69,7 +73,7 @@ class DirectoryAnnex(GenericAnnex):
 
     def get(self, identifier, destpath):
         """Get a file identified by identifier and copy it at destpath."""
-        logging.debug('Extracting %s to %s', identifier, destpath)
+        logging.debug("Extracting %s to %s", identifier, destpath)
         idpath = os.path.join(self.annex_path, identifier)
         shutil.copyfile(idpath, destpath)
 
@@ -78,7 +82,7 @@ class DirectoryAnnex(GenericAnnex):
     def delete(self, identifier):
         """Remove a file from annex, whose ID is `identifier'"""
         idpath = os.path.join(self.annex_path, identifier)
-        logging.debug('Deleting from annex: %s', idpath)
+        logging.debug("Deleting from annex: %s", idpath)
         infopath = get_info_from_digest(idpath)
         if os.path.exists(infopath):
             os.unlink(infopath)
@@ -112,27 +116,32 @@ class DirectoryAnnex(GenericAnnex):
                 continue
 
             info = self._load_metadata(filename)
-            names = info.get('filenames', [])
+            names = info.get("filenames", [])
             for annexed_file, details in names.items():
-                insertion_time = details['date']
+                insertion_time = details["date"]
 
                 # Handle different date formats (old method)
                 if not isinstance(insertion_time, (int, float, str)):
-                    raise ValueError(f"Invalid date format in metadata: "
-                                     f"{insertion_time} "
-                                     f"(type {type(insertion_time)})")
+                    raise ValueError(
+                        f"Invalid date format in metadata: "
+                        f"{insertion_time} "
+                        f"(type {type(insertion_time)})"
+                    )
 
                 if isinstance(insertion_time, str):
-                    fmt = '%a %b %d %H:%M:%S %Y'
+                    fmt = "%a %b %d %H:%M:%S %Y"
                     try:
                         insertion_time = dt.strptime(insertion_time, fmt).timestamp()
                     except ValueError:
-                        fmt = '%a %d %b %Y %H:%M:%S %p %Z'
+                        fmt = "%a %d %b %Y %H:%M:%S %p %Z"
                         try:
-                            insertion_time = dt.strptime(insertion_time, fmt).timestamp()
+                            insertion_time = dt.strptime(
+                                insertion_time, fmt
+                            ).timestamp()
                         except ValueError as exc:
-                            raise ValueError(f"Unknown date format in "
-                                             f"metadata: {insertion_time}") from exc
+                            raise ValueError(
+                                f"Unknown date format in metadata: {insertion_time}"
+                            ) from exc
 
                 elif isinstance(insertion_time, float):
                     insertion_time = int(insertion_time)
@@ -160,24 +169,26 @@ class DirectoryAnnex(GenericAnnex):
         destinfo = None
         if os.path.exists(destpath):
             destinfo = os.stat(destpath)
-            if destinfo and destinfo.st_size == originfo.st_size and \
-            filename in metadata.get('filenames', {}):
-                logging.debug('%s is already into annex, skipping it', filename)
+            if (
+                destinfo
+                and destinfo.st_size == originfo.st_size
+                and filename in metadata.get("filenames", {})
+            ):
+                logging.debug("%s is already into annex, skipping it", filename)
                 return
 
         # Update them and write them back
-        fileset = metadata.setdefault('filenames', {})
+        fileset = metadata.setdefault("filenames", {})
         fileset.setdefault(filename, {})
-        fileset[filename]['date'] = time.time()  # Unix timestamp
+        fileset[filename]["date"] = time.time()  # Unix timestamp
 
-        metapath = os.path.join(self.annex_path,
-                                get_info_from_digest(digest))
-        with open(metapath, 'w', encoding="utf-8") as fyaml:
+        metapath = os.path.join(self.annex_path, get_info_from_digest(digest))
+        with open(metapath, "w", encoding="utf-8") as fyaml:
             yaml.dump(metadata, fyaml, default_flow_style=False)
         os.chmod(metapath, self.WMODE)
 
         # Move binary file to annex
-        logging.debug('Importing %s into annex (%s)', filepath, digest)
+        logging.debug("Importing %s into annex (%s)", filepath, digest)
         shutil.copyfile(filepath, destpath)
         os.chmod(destpath, self.WMODE)
 
@@ -193,7 +204,9 @@ class DirectoryAnnex(GenericAnnex):
             for _file in filelist:
                 digest = get_digest_from_path(_file)
                 annex_file = os.path.join(self.annex_path, digest)
-                annex_file_info = os.path.join(self.annex_path, get_info_from_digest(digest))
+                annex_file_info = os.path.join(
+                    self.annex_path, get_info_from_digest(digest)
+                )
                 tar.add(annex_file, arcname=os.path.basename(annex_file))
                 tar.add(annex_file_info, arcname=os.path.basename(annex_file_info))
 

--- a/lib/rift/annex/generic_annex.py
+++ b/lib/rift/annex/generic_annex.py
@@ -36,10 +36,12 @@ repository called an annex.
 
 from abc import ABC, abstractmethod
 
+
 class GenericAnnex(ABC):
     """
     Generic implemention of an annex and the methods it should define
     """
+
     @abstractmethod
     def get(self, identifier, destpath):
         """

--- a/lib/rift/annex/s3.py
+++ b/lib/rift/annex/s3.py
@@ -33,6 +33,7 @@
 Class and function to detect binary files and push them into a file repository
 called an annex.
 """
+
 import errno
 import logging
 import os
@@ -40,7 +41,6 @@ import shutil
 import sys
 import tempfile
 import time
-
 from datetime import datetime as dt
 from urllib.parse import urlparse
 
@@ -49,9 +49,9 @@ import botocore
 import yaml
 
 from rift import RiftError
-from rift.auth import Auth
 from rift.annex.generic_annex import GenericAnnex
-from rift.annex.utils import get_info_from_digest, _INFOSUFFIX
+from rift.annex.utils import _INFOSUFFIX, get_info_from_digest
+from rift.auth import Auth
 
 
 class S3Annex(GenericAnnex):
@@ -64,6 +64,7 @@ class S3Annex(GenericAnnex):
 
     For now, files are stored in a flat namespace.
     """
+
     def __init__(self, config, annex_path):
         self.annex_path = annex_path
 
@@ -93,11 +94,13 @@ class S3Annex(GenericAnnex):
         if not self.push_s3_auth.authenticate():
             raise RiftError("authentication failed; cannot get push_s3_client")
 
-        self.push_s3_client = boto3.client('s3',
-            aws_access_key_id = self.push_s3_auth.config["access_key_id"],
-            aws_secret_access_key = self.push_s3_auth.config["secret_access_key"],
-            aws_session_token = self.push_s3_auth.config["session_token"],
-            endpoint_url = self.push_s3_endpoint)
+        self.push_s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=self.push_s3_auth.config["access_key_id"],
+            aws_secret_access_key=self.push_s3_auth.config["secret_access_key"],
+            aws_session_token=self.push_s3_auth.config["session_token"],
+            endpoint_url=self.push_s3_endpoint,
+        )
 
         return self.push_s3_client
 
@@ -116,12 +119,12 @@ class S3Annex(GenericAnnex):
         # s3.meta.events.register('choose-signer.s3.*', botocore.handlers.disable_signing)
 
         success = False
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
             try:
                 s3.download_fileobj(self.push_s3_bucket, key, tmp_file)
                 success = True
             except botocore.exceptions.ClientError as error:
-                if error.response['Error']['Code'] == '404':
+                if error.response["Error"]["Code"] == "404":
                     logging.info("object not found: %s", key)
                 logging.error(error)
             except Exception as error:
@@ -130,7 +133,7 @@ class S3Annex(GenericAnnex):
         if not success:
             return False
 
-        logging.debug('Extracting %s to %s', identifier, destpath)
+        logging.debug("Extracting %s to %s", identifier, destpath)
         shutil.move(tmp_file.name, destpath)
 
         return True
@@ -150,18 +153,17 @@ class S3Annex(GenericAnnex):
         s3 = self.get_push_s3_client()
 
         # disable signing if accessing anonymously
-        s3.meta.events.register('choose-signer.s3.*', botocore.handlers.disable_signing)
+        s3.meta.events.register("choose-signer.s3.*", botocore.handlers.disable_signing)
 
         response = s3.list_objects_v2(
-            Bucket=self.read_s3_bucket,
-            Prefix=self.read_s3_prefix
+            Bucket=self.read_s3_bucket, Prefix=self.read_s3_prefix
         )
-        if 'Contents' not in response:
+        if "Contents" not in response:
             logging.info("No files found in %s", self.read_s3_prefix)
             return
 
-        for obj in response['Contents']:
-            key = obj['Key']
+        for obj in response["Contents"]:
+            key = obj["Key"]
             filename = os.path.basename(key)
 
             if filename.endswith(_INFOSUFFIX):
@@ -169,13 +171,13 @@ class S3Annex(GenericAnnex):
 
             meta_obj_name = get_info_from_digest(key)
             meta_obj = s3.get_object(Bucket=self.read_s3_bucket, Key=meta_obj_name)
-            info = yaml.safe_load(meta_obj['Body']) or {}
-            names = info.get('filenames', [])
+            info = yaml.safe_load(meta_obj["Body"]) or {}
+            names = info.get("filenames", [])
             for annexed_file in names.values():
-                insertion_time = annexed_file['date']
+                insertion_time = annexed_file["date"]
                 insertion_time = dt.strptime(insertion_time, "%c").timestamp()
 
-            size = obj['Size']
+            size = obj["Size"]
 
             yield filename, size, insertion_time, names
 
@@ -200,11 +202,13 @@ class S3Annex(GenericAnnex):
         metadata = {}
         try:
             meta_obj = s3.get_object(Bucket=self.push_s3_bucket, Key=meta_obj_name)
-            metadata = yaml.safe_load(meta_obj['Body']) or {}
+            metadata = yaml.safe_load(meta_obj["Body"]) or {}
         except s3.exceptions.NoSuchKey:
             logging.info("metadata not found in s3: %s", meta_obj_name)
         except yaml.YAMLError:
-            logging.info("retrieved metadata could not be parsed as yaml: %s", meta_obj_name)
+            logging.info(
+                "retrieved metadata could not be parsed as yaml: %s", meta_obj_name
+            )
 
         originfo = os.stat(filepath)
         destinfo = None
@@ -212,16 +216,21 @@ class S3Annex(GenericAnnex):
             destinfo = s3.get_object(Bucket=self.push_s3_bucket, Key=key)
         except s3.exceptions.NoSuchKey:
             logging.info("key not found in s3: %s", key)
-        if destinfo and destinfo["ContentLength"] == originfo.st_size and \
-          filename in metadata.get('filenames', {}):
+        if (
+            destinfo
+            and destinfo["ContentLength"] == originfo.st_size
+            and filename in metadata.get("filenames", {})
+        ):
             logging.debug("%s is already into annex, skipping it", filename)
         else:
             # Update them and write them back
-            fileset = metadata.setdefault('filenames', {})
+            fileset = metadata.setdefault("filenames", {})
             fileset.setdefault(filename, {})
-            fileset[filename]['date'] = time.strftime("%c")
+            fileset[filename]["date"] = time.strftime("%c")
 
-            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.info') as f:
+            with tempfile.NamedTemporaryFile(
+                mode="w", delete=False, suffix=".info"
+            ) as f:
                 yaml.dump(metadata, f, default_flow_style=False)
                 s3.upload_file(f.name, self.push_s3_bucket, meta_obj_name)
             logging.debug("Importing %s into annex (%s)", filepath, digest)

--- a/lib/rift/annex/s3.py
+++ b/lib/rift/annex/s3.py
@@ -112,11 +112,14 @@ class S3Annex(GenericAnnex):
 
     def get(self, identifier, destpath):
         """Get a file identified by identifier and copy it at destpath."""
-        # Checking annex push, expecting annex push path to be an s3-providing http(s) url
+        # Checking annex push, expecting annex push path to be an
+        # s3-providing http(s) url
         key = os.path.join(self.push_s3_prefix, identifier)
 
         s3 = self.get_push_s3_client()
-        # s3.meta.events.register('choose-signer.s3.*', botocore.handlers.disable_signing)
+        # s3.meta.events.register(
+        #     'choose-signer.s3.*', botocore.handlers.disable_signing
+        # )
 
         success = False
         with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp_file:

--- a/lib/rift/annex/server.py
+++ b/lib/rift/annex/server.py
@@ -45,13 +45,13 @@ import tempfile
 import requests
 
 from rift import RiftError
-from rift.auth import Auth
 from rift.annex.generic_annex import GenericAnnex
 from rift.annex.utils import (
     get_digest_from_path,
     get_info_from_digest,
     print_annex_tar_progress,
 )
+from rift.auth import Auth
 
 
 class ServerAnnex(GenericAnnex):
@@ -64,16 +64,17 @@ class ServerAnnex(GenericAnnex):
 
     For now, files are stored in a flat namespace.
     """
+
     def __init__(self, config, annex_path, auth=None):
         self.annex_path = annex_path
-        self._auth = Auth(config) if auth == 'idp_token' else None
+        self._auth = Auth(config) if auth == "idp_token" else None
 
     def _request_headers(self):
         """Return HTTP headers for annex requests, including Bearer token if configured."""
         if self._auth is None:
             return {}
         token = self._auth.get_idp_token_noninteractive()
-        return {'Authorization': f'Bearer {token}'}
+        return {"Authorization": f"Bearer {token}"}
 
     def get_cached_path(self, path):
         """
@@ -93,7 +94,7 @@ class ServerAnnex(GenericAnnex):
                 )
 
                 if res:
-                    with open(tmp_file, 'wb') as f:
+                    with open(tmp_file, "wb") as f:
                         # If the annex object to get is a gzip, reading it
                         # with the standard 'iter_content()' method will
                         # mistakenly gunzip it, which will cause errors
@@ -104,15 +105,16 @@ class ServerAnnex(GenericAnnex):
                             f.write(chunk)
                             chunk = res.raw.read(8192)
 
-                        logging.debug('Extracting %s to %s',
-                                      identifier, destpath)
+                        logging.debug("Extracting %s to %s", identifier, destpath)
                         shutil.move(tmp_file, destpath)
 
                         return True
                 elif res.status_code != 404:
                     res.raise_for_status()
             except requests.exceptions.RequestException as e:
-                raise RiftError(f"failed to fetch file from annex: {idpath}: {e}") from e
+                raise RiftError(
+                    f"failed to fetch file from annex: {idpath}: {e}"
+                ) from e
 
         return False
 
@@ -152,8 +154,9 @@ class ServerAnnex(GenericAnnex):
                 for _file in filelist:
                     digest = get_digest_from_path(_file)
                     annex_file = os.path.join(self.annex_path, digest)
-                    annex_file_info = os.path.join(self.annex_path,
-                                                   get_info_from_digest(digest))
+                    annex_file_info = os.path.join(
+                        self.annex_path, get_info_from_digest(digest)
+                    )
 
                     for f in (annex_file, annex_file_info):
                         basename = os.path.basename(f)
@@ -161,17 +164,22 @@ class ServerAnnex(GenericAnnex):
 
                         try:
                             res = requests.get(
-                                f, stream=True, timeout=15, headers=self._request_headers()
+                                f,
+                                stream=True,
+                                timeout=15,
+                                headers=self._request_headers(),
                             )
                             if res.status_code != 404:
                                 res.raise_for_status()
 
-                            with open(tmp, 'wb') as f:
+                            with open(tmp, "wb") as f:
                                 for chunk in res.iter_content(chunk_size=8192):
                                     f.write(chunk)
                                 tar.add(tmp, arcname=basename)
                         except requests.exceptions.RequestException as e:
-                            raise RiftError(f"failed to fetch file from annex: {f}: {e}") from e
+                            raise RiftError(
+                                f"failed to fetch file from annex: {f}: {e}"
+                            ) from e
 
                     print_annex_tar_progress(pkg_nb, total_packages)
                     pkg_nb += 1

--- a/lib/rift/annex/server.py
+++ b/lib/rift/annex/server.py
@@ -70,7 +70,7 @@ class ServerAnnex(GenericAnnex):
         self._auth = Auth(config) if auth == "idp_token" else None
 
     def _request_headers(self):
-        """Return HTTP headers for annex requests, including Bearer token if configured."""
+        """Return HTTP headers for annex requests, with Bearer token if set."""
         if self._auth is None:
             return {}
         token = self._auth.get_idp_token_noninteractive()

--- a/lib/rift/annex/utils.py
+++ b/lib/rift/annex/utils.py
@@ -32,6 +32,7 @@
 """
 Utils class for the annexes
 """
+
 import hashlib
 import string
 
@@ -39,15 +40,18 @@ import string
 _TEXTCHARS = bytearray([9, 10, 13] + list(range(32, 127)))
 
 # Suffix of metadata filename
-_INFOSUFFIX = '.info'
+_INFOSUFFIX = ".info"
+
 
 def get_digest_from_path(path):
     """Get file id from the givent path"""
-    return open(path, encoding='utf-8').read()
+    return open(path, encoding="utf-8").read()
+
 
 def get_info_from_digest(digest):
     """Get file info id"""
     return digest + _INFOSUFFIX
+
 
 def is_binary(filepath, blocksize=65536):
     """
@@ -59,7 +63,7 @@ def is_binary(filepath, blocksize=65536):
     If there is a very small number of binary characters compared to the whole
     file, we still consider it as non-binary to avoid using Annex uselessly.
     """
-    with open(filepath, 'rb') as srcfile:
+    with open(filepath, "rb") as srcfile:
         data = srcfile.read(blocksize)
         binchars = data.translate(None, _TEXTCHARS)
         if len(data) == 0:
@@ -72,13 +76,14 @@ def is_binary(filepath, blocksize=65536):
             result = bool(binchars)
     return result
 
+
 def is_pointer(filepath):
     """
     Return true if content of file at filepath looks like a valid digest
     identifier.
     """
     try:
-        with open(filepath, encoding='utf-8') as fh:
+        with open(filepath, encoding="utf-8") as fh:
             identifier = fh.read()
             # Remove possible trailing whitespace, newline and carriage return
             # characters.
@@ -95,10 +100,11 @@ def is_pointer(filepath):
     # If the identifier is not a valid Rift Annex pointer
     return False
 
+
 def hashfile(filepath, iosize=65536):
     """Compute a digest of filepath content."""
     hasher = hashlib.sha3_256()
-    with open(filepath, 'rb') as srcfile:
+    with open(filepath, "rb") as srcfile:
         buf = srcfile.read(iosize)
         while len(buf) > 0:
             hasher.update(buf)

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -33,6 +33,7 @@
 Auth:
     This package manage rift s3 authentication
 """
+
 import datetime
 import getpass
 import json
@@ -48,19 +49,21 @@ from rift import RiftError
 
 urllib3.disable_warnings()
 
+
 class Auth:
     """
     Config: Manage rift authentication
         This class manages rift authentication
     """
+
     def __init__(self, config):
-        self.idp_app_token = config.get('idp_app_token')
+        self.idp_app_token = config.get("idp_app_token")
         if self.idp_app_token is None:
             msg = "authentication requires presence of idp_app_token config"
             raise RiftError(msg)
-        self.idp_auth_endpoint = config.get('idp_auth_endpoint')
-        self.s3_auth_endpoint = config.get('s3_auth_endpoint')
-        self.credentials_file = os.path.expanduser(config.get('s3_credential_file'))
+        self.idp_auth_endpoint = config.get("idp_auth_endpoint")
+        self.s3_auth_endpoint = config.get("s3_auth_endpoint")
+        self.credentials_file = os.path.expanduser(config.get("s3_credential_file"))
 
         self.config = {}
         self.expiration_dt = ""
@@ -80,14 +83,16 @@ class Auth:
         If credentials file contains expired data, remove expired items from file.
         """
 
-        with open(self.credentials_file, 'r', encoding="utf-8") as fs:
+        with open(self.credentials_file, "r", encoding="utf-8") as fs:
             data = fs.read()
 
             config = {}
             try:
                 config = json.loads(data)
             except json.JSONDecodeError as e:
-                logging.info("failed to decode json from existing credentials file: %s", e)
+                logging.info(
+                    "failed to decode json from existing credentials file: %s", e
+                )
 
             update_authfile = False
 
@@ -109,7 +114,9 @@ class Auth:
 
             idp_expiry = config.get("idp_token_expiration")
             if idp_expiry:
-                expiration = datetime.datetime.strptime(idp_expiry, "%Y-%m-%dT%H:%M:%SZ")
+                expiration = datetime.datetime.strptime(
+                    idp_expiry, "%Y-%m-%dT%H:%M:%SZ"
+                )
                 if expiration > datetime.datetime.now():
                     # IDP access token is still valid
                     logging.info("found existing, valid idp access token")
@@ -131,9 +138,9 @@ class Auth:
         """
         os.umask(0)
         fd = os.open(
-            path = self.credentials_file,
-            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            mode=0o600
+            path=self.credentials_file,
+            flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            mode=0o600,
         )
         with open(fd, "w", encoding="utf-8") as fs:
             json.dump(self.config, fs, indent=2, sort_keys=True)
@@ -161,21 +168,21 @@ class Auth:
 
         password = os.environ.get("RIFT_AUTH_PASSWORD")
         if not password:
-            password = getpass.getpass('Password: ')
+            password = getpass.getpass("Password: ")
 
         data = {
-            'client_id': 'minio',
-            'grant_type': 'password',
-            'username': user,
-            'password': password,
-            'client_secret': client_secret,
+            "client_id": "minio",
+            "grant_type": "password",
+            "username": user,
+            "password": password,
+            "client_secret": client_secret,
         }
 
         res = requests.post(
             self.idp_auth_endpoint,
-            data = data,
-            headers = {"Content-Type": "application/x-www-form-urlencoded"},
-            timeout = 60
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=60,
         )
 
         js = res.json()
@@ -250,18 +257,18 @@ class Auth:
             return False
 
         data = {
-          'Version': '2011-06-15',
-          'Action': 'AssumeRoleWithWebIdentity',
-          'DurationSeconds': '86000',
-          'WebIdentityToken': self.config["idp_token"],
+            "Version": "2011-06-15",
+            "Action": "AssumeRoleWithWebIdentity",
+            "DurationSeconds": "86000",
+            "WebIdentityToken": self.config["idp_token"],
         }
 
         res = requests.post(
             self.s3_auth_endpoint,
-            data = data,
-            headers = {"Content-Type": "application/x-www-form-urlencoded"},
-            verify = False,
-            timeout = 60
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            verify=False,
+            timeout=60,
         )
 
         res_xml = xmltodict.parse(res.text)
@@ -296,7 +303,9 @@ class Auth:
         self.config["session_token"] = session_token
         self.config["expiration"] = expiration
 
-        self.expiration_dt = datetime.datetime.strptime(expiration, "%Y-%m-%dT%H:%M:%SZ")
+        self.expiration_dt = datetime.datetime.strptime(
+            expiration, "%Y-%m-%dT%H:%M:%SZ"
+        )
 
         self.save_state()
 
@@ -307,7 +316,7 @@ class Auth:
         Ensures S3 credentials are available.
         Returns True if S3 credentials are found, or False if not.
 
-        This is the method auth object consumers should invoke to 
+        This is the method auth object consumers should invoke to
         ensure authentication credentials are available.
         """
 
@@ -316,7 +325,9 @@ class Auth:
         aws_session_token = os.environ.get("AWS_SESSION_TOKEN")
 
         if None not in (aws_access_key_id, aws_secret_access_key):
-            msg = "found AWS S3 variables in environment; will bypass credentials file\n"
+            msg = (
+                "found AWS S3 variables in environment; will bypass credentials file\n"
+            )
             msg += "to allow use of credential file, please clear these environment variables:"
             msg += " AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN"
             logging.info(msg)

--- a/lib/rift/auth.py
+++ b/lib/rift/auth.py
@@ -227,7 +227,8 @@ class Auth:
         token = self.config.get("idp_token")
         if not token:
             raise RiftError(
-                f"Missing idp_token in authentication state file {self.credentials_file}. "
+                "Missing idp_token in authentication state file "
+                f"{self.credentials_file}. "
                 "Run 'rift auth' first."
             )
         return token
@@ -235,9 +236,10 @@ class Auth:
     # Step 2: Get S3 credentials using token from (1)
     def get_s3_credentials(self):
         """
-        Obtains an S3 credential using an already-obtained OpenID credential, unless
-        an S3 credential is already available in auth object's config, in which case the credential
-        is considered to have already been obtained.
+        Obtains an S3 credential using an already-obtained OpenID credential,
+        unless an S3 credential is already available in auth object's config,
+        in which case the credential is considered to have already been
+        obtained.
 
         Returns True on success, False on failure.
         """
@@ -275,12 +277,18 @@ class Auth:
 
         creds = res_xml.get("AssumeRoleWithWebIdentityResponse")
         if not creds:
-            msg = "S3 credential response missing expected key: AssumeRoleWithWebIdentityResponse"
+            msg = (
+                "S3 credential response missing expected key: "
+                "AssumeRoleWithWebIdentityResponse"
+            )
             raise RiftError(msg)
 
         creds = creds.get("AssumeRoleWithWebIdentityResult")
         if not creds:
-            msg = "S3 credential response missing expected key: AssumeRoleWithWebIdentityResult"
+            msg = (
+                "S3 credential response missing expected key: "
+                "AssumeRoleWithWebIdentityResult"
+            )
             raise RiftError(msg)
 
         creds = creds.get("Credentials")
@@ -328,7 +336,10 @@ class Auth:
             msg = (
                 "found AWS S3 variables in environment; will bypass credentials file\n"
             )
-            msg += "to allow use of credential file, please clear these environment variables:"
+            msg += (
+                "to allow use of credential file, please clear these "
+                "environment variables:"
+            )
             msg += " AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN"
             logging.info(msg)
             self.config["access_key_id"] = aws_access_key_id

--- a/lib/rift/container.py
+++ b/lib/rift/container.py
@@ -31,19 +31,18 @@
 #
 """Module to instanciate container and manage container images."""
 
-import os
 import getpass
 import logging
+import os
 
 from rift import RiftError
 from rift.run import run_command
 
+
 class ContainerRuntime:
     """Handle containers and images."""
-    ARCHS_MAP = {
-        'x86_64': 'amd64',
-        'aarch64': 'arm64'
-    }
+
+    ARCHS_MAP = {"x86_64": "amd64", "aarch64": "arm64"}
 
     def __init__(self, config):
         self.config = config
@@ -59,16 +58,23 @@ class ContainerRuntime:
     def build(self, actionable_pkg, sources_topdir):
         """Execute command to build OCI package container image."""
         cmd = [
-            self.config.get('containers').get('command'),
-            '--root', self.rootdir, 'build',
-            '--arch', self.ARCHS_MAP[actionable_pkg.arch],
-            '--annotation',
+            self.config.get("containers").get("command"),
+            "--root",
+            self.rootdir,
+            "build",
+            "--arch",
+            self.ARCHS_MAP[actionable_pkg.arch],
+            "--annotation",
             f"org.opencontainers.image.version={actionable_pkg.package.version}"
             f"-{actionable_pkg.package.release}",
-            '--annotation', f"org.opencontainers.image.title={actionable_pkg.name}",
-            '--annotation', "org.opencontainers.image.vendir=rift",
-            '--tag', self.tag(actionable_pkg),
-            sources_topdir ]
+            "--annotation",
+            f"org.opencontainers.image.title={actionable_pkg.name}",
+            "--annotation",
+            "org.opencontainers.image.vendir=rift",
+            "--tag",
+            self.tag(actionable_pkg),
+            sources_topdir,
+        ]
         proc = run_command(cmd)
         if proc.returncode:
             raise RiftError(f"Container image build error: exit code {proc.returncode}")
@@ -79,15 +85,19 @@ class ContainerRuntime:
         container.
         """
         cmd = [
-            self.config.get('containers').get('command'),
-            '--root', self.rootdir,
-            'run', '--rm', '-i',
-            '--mount',
+            self.config.get("containers").get("command"),
+            "--root",
+            self.rootdir,
+            "run",
+            "--rm",
+            "-i",
+            "--mount",
             f"type=bind,src={test.command},"
             f"dst=/run/{os.path.basename(test.command)},ro=true",
-            '--arch', self.ARCHS_MAP[actionable_pkg.arch],
+            "--arch",
+            self.ARCHS_MAP[actionable_pkg.arch],
             f"localhost/{self.tag(actionable_pkg)}",
-            f"/run/{os.path.basename(test.command)}"
+            f"/run/{os.path.basename(test.command)}",
         ]
         return run_command(cmd, capture_output=True)
 
@@ -97,10 +107,12 @@ class ContainerRuntime:
         image as OCI archive in the provided path.
         """
         cmd = [
-            self.config.get('containers').get('command'),
-            '--root', self.rootdir,
-            'push', self.tag(actionable_pkg),
-            f"oci-archive:{container_archive.path}:{self.tag(actionable_pkg)}"
+            self.config.get("containers").get("command"),
+            "--root",
+            self.rootdir,
+            "push",
+            self.tag(actionable_pkg),
+            f"oci-archive:{container_archive.path}:{self.tag(actionable_pkg)}",
         ]
         return run_command(cmd)
 
@@ -123,14 +135,14 @@ class ContainerArchive:
         parameters are missing in project configuration or GPG key is not found.
         """
         # GPG parameters not defined in project config, raise RiftError.
-        if self.config is None or self.config.get('gpg') is None:
+        if self.config is None or self.config.get("gpg") is None:
             raise RiftError(
                 "Unable to retrieve GPG configuration, unable to sign OCI "
                 f"archive {self.path}",
             )
 
-        gpg = self.config.get('gpg')
-        keyring = os.path.expanduser(gpg.get('keyring'))
+        gpg = self.config.get("gpg")
+        keyring = os.path.expanduser(gpg.get("keyring"))
 
         # Check gpg_keyring path exists or raise error
         if not os.path.exists(keyring):
@@ -143,38 +155,40 @@ class ContainerArchive:
 
         # If passphrase is defined, add the passphrase to gpg command
         # parameters and make it non-interactive.
-        if gpg.get('passphrase') is not None:
+        if gpg.get("passphrase") is not None:
             gpg_passphrase_args = [
-                '--batch',
-                '--passphrase',
-                gpg.get('passphrase'),
-                '--pinentry-mode',
-                'loopback',
+                "--batch",
+                "--passphrase",
+                gpg.get("passphrase"),
+                "--pinentry-mode",
+                "loopback",
             ]
 
         cmd = [
-            'gpg',
-            '--detach-sign',
-            '--output',
+            "gpg",
+            "--detach-sign",
+            "--output",
             self.signature,
-            '--default-key',
-            gpg.get('key'),
+            "--default-key",
+            gpg.get("key"),
             self.path,
         ]
 
         cmd[2:2] = gpg_passphrase_args
         print(cmd)
         # Run gpg command and raise error in case of failure.
-        proc = run_command(cmd, capture_output=True, merge_out_err=True, env={'GNUPGHOME': keyring})
+        proc = run_command(
+            cmd, capture_output=True, merge_out_err=True, env={"GNUPGHOME": keyring}
+        )
         if proc.returncode:
             raise RiftError(
-                f"Error with signing OCI archive {self.path} command: "
-                f"{proc.out}"
+                f"Error with signing OCI archive {self.path} command: {proc.out}"
             )
 
 
 class ContainerFile:
     """Handle Containerfile with checks and review analysis."""
+
     def __init__(self, config, path):
         self.config = config
         self.path = path
@@ -184,17 +198,17 @@ class ContainerFile:
     @property
     def linter(self):
         """Return linter path or executable name in configuration."""
-        return self.config.get('containers').get('linter')
+        return self.config.get("containers").get("linter")
 
     def _check(self, configdir):
         cmd = [self.linter, self.path]
 
         if configdir:
-            pkg_config = os.path.join(configdir, 'hadolint.yaml')
+            pkg_config = os.path.join(configdir, "hadolint.yaml")
             if os.path.exists(pkg_config):
-                cmd[1:1] = ['--config', pkg_config]
+                cmd[1:1] = ["--config", pkg_config]
 
-        logging.debug('Running OCI linter command: %s', ' '.join(cmd))
+        logging.debug("Running OCI linter command: %s", " ".join(cmd))
         return run_command(cmd, capture_output=True, merge_out_err=True)
 
     def check(self, pkg=None):
@@ -224,12 +238,11 @@ class ContainerFile:
             raise RiftError(f"hadolint returned {result.returncode}: {result.out}")
 
         for line in result.out.splitlines():
-            if line.startswith(self.path + ':'):
-                line = line[len(self.path + ':'):]
+            if line.startswith(self.path + ":"):
+                line = line[len(self.path + ":") :]
                 try:
-                    (linenbr, code, _, txt) = line.split(' ', 3)
-                    review.add_comment(self.path, linenbr,
-                                       code.strip(), txt.strip())
+                    (linenbr, code, _, txt) = line.split(" ", 3)
+                    review.add_comment(self.path, linenbr, code.strip(), txt.strip())
                 except (ValueError, KeyError):
                     pass
 

--- a/lib/rift/graph.py
+++ b/lib/rift/graph.py
@@ -34,19 +34,21 @@
 Module to track dependencies between packages in Rift projects in a graph and
 solve recursive build requirements.
 """
+
+import logging
+import textwrap
 import time
 from collections import namedtuple
-import textwrap
-import logging
 
-from rift.package import ProjectPackages
 from rift import RiftError
+from rift.package import ProjectPackages
 
 BuildRequirement = namedtuple("BuildRequirement", ["package", "reasons"])
 
 
 class PackageDependencyNode:
     """Node in PackagesDependencyGraph."""
+
     def __init__(self, package):
         self.package = package
         self.subpackages = package.subpackages()
@@ -62,14 +64,13 @@ class PackageDependencyNode:
         # Check depends in info.yaml
         if self.package.depends is not None:
             return (
-                node.package.format == self.package.format and
-                node.package.name in self.package.depends
+                node.package.format == self.package.format
+                and node.package.name in self.package.depends
             )
         # If dependencies are not defined in info.yaml, look at build requires
         # and produced subpackages found in spec file.
         return any(
-            build_require in node.subpackages
-            for build_require in self.build_requires
+            build_require in node.subpackages for build_require in self.build_requires
         )
 
     def required_subpackages(self, rdep):
@@ -92,9 +93,7 @@ class PackageDependencyNode:
         """
         if rdep.package.depends is not None:
             return f"depends on {self.package.format}:{self.package.name}"
-        return 'build depends on ' + ', '.join(
-            self.required_subpackages(rdep)
-        )
+        return "build depends on " + ", ".join(self.required_subpackages(rdep))
 
     def draw_label(self):
         """
@@ -103,19 +102,21 @@ class PackageDependencyNode:
         return (
             '<<table border="0" cellborder="0" cellpadding="1"><tr>'
             '<td bgcolor="#555555" align="center">'
-            f"<font color=\"white\">{self.package.format}:{self.package.name}</font>"
-            '</td></tr>'
-            + ''.join(
+            f'<font color="white">{self.package.format}:{self.package.name}</font>'
+            "</td></tr>"
+            + "".join(
                 [
-                    f"<tr><td align=\"center\">{subpackage}</td></tr>"
+                    f'<tr><td align="center">{subpackage}</td></tr>'
                     for subpackage in self.subpackages
                 ]
             )
-            + '</table>>'
+            + "</table>>"
         )
+
 
 class PackagesDependencyGraph:
     """Graph of dependencies between packages in Rift project."""
+
     def __init__(self):
         self.nodes = []
         self.path = None
@@ -135,7 +136,7 @@ class PackagesDependencyGraph:
                         f"{rdep.package.format}:{rdep.package.name}"
                         for rdep in node.rdeps
                     ]
-                )
+                ),
             )
 
     def draw(self, external, packages):
@@ -149,12 +150,12 @@ class PackagesDependencyGraph:
         # cases, there are generally more relations and default dot layout is
         # preferred.
         print(
-            'digraph rift {\n'
+            "digraph rift {\n"
             f"  layout={'dot' if external or packages else 'circo'} \n"
             '  fontname="Helvetica,Arial,sans-serif"\n'
             '  node [fontname="Helvetica,Arial,sans-serif", style=filled, '
-            'fillcolor=white, penwidth=1, fontsize=8, shape=Mrecord, '
-            'height=0.25]\n'
+            "fillcolor=white, penwidth=1, fontsize=8, shape=Mrecord, "
+            "height=0.25]\n"
             '  edge [fontname="Helvetica,Arial,sans-serif", fontsize=6, '
             'fontcolor="#444444"]\n'
         )
@@ -177,7 +178,7 @@ class PackagesDependencyGraph:
         if node in self.represented_nodes:
             return
         print(
-            f"  \"{node.package.format}:{node.package.name}\" "
+            f'  "{node.package.format}:{node.package.name}" '
             f"[ label = {node.draw_label()} ];"
         )
         self.represented_nodes.append(node)
@@ -199,12 +200,10 @@ class PackagesDependencyGraph:
         if packages:
             logging.debug(
                 "Dependency graph represented with this list of packages: %s",
-                str(packages)
+                str(packages),
             )
         else:
-            logging.debug(
-                "Dependency graph represented with all project packages"
-            )
+            logging.debug("Dependency graph represented with all project packages")
         for node in self.nodes:
             # If a subset of packages is specified and node's package is not in
             # this list, skip this node.
@@ -222,9 +221,7 @@ class PackagesDependencyGraph:
         # distinctive color.
         if external:
             for external_dep in self.external_deps:
-                print(
-                    f"  \"{external_dep}\" [fillcolor=orange];"
-                )
+                print(f'  "{external_dep}" [fillcolor=orange];')
 
     def _draw_relations(self, external):
         """
@@ -239,11 +236,11 @@ class PackagesDependencyGraph:
                 if rdep not in self.represented_nodes:
                     continue
                 print(
-                    f"  \"{rdep.package.format}:{rdep.package.name}\" -> "
-                    f"\"{node.package.format}:{node.package.name}\" "
+                    f'  "{rdep.package.format}:{rdep.package.name}" -> '
+                    f'"{node.package.format}:{node.package.name}" '
                     '[ label = "',
                     textwrap.fill(node.rdep_reason(rdep), 20),
-                    '" ];'
+                    '" ];',
                 )
             # If external dependencies have to be represented, draw relations
             # between project packages and these external dependencies.
@@ -252,10 +249,10 @@ class PackagesDependencyGraph:
                     build_require_str = f"{node.package.format}:{build_require}"
                     if build_require_str in self.external_deps:
                         print(
-                            f"  \"{node.package.format}:{node.package.name}\" "
-                            f"-> \"{build_require_str}\";"
+                            f'  "{node.package.format}:{node.package.name}" '
+                            f'-> "{build_require_str}";'
                         )
-        print('}')
+        print("}")
 
     def _dep_index(self, new, result):
         """
@@ -296,16 +293,14 @@ class PackagesDependencyGraph:
         result = []
         logging.debug(
             "%s→ Source package %s:%s must be rebuilt",
-            '  '*depth,
+            "  " * depth,
             node.package.format,
-            node.package.name
+            node.package.name,
         )
-        result.append(
-            BuildRequirement(node.package, [reason])
-        )
+        result.append(BuildRequirement(node.package, [reason]))
 
         # Remove the end of the processing path after the current node
-        del self.path[max(0, depth-1):-1]
+        del self.path[max(0, depth - 1) : -1]
         # Add current node to the processing path
         self.path.append(node)
 
@@ -317,11 +312,11 @@ class PackagesDependencyGraph:
             if rdep in self.path[0:depth]:
                 logging.debug(
                     "%s   ⥀ Loop detected on node %s:%s at depth %d: %s",
-                    '  '*depth,
+                    "  " * depth,
                     rdep.package.format,
                     rdep.package.name,
                     depth,
-                    '→'.join(
+                    "→".join(
                         f"{node.package.format}:{node.package.name}"
                         for node in self.path + [rdep]
                     ),
@@ -330,21 +325,19 @@ class PackagesDependencyGraph:
                 continue
             logging.debug(
                 "%s  Exploring reverse dependency %s:%s",
-                '  '*depth,
+                "  " * depth,
                 rdep.package.format,
-                rdep.package.name
+                rdep.package.name,
             )
             # Iterate over all recursively solved build requirements for this
             # reverse dependency.
-            build_requirements = self._solve(rdep, reason, depth+1)
+            build_requirements = self._solve(rdep, reason, depth + 1)
             for idx, build_requirement in enumerate(build_requirements):
                 found, position = self._dep_index(build_requirements[idx:], result)
                 if found:
                     # Build requirement already present in result, just extend
                     # the build reasons.
-                    result[position].reasons.extend(
-                        build_requirement.reasons
-                    )
+                    result[position].reasons.extend(build_requirement.reasons)
                 elif position == -1:
                     # The recursive build requirements of the new build
                     # requirement are not present in the list, just append the
@@ -363,8 +356,8 @@ class PackagesDependencyGraph:
         self.path = []  # Start with empty path
         for node in self.nodes:
             if (
-                node.package.name == package.name and
-                node.package.format == package.format
+                node.package.name == package.name
+                and node.package.format == package.format
             ):
                 return self._solve(node, "User request")
 
@@ -390,8 +383,9 @@ class PackagesDependencyGraph:
             try:
                 package.load()
             except (RiftError, FileNotFoundError) as err:
-                logging.warning("Skipping package '%s' unable to load: %s",
-                                package.name, err)
+                logging.warning(
+                    "Skipping package '%s' unable to load: %s", package.name, err
+                )
                 continue
             self._insert(package)
         toc = time.perf_counter()
@@ -404,9 +398,9 @@ class PackagesDependencyGraph:
         graph = cls()
         graph.build(
             [
-                package for package in ProjectPackages.list(
-                    config, staff, modules
-                ) if not formats or package.format in formats
+                package
+                for package in ProjectPackages.list(config, staff, modules)
+                if not formats or package.format in formats
             ]
         )
         return graph

--- a/lib/rift/package/__init__.py
+++ b/lib/rift/package/__init__.py
@@ -34,3 +34,10 @@
 
 from rift.package._base import RIFT_SUPPORTED_FORMATS, Package, Test
 from rift.package._project import ProjectPackages
+
+__all__ = [
+    "RIFT_SUPPORTED_FORMATS",
+    "Package",
+    "ProjectPackages",
+    "Test",
+]

--- a/lib/rift/package/__init__.py
+++ b/lib/rift/package/__init__.py
@@ -31,5 +31,6 @@
 #
 
 """Module to handle packages in different formats."""
+
 from rift.package._base import RIFT_SUPPORTED_FORMATS, Package, Test
 from rift.package._project import ProjectPackages

--- a/lib/rift/package/_base.py
+++ b/lib/rift/package/_base.py
@@ -37,26 +37,26 @@ Class to manipulate packages and package tests with Rift.
 import glob
 import logging
 import os
+import re
+import shlex
 from abc import ABC, abstractmethod
 
-import shlex
-import re
 import yaml
 
 from rift import RiftError
 from rift.Config import OrderedLoader
-from rift.utils import message
-from rift.run import run_command
 from rift.repository import ProjectArchRepositories
+from rift.run import run_command
+from rift.utils import message
 
-_META_FILE = 'info.yaml'
-_SOURCES_DIR = 'sources'
-_TESTS_DIR = 'tests'
-_DOC_FILES = ['README', 'README.md', 'README.rst', 'README.txt']
+_META_FILE = "info.yaml"
+_SOURCES_DIR = "sources"
+_TESTS_DIR = "tests"
+_DOC_FILES = ["README", "README.md", "README.rst", "README.txt"]
 
 
 # Rift supported package formats
-RIFT_SUPPORTED_FORMATS = ('rpm', 'oci')
+RIFT_SUPPORTED_FORMATS = ("rpm", "oci")
 
 
 class Package(ABC):
@@ -73,7 +73,7 @@ class Package(ABC):
         self.name = name
         # Check package format. Allow special _virtual format to handle
         # unexisting package (typically package being removed).
-        if _format not in RIFT_SUPPORTED_FORMATS + ('_virtual',):
+        if _format not in RIFT_SUPPORTED_FORMATS + ("_virtual",):
             raise RiftError(f"Unsupported package format {_format}")
         self.format = _format
 
@@ -86,7 +86,7 @@ class Package(ABC):
         self.exclude_archs = None
 
         # Static paths
-        pkgdir = os.path.join(self._config.get('packages_dir'), self.name)
+        pkgdir = os.path.join(self._config.get("packages_dir"), self.name)
         self.dir = self._config.project_path(pkgdir)
         self.sourcesdir = os.path.join(self.dir, _SOURCES_DIR)
         self.testsdir = os.path.join(self.dir, _TESTS_DIR)
@@ -113,7 +113,7 @@ class Package(ABC):
 
     def check(self):
         """Load package and check info."""
-        message('Validate package info...')
+        message("Validate package info...")
         self.check_info()
 
     def _check_generic_info(self):
@@ -155,17 +155,17 @@ class Package(ABC):
         """Return dict of package generic metadata to write in metadata file."""
         data = {}
         if self.module:
-            data['module'] = self.module
+            data["module"] = self.module
         if self.reason:
-            data['reason'] = self.reason
+            data["reason"] = self.reason
         if self.maintainers:
-            data['maintainers'] = self.maintainers
+            data["maintainers"] = self.maintainers
         if self.origin:
-            data['origin'] = self.origin
+            data["origin"] = self.origin
         if self.depends:
-            data['depends'] = self.depends
+            data["depends"] = self.depends
         if self.exclude_archs:
-            data['exclude_archs'] = self.exclude_archs
+            data["exclude_archs"] = self.exclude_archs
         return data
 
     @abstractmethod
@@ -194,28 +194,28 @@ class Package(ABC):
 
         # Write meta information
         data = self._serialize_metadata()
-        with open(self.metafile, 'w', encoding='utf-8') as fyaml:
-            yaml.dump({'package': data}, fyaml, default_flow_style=False)
+        with open(self.metafile, "w", encoding="utf-8") as fyaml:
+            yaml.dump({"package": data}, fyaml, default_flow_style=False)
 
     def _deserialize_generic_metadata(self, data):
         """Set generic package object attribute with values in metadata dict."""
-        self.module = data.get('module')
-        if isinstance(data.get('maintainers'), str):
-            self.maintainers = [data['maintainers']]
+        self.module = data.get("module")
+        if isinstance(data.get("maintainers"), str):
+            self.maintainers = [data["maintainers"]]
         else:
-            self.maintainers = data.get('maintainers')
-        self.reason = data.get('reason')
-        self.origin = data.get('origin')
-        depends = data.get('depends')
+            self.maintainers = data.get("maintainers")
+        self.reason = data.get("reason")
+        self.origin = data.get("origin")
+        depends = data.get("depends")
         if depends is not None:
             if isinstance(depends, str):
                 self.depends = [depends]
             else:
                 self.depends = depends
-        if isinstance(data.get('exclude_archs'), str):
-            self.exclude_archs = [data.get('exclude_archs')]
+        if isinstance(data.get("exclude_archs"), str):
+            self.exclude_archs = [data.get("exclude_archs")]
         else:
-            self.exclude_archs = data.get('exclude_archs', [])
+            self.exclude_archs = data.get("exclude_archs", [])
 
     @abstractmethod
     def _deserialize_specific_metadata(self, data):
@@ -239,10 +239,10 @@ class Package(ABC):
                 raise RiftError(msg)
             infopath = self.metafile
 
-        with open(infopath, encoding='utf-8') as fyaml:
+        with open(infopath, encoding="utf-8") as fyaml:
             data = yaml.load(fyaml, Loader=OrderedLoader)
 
-        data = data.pop('package') or {}
+        data = data.pop("package") or {}
         self._deserialize_metadata(data)
 
         self.check_info()
@@ -264,7 +264,7 @@ class Package(ABC):
 
     def tests(self):
         """An iterator over Test objects for each test files."""
-        testspattern = os.path.join(self.testsdir, '*.sh')
+        testspattern = os.path.join(self.testsdir, "*.sh")
         for testpath in glob.glob(testspattern):
             test = Test(testpath)
             # Skip the test if restricted to other specific package formats.
@@ -300,15 +300,16 @@ class ActionableArchPackage(ABC):
     architecture. This class must be overriden with expected methods for every
     supported package formats.
     """
+
     def __init__(self, package, arch):
         self.name = package.name
         self.buildfile = package.buildfile
         self.config = package._config
         self.package = package
         self.arch = arch
-        self.repos = ProjectArchRepositories(
-            self.config, self.arch
-        ).for_format(self.package.format)
+        self.repos = ProjectArchRepositories(self.config, self.arch).for_format(
+            self.package.format
+        )
 
     @abstractmethod
     def build(self, **kwargs):
@@ -324,7 +325,7 @@ class ActionableArchPackage(ABC):
         provided. Shell will be initialized with these functions before running
         the test.
         """
-        cmd = ''
+        cmd = ""
         if not funcs:
             funcs = {}
         for func, code in funcs.items():
@@ -345,7 +346,7 @@ class ActionableArchPackage(ABC):
         """
 
 
-class Test():
+class Test:
     """
     Wrapper around test scripts or test commands.
 
@@ -353,8 +354,8 @@ class Test():
     specific package formats.
     """
 
-    _LOCAL_PATTERN = '*** RIFT LOCAL ***'
-    _FORMAT_PATTERN = r'\*\*\* RIFT FORMAT (\S+) \*\*\*'
+    _LOCAL_PATTERN = "*** RIFT LOCAL ***"
+    _FORMAT_PATTERN = r"\*\*\* RIFT FORMAT (\S+) \*\*\*"
 
     def __init__(self, command, name=None):
         self.command = command
@@ -370,7 +371,7 @@ class Test():
         Look for special patterns (local or format restrictions) in file header
         and flag the test accordingly.
         """
-        with open(self.command, 'rt', encoding='utf-8') as ftest:
+        with open(self.command, "rt", encoding="utf-8") as ftest:
             data = ftest.read(blocksize)
             if self._LOCAL_PATTERN in data:
                 logging.debug("Test '%s' detected as local", self.name)
@@ -381,5 +382,6 @@ class Test():
             if self.formats:
                 logging.debug(
                     "Test '%s' restricted to specific formats: %s",
-                    self.name, ', '.join(self.formats)
+                    self.name,
+                    ", ".join(self.formats),
                 )

--- a/lib/rift/package/_project.py
+++ b/lib/rift/package/_project.py
@@ -36,8 +36,9 @@ import os
 
 from rift import RiftError
 from rift.package._virtual import PackageVirtual
-from rift.package.rpm import PackageRPM
 from rift.package.oci import PackageOCI
+from rift.package.rpm import PackageRPM
+
 
 class ProjectPackages:
     """
@@ -51,10 +52,13 @@ class ProjectPackages:
         Iterate over PackageBase concrete children instances from 'names' list
         or all packages if list is not provided.
         """
-        pkgs_dir = config.project_path(config.get('packages_dir'))
+        pkgs_dir = config.project_path(config.get("packages_dir"))
         if not names:
-            names = [path for path in os.listdir(pkgs_dir)
-                     if os.path.isdir(os.path.join(pkgs_dir, path))]
+            names = [
+                path
+                for path in os.listdir(pkgs_dir)
+                if os.path.isdir(os.path.join(pkgs_dir, path))
+            ]
 
         for name in names:
             yield from ProjectPackages._get(name, config, staff, modules)
@@ -68,7 +72,7 @@ class ProjectPackages:
         present. Raise RiftError if package directory is present without
         supported package buildfile.
         """
-        pkgdir = os.path.join(config.project_path(config.get('packages_dir')), name)
+        pkgdir = os.path.join(config.project_path(config.get("packages_dir")), name)
         if not os.path.isdir(pkgdir):
             yield PackageVirtual(name, config, staff, modules)
             return  # stop here when directory does not exist
@@ -79,8 +83,10 @@ class ProjectPackages:
                 package_format_found = True
                 yield pkg
         if not package_format_found:
-            raise RiftError(f"Unable to determine format of package {name} due "
-                    f"to missing build file in {pkgdir}")
+            raise RiftError(
+                f"Unable to determine format of package {name} due "
+                f"to missing build file in {pkgdir}"
+            )
 
     @staticmethod
     def get(name, config, staff, modules):

--- a/lib/rift/package/_virtual.py
+++ b/lib/rift/package/_virtual.py
@@ -31,8 +31,8 @@
 #
 """Manage virtual packages."""
 
-from rift.package._base import Package
 from rift import RiftError
+from rift.package._base import Package
 
 
 class PackageVirtual(Package):
@@ -45,7 +45,7 @@ class PackageVirtual(Package):
     """
 
     def __init__(self, name, config, staff, modules):
-        super().__init__(name, config, staff, modules, '_virtual', None)
+        super().__init__(name, config, staff, modules, "_virtual", None)
 
     def add_changelog_entry(self, maintainer, comment, bump):
         """Must not be called on virtual package."""

--- a/lib/rift/package/oci.py
+++ b/lib/rift/package/oci.py
@@ -31,27 +31,28 @@
 #
 """Manage packages in OCI format."""
 
-import os
-import shutil
-import time
-import tempfile
-import tarfile
 import glob
 import logging
+import os
+import shutil
+import tarfile
+import tempfile
+import time
 
 from rift import RiftError
-from rift.Config import _DEFAULT_VARIANT
-from rift.package._base import Package, ActionableArchPackage
 from rift.annex import Annex
+from rift.Config import _DEFAULT_VARIANT
+from rift.container import ContainerArchive, ContainerFile, ContainerRuntime
+from rift.package._base import ActionableArchPackage, Package
 from rift.TestResults import TestCase, TestResults
-from rift.container import ContainerRuntime, ContainerFile, ContainerArchive
-from rift.utils import message, banner
+from rift.utils import banner, message
+
 
 class PackageOCI(Package):
     """Handle rift project package in OCI format."""
 
     def __init__(self, name, config, staff, modules):
-        super().__init__(name, config, staff, modules, 'oci', 'Containerfile')
+        super().__init__(name, config, staff, modules, "oci", "Containerfile")
         self.containerfile = None
         self.version = None
         self.release = None
@@ -61,29 +62,28 @@ class PackageOCI(Package):
     def _serialize_specific_metadata(self):
         """Return dict of format specific metadata to write in metadata file."""
         data = {}
-        data['oci'] = {
-            'version': self.version,
-            'release': self.release
-        }
+        data["oci"] = {"version": self.version, "release": self.release}
         if self.main_source:
-            data['oci']['main_source'] = self.main_source
+            data["oci"]["main_source"] = self.main_source
         if self.source_topdir:
-            data['oci']['source_topdir'] = self.source_topdir
+            data["oci"]["source_topdir"] = self.source_topdir
         return data
 
     def _deserialize_specific_metadata(self, data):
         """Set format specific object attribute with values in metadata dict."""
-        oci = data.get('oci')
+        oci = data.get("oci")
+
         def str_or_none(value):
             """If value is not None, return its string representation."""
             if value is not None:
                 return str(value)
             return value
+
         if oci:
-            self.version = str_or_none(oci.get('version'))
-            self.release = str_or_none(oci.get('release'))
-            self.main_source = oci.get('main_source')
-            self.source_topdir = oci.get('source_topdir')
+            self.version = str_or_none(oci.get("version"))
+            self.release = str_or_none(oci.get("release"))
+            self.main_source = oci.get("main_source")
+            self.source_topdir = oci.get("source_topdir")
 
     def _check_specific_info(self):
         """Check info.yaml OCI specific content is correct."""
@@ -104,7 +104,7 @@ class PackageOCI(Package):
 
         # Check Containerfile
         assert self.containerfile is not None
-        message('Validate Containerfile...')
+        message("Validate Containerfile...")
         self.containerfile.check()
 
     def subpackages(self):
@@ -147,7 +147,7 @@ class ActionableArchPackageOCI(ActionableArchPackage):
 
     def __init__(self, package, arch):
         super().__init__(package, arch)
-        self.tempdir = tempfile.TemporaryDirectory(prefix='rift-container-setup-')
+        self.tempdir = tempfile.TemporaryDirectory(prefix="rift-container-setup-")
         self.runtime = ContainerRuntime(self.config)
 
     @property
@@ -166,21 +166,20 @@ class ActionableArchPackageOCI(ActionableArchPackage):
     def build(self, **kwargs):
         """Build container image of an OCI package."""
         sources_topdir = self._setup_sources()
-        message(f"Building container image '{self.name}' on "
-                f"architecture {self.arch}")
+        message(f"Building container image '{self.name}' on architecture {self.arch}")
         self.runtime.build(self, sources_topdir)
         message("Container image successfully built")
 
     def _setup_sources(self):
         """Prepare build context directory with extracted sources and Containerfile."""
         extracted_archive = None
-        tmp_sourcesdir = Annex(self.config).import_dir(self.package.sourcesdir,
-                                                       force_temp=True)
+        tmp_sourcesdir = Annex(self.config).import_dir(
+            self.package.sourcesdir, force_temp=True
+        )
         if not self.package.sources:
             raise RiftError(f"Unable to find sources for package {self.name}")
         if len(self.package.sources) == 1:
-            _main_source = os.path.join(tmp_sourcesdir.path,
-                                        self.package.sources.pop())
+            _main_source = os.path.join(tmp_sourcesdir.path, self.package.sources.pop())
             self._extract_archive(_main_source)
             extracted_archive = _main_source
         else:
@@ -189,28 +188,31 @@ class ActionableArchPackageOCI(ActionableArchPackage):
                 if self.package.main_source not in self.package.sources:
                     raise RiftError(
                         f"Unable to find main source {self.package.main_source} among "
-                        f"available package sources: {self.package.sources}")
-                _main_source = os.path.join(tmp_sourcesdir.path,
-                                            self.package.main_source)
+                        f"available package sources: {self.package.sources}"
+                    )
+                _main_source = os.path.join(
+                    tmp_sourcesdir.path, self.package.main_source
+                )
                 self._extract_archive(_main_source)
                 extracted_archive = _main_source
             else:
                 # Search archive matching default glob
                 found_sources = glob.glob(
-                    os.path.join(tmp_sourcesdir.path,
-                                 self.default_main_source_glob))
+                    os.path.join(tmp_sourcesdir.path, self.default_main_source_glob)
+                )
                 if len(found_sources) != 1:
                     raise RiftError(
                         "Unable to determine main package source among "
-                        f"available package sources: {self.package.sources}")
+                        f"available package sources: {self.package.sources}"
+                    )
                 self._extract_archive(found_sources[0])
                 extracted_archive = found_sources[0]
         # Determine top dir
-        topdir = os.path.join(self.tempdir.name,
-                              self.package.source_topdir or self.default_source_topdir)
+        topdir = os.path.join(
+            self.tempdir.name, self.package.source_topdir or self.default_source_topdir
+        )
         if not os.path.isdir(topdir):
-            raise RiftError(
-                f"Unable to find package source top directory {topdir}")
+            raise RiftError(f"Unable to find package source top directory {topdir}")
         # Copy all other sources
         for source in self.package.sources:
             _source = os.path.join(tmp_sourcesdir.path, source)
@@ -233,7 +235,7 @@ class ActionableArchPackageOCI(ActionableArchPackage):
                     # compatible with older Python version, fallback without
                     # this argument.
                     try:
-                        _tarball.extract(member, path=self.tempdir.name, filter='data')
+                        _tarball.extract(member, path=self.tempdir.name, filter="data")
                     except TypeError:
                         _tarball.extract(member, path=self.tempdir.name)
         except (tarfile.ReadError, tarfile.CompressionError) as err:
@@ -246,23 +248,22 @@ class ActionableArchPackageOCI(ActionableArchPackage):
         for member in tarball.getmembers():
             if os.path.isabs(member.name):
                 raise RiftError(
-                    f"Source archive contains file {member.name} with absolute "
-                    "path")
+                    f"Source archive contains file {member.name} with absolute path"
+                )
             target = os.path.realpath(os.path.join(self.tempdir.name, member.name))
             if os.path.commonpath([target, self.tempdir.name]) != self.tempdir.name:
                 raise RiftError(
-                    f"Source archive contains file {target} outside file tree")
+                    f"Source archive contains file {target} outside file tree"
+                )
             yield member
 
     def test(self, **kwargs):
         """Execute test in OCI container and return TestResults"""
-        results = TestResults('test')
+        results = TestResults("test")
         banner(f"Starting tests of package {self.name} on architecture {self.arch}")
         tests = list(self.package.tests())
         for test in tests:
-            case = TestCase(
-                test.name, self.name, _DEFAULT_VARIANT, self.arch, 'oci'
-            )
+            case = TestCase(test.name, self.name, _DEFAULT_VARIANT, self.arch, "oci")
             now = time.time()
             message(f"Running test '{case.fullname}' on architecture '{self.arch}'")
             if test.local:
@@ -280,7 +281,7 @@ class ActionableArchPackageOCI(ActionableArchPackage):
     def publish(self, **kwargs):
         """Publish archive of a container in OCI registry."""
         # No notion of staging repository in OCI format, no-op in this case.
-        if kwargs.get('staging', False):
+        if kwargs.get("staging", False):
             return
 
         assert self.repos.path is not None
@@ -291,11 +292,10 @@ class ActionableArchPackageOCI(ActionableArchPackage):
             self.config,
             os.path.join(
                 self.repos.path,
-                f"{self.name}_{self.package.version}-{self.package.release}.{self.arch}.tar"
-            )
+                f"{self.name}_{self.package.version}-{self.package.release}.{self.arch}.tar",
+            ),
         )
         self.runtime.archive(self, container_archive)
-        if kwargs.get('sign', False):
-            logging.info(
-                "Signing OCI archive %s with GPG key", container_archive.path)
+        if kwargs.get("sign", False):
+            logging.info("Signing OCI archive %s with GPG key", container_archive.path)
             container_archive.sign()

--- a/lib/rift/package/rpm.py
+++ b/lib/rift/package/rpm.py
@@ -33,28 +33,29 @@
 
 import logging
 import os
+import platform
 import random
+import re
 import shutil
 import textwrap
 import time
-import re
-import platform
 
 from rift import RiftError
-from rift.package._base import Package, ActionableArchPackage, Test
 from rift.annex import Annex
+from rift.Config import _DEFAULT_VARIANT
 from rift.Mock import Mock
+from rift.package._base import ActionableArchPackage, Package, Test
 from rift.RPM import Spec
 from rift.TestResults import TestCase, TestResults
+from rift.utils import banner, message
 from rift.VM import VM
-from rift.Config import _DEFAULT_VARIANT
-from rift.utils import message, banner
+
 
 class PackageRPM(Package):
     """Handle rift project package in RPM format."""
 
     def __init__(self, name, config, staff, modules):
-        super().__init__(name, config, staff, modules, 'rpm', f"{name}.spec")
+        super().__init__(name, config, staff, modules, "rpm", f"{name}.spec")
 
         # Attributes assigned in load()
         # Extracted from infos.yaml
@@ -68,27 +69,27 @@ class PackageRPM(Package):
         """Return dict of format specific metadata to write in metadata file."""
         data = {}
         if self.rpmnames:
-            data['rpm_names'] = self.rpmnames
+            data["rpm_names"] = self.rpmnames
         if self.ignore_rpms:
-            data['ignore_rpms'] = self.ignore_rpms
+            data["ignore_rpms"] = self.ignore_rpms
         if self.variants:
-            data['variants'] = self.variants
+            data["variants"] = self.variants
         return data
 
     def _deserialize_specific_metadata(self, data):
         """Set format specific object attribute with values in metadata dict."""
-        if isinstance(data.get('rpm_names'), str):
-            self.rpmnames = [data.get('rpm_names')]
+        if isinstance(data.get("rpm_names"), str):
+            self.rpmnames = [data.get("rpm_names")]
         else:
-            self.rpmnames = data.get('rpm_names', [])
-        if isinstance(data.get('ignore_rpms'), str):
-            self.ignore_rpms = [data.get('ignore_rpms')]
+            self.rpmnames = data.get("rpm_names", [])
+        if isinstance(data.get("ignore_rpms"), str):
+            self.ignore_rpms = [data.get("ignore_rpms")]
         else:
-            self.ignore_rpms = data.get('ignore_rpms', [])
-        if isinstance(data.get('variants'), str):
-            self.variants = [data.get('variants')]
+            self.ignore_rpms = data.get("ignore_rpms", [])
+        if isinstance(data.get("variants"), str):
+            self.variants = [data.get("variants")]
         else:
-            self.variants = data.get('variants', [_DEFAULT_VARIANT])
+            self.variants = data.get("variants", [_DEFAULT_VARIANT])
 
     def load(self, infopath=None):
         """Load package metadata, check its content and load RPM spec file with
@@ -96,7 +97,9 @@ class PackageRPM(Package):
         # load infos.yaml with parent class
         super().load(infopath)
         arch_pkg = self.for_arch(platform.machine())
-        self.spec = Spec(self.buildfile, arch_pkg.mock, arch_pkg.repos.all, config=self._config)
+        self.spec = Spec(
+            self.buildfile, arch_pkg.mock, arch_pkg.repos.all, config=self._config
+        )
         self.version = self.spec.version
         self.release = self.spec.release
         self.arch = self.spec.arch
@@ -110,7 +113,7 @@ class PackageRPM(Package):
 
         # Check spec
         assert self.spec is not None
-        message('Validate specfile...')
+        message("Validate specfile...")
         self.spec.check(self)
 
     def subpackages(self):
@@ -136,8 +139,9 @@ class PackageRPM(Package):
         # versions before the actual builds.
         return [
             value.group(1)
-            for value
-            in re.finditer(r"(\S+)( (>|>=|=|<=|<) \S+)?", self.spec.buildrequires)
+            for value in re.finditer(
+                r"(\S+)( (>|>=|=|<=|<) \S+)?", self.spec.buildrequires
+            )
         ]
 
     def add_changelog_entry(self, maintainer, comment, bump):
@@ -156,16 +160,18 @@ class PackageRPM(Package):
         # Format comment.
         # Grab bullet, insert one if not found.
         bullet = "-"
-        match = re.search(r'^([^\s\w])\s', comment, re.UNICODE)
+        match = re.search(r"^([^\s\w])\s", comment, re.UNICODE)
         if match:
             bullet = match.group(1)
         else:
             comment = bullet + " " + comment
 
         if comment.find("\n") == -1:
-            wrapopts = {"subsequent_indent": (len(bullet) + 1) * " ",
-                        "break_long_words": False,
-                        "break_on_hyphens": False}
+            wrapopts = {
+                "subsequent_indent": (len(bullet) + 1) * " ",
+                "break_long_words": False,
+                "break_on_hyphens": False,
+            }
             comment = textwrap.fill(comment, 80, **wrapopts)
 
         logging.info("Adding changelog record for '%s'", author)
@@ -202,7 +208,7 @@ class ActionableArchPackageRPM(ActionableArchPackage):
 
     def __init__(self, package, arch):
         super().__init__(package, arch)
-        self.mock = Mock(self.config, arch, self.config.get('version'))
+        self.mock = Mock(self.config, arch, self.config.get("version"))
 
     def build(self, **kwargs):
         message(f"Building RPM package '{self.name}' on architecture {self.arch}")
@@ -211,47 +217,51 @@ class ActionableArchPackageRPM(ActionableArchPackage):
         mock_repos = self.repos.all
         # If staging is set, append it to the list of repositories in mock build
         # environment.
-        staging = kwargs.get('staging')
+        staging = kwargs.get("staging")
         if staging:
-            mock_repos.append(staging.for_format(
-                self.package.format
-            ).repo.consumables[self.arch])
+            mock_repos.append(
+                staging.for_format(self.package.format).repo.consumables[self.arch]
+            )
 
         with self.mock.lock():
-            message('Preparing Mock environment...')
+            message("Preparing Mock environment...")
             self.mock.init(mock_repos)
 
             message("Building SRPM...")
-            sign = kwargs.get('sign', False)
+            sign = kwargs.get("sign", False)
             srpm = self._build_srpm(sign)
             logging.info("Built: %s", srpm.filepath)
 
             for variant in self.package.variants:
                 message(
                     "Building RPMS"
-                    + (f" variant {variant}" if self.package.has_real_variants() else '')
+                    + (
+                        f" variant {variant}"
+                        if self.package.has_real_variants()
+                        else ""
+                    )
                     + "..."
                 )
                 for rpm in self._build_rpms(srpm, variant, sign):
-                    logging.info('Built: %s', rpm.filepath)
+                    logging.info("Built: %s", rpm.filepath)
 
         message("RPMS successfully built")
 
     def test(self, **kwargs):
         """Execute test and return TestResults"""
 
-        results = TestResults('test')
-        staging = kwargs.get('staging')
+        results = TestResults("test")
+        staging = kwargs.get("staging")
         if staging:
             extra_repos = [
                 staging.for_format(self.package.format).repo.consumables[self.arch]
             ]
         else:
-            extra_repos=[]
+            extra_repos = []
         vm = VM(self.config, self.arch, extra_repos=extra_repos)
 
         if vm.running():
-            raise RiftError('VM is already running')
+            raise RiftError("VM is already running")
 
         message(f"Preparing {self.arch} test environment")
         vm.start(False)
@@ -259,22 +269,22 @@ class ActionableArchPackageRPM(ActionableArchPackage):
         for variant in self.package.variants:
             # Setup repos in VM considering the variant and presence of working
             # repository.
-            repos_args = ''
+            repos_args = ""
             if variant != _DEFAULT_VARIANT:
                 for repo in self.repos.for_variant(variant):
                     repos_args += f"--enablerepo={repo} "
             if self.repos.working is None:
-                repos_args = '--disablerepo=working'
+                repos_args = "--disablerepo=working"
             vm.cmd(f"yum -y -d0 {repos_args} update")
 
             banner(
                 f"Starting tests of package {self.name}"
-                + (f" variant {variant}" if self.package.has_real_variants() else '')
+                + (f" variant {variant}" if self.package.has_real_variants() else "")
                 + f" on architecture {self.arch}"
             )
 
             tests = list(self.package.tests())
-            if not kwargs.get('noauto', False):
+            if not kwargs.get("noauto", False):
                 tests.insert(
                     0,
                     BasicTest(
@@ -282,8 +292,8 @@ class ActionableArchPackageRPM(ActionableArchPackage):
                         self.mock,
                         self.repos.all,
                         variant,
-                        config=self.config
-                    )
+                        config=self.config,
+                    ),
                 )
             for test in tests:
                 case = TestCase(
@@ -302,13 +312,13 @@ class ActionableArchPackageRPM(ActionableArchPackage):
                     message(f"Test '{case.fullname}' on architecture {self.arch}: OK")
                 else:
                     results.add_failure(
-                        case, time.time() - now, out=proc.out,  err=proc.err
+                        case, time.time() - now, out=proc.out, err=proc.err
                     )
                     message(
                         f"Test '{case.fullname}' on architecture {self.arch}: ERROR"
                     )
 
-        if not kwargs.get('noquit', False):
+        if not kwargs.get("noquit", False):
             message(f"Cleaning {self.arch} test environment")
             vm.cmd("poweroff")
             time.sleep(5)
@@ -317,7 +327,7 @@ class ActionableArchPackageRPM(ActionableArchPackage):
         return results
 
     def publish(self, **kwargs):
-        staging = kwargs.get('staging')
+        staging = kwargs.get("staging")
         if staging:
             repo = staging.for_format(self.package.format).repo
         else:
@@ -328,12 +338,12 @@ class ActionableArchPackageRPM(ActionableArchPackage):
         message("Publishing RPMS...")
         self.mock.publish(repo)
 
-        if kwargs.get('updaterepo', True):
+        if kwargs.get("updaterepo", True):
             message("Updating repository...")
             repo.update()
 
     def clean(self, **kwargs):
-        if kwargs.get('noquit', False):
+        if kwargs.get("noquit", False):
             message("Keep environment, VM is running. Use: rift vm connect")
         else:
             self.mock.clean()
@@ -342,14 +352,15 @@ class ActionableArchPackageRPM(ActionableArchPackage):
         """
         Build package source RPM
         """
-        tmpdir = Annex(self.config).import_dir(self.package.sourcesdir,
-                                               force_temp=True)
+        tmpdir = Annex(self.config).import_dir(self.package.sourcesdir, force_temp=True)
 
         # To avoid root_squash issue, also copy the specfile in the temp dir
         tmpspec = os.path.join(tmpdir.path, os.path.basename(self.buildfile))
         shutil.copyfile(self.buildfile, tmpspec)
 
-        srpm = self.mock.build_srpm(tmpspec, tmpdir.path or self.package.sourcesdir, sign)
+        srpm = self.mock.build_srpm(
+            tmpspec, tmpdir.path or self.package.sourcesdir, sign
+        )
         tmpdir.delete()
         return srpm
 
@@ -374,7 +385,9 @@ class BasicTest(Test):
         if pkg.rpmnames:
             rpmnames = pkg.rpmnames
         else:
-            rpmnames = Spec(pkg.buildfile, mock, repos, config=config, variant=variant).pkgnames
+            rpmnames = Spec(
+                pkg.buildfile, mock, repos, config=config, variant=variant
+            ).pkgnames
 
         try:
             for name in pkg.ignore_rpms:
@@ -392,7 +405,7 @@ class BasicTest(Test):
             YUM="yum"
         fi
         i=0
-        for pkg in {' '.join(rpmnames)}; do
+        for pkg in {" ".join(rpmnames)}; do
             i=$(( $i + 1 ))
             echo -e "[Testing '${{pkg}}' (${{i}}/{len(rpmnames)})]"
             rm -rf /var/lib/${{YUM}}/history*

--- a/lib/rift/patches.py
+++ b/lib/rift/patches.py
@@ -33,14 +33,15 @@
 patches.py:
     Package to parse patches files in unified diff format
 """
-import os
-import logging
 
-from unidiff import parse_unidiff
+import logging
+import os
+
 from rift import RiftError
-from rift.package import ProjectPackages
+from rift.Config import Modules, Staff
 from rift.Mock import RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2
-from rift.Config import Staff, Modules
+from rift.package import ProjectPackages
+from unidiff import parse_unidiff
 
 
 def get_packages_from_patch(patch, config, modules, staff):
@@ -56,30 +57,21 @@ def get_packages_from_patch(patch, config, modules, staff):
 
     for patchedfile in patchedfiles:
         modifies_packages = _validate_patched_file(
-            patchedfile,
-            config=config,
-            modules=modules,
-            staff=staff
+            patchedfile, config=config, modules=modules, staff=staff
         )
         if not modifies_packages:
             continue
         for pkg in _patched_file_updated_packages(
-                patchedfile,
-                config=config,
-                modules=modules,
-                staff=staff
-            ):
+            patchedfile, config=config, modules=modules, staff=staff
+        ):
             if pkg not in updated:
-                logging.info('Patch updates package %s[%s]', pkg.name, pkg.format)
+                logging.info("Patch updates package %s[%s]", pkg.name, pkg.format)
                 updated.append(pkg)
         for pkg in _patched_file_removed_packages(
-                patchedfile,
-                config=config,
-                modules=modules,
-                staff=staff
-            ):
+            patchedfile, config=config, modules=modules, staff=staff
+        ):
             if pkg not in removed:
-                logging.info('Patch deletes package %s[%s]', pkg.name, pkg.format)
+                logging.info("Patch deletes package %s[%s]", pkg.name, pkg.format)
                 removed.append(pkg)
 
     return updated, removed
@@ -95,36 +87,36 @@ def _validate_patched_file(patched_file, config, modules, staff):
     filepath = patched_file.path
     names = filepath.split(os.path.sep)
 
-    if filepath == config.get('staff_file'):
+    if filepath == config.get("staff_file"):
         staff = Staff(config)
         staff.load(filepath)
-        logging.info('Staff file is OK.')
+        logging.info("Staff file is OK.")
         return False
 
-    if filepath == config.get('modules_file'):
+    if filepath == config.get("modules_file"):
         modules = Modules(config, staff)
         modules.load(filepath)
-        logging.info('Modules file is OK.')
+        logging.info("Modules file is OK.")
         return False
 
-    if filepath == 'mock.tpl':
-        logging.debug('Ignoring mock template file: %s', filepath)
+    if filepath == "mock.tpl":
+        logging.debug("Ignoring mock template file: %s", filepath)
         return False
 
-    if filepath == '.gitignore':
-        logging.debug('Ignoring git file: %s', filepath)
+    if filepath == ".gitignore":
+        logging.debug("Ignoring git file: %s", filepath)
         return False
 
-    if filepath == 'project.conf':
-        logging.debug('Ignoring project config file: %s', filepath)
+    if filepath == "project.conf":
+        logging.debug("Ignoring project config file: %s", filepath)
         return False
 
-    if filepath == '.gitlab-ci.yml':
-        logging.debug('Ignoring gitlab ci file: %s', filepath)
+    if filepath == ".gitlab-ci.yml":
+        logging.debug("Ignoring gitlab ci file: %s", filepath)
         return False
 
-    if filepath == 'CODEOWNERS':
-        logging.debug('Ignoring gitlab ci file: %s', filepath)
+    if filepath == "CODEOWNERS":
+        logging.debug("Ignoring gitlab ci file: %s", filepath)
         return False
 
     if names[0] == "gitlab-ci":
@@ -134,7 +126,7 @@ def _validate_patched_file(patched_file, config, modules, staff):
     if patched_file.binary:
         raise RiftError(f"Binary file detected: {filepath}")
 
-    if names[0] != config.get('packages_dir'):
+    if names[0] != config.get("packages_dir"):
         raise RiftError(f"Unknown file pattern: {filepath}")
 
     return True
@@ -159,7 +151,7 @@ def _patched_file_updated_packages(patched_file, config, modules, staff):
     pkg = None
 
     if patched_file.is_deleted_file:
-        logging.debug('Ignoring removed file: %s', filepath)
+        logging.debug("Ignoring removed file: %s", filepath)
         return []
 
     # Drop config.get('packages_dir') from list
@@ -173,54 +165,52 @@ def _patched_file_updated_packages(patched_file, config, modules, staff):
     known_file = False
 
     for pkg in pkgs:
-
         # info.yaml
         if fullpath == pkg.metafile:
-            logging.info('Ignoring meta file')
+            logging.info("Ignoring meta file")
             known_file = True
             continue
 
         # README file
         if fullpath in pkg.docfiles:
-            logging.debug('Ignoring documentation file: %s', fullpath)
+            logging.debug("Ignoring documentation file: %s", fullpath)
             known_file = True
             continue
 
         # backup buildfile
         if fullpath == f"{pkg.buildfile}.orig":
-            logging.debug('Ignoring backup buildfile')
+            logging.debug("Ignoring backup buildfile")
             known_file = True
             continue
 
         # buildfile
         if fullpath == pkg.buildfile:
-            logging.info('Detected buildfile file')
+            logging.info("Detected buildfile file")
             known_file = True
 
         # rpmlint config file
         elif names in [RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2]:
-            logging.debug('Detecting rpmlint config file')
+            logging.debug("Detecting rpmlint config file")
             known_file = True
 
         # sources/
         elif fullpath.startswith(pkg.sourcesdir) and len(names) == 2:
-            logging.debug('Detecting source file: %s', names[1])
+            logging.debug("Detecting source file: %s", names[1])
             known_file = True
 
         # tests/
         elif fullpath.startswith(pkg.testsdir):
-            logging.debug('Detecting test script: %s', filepath)
+            logging.debug("Detecting test script: %s", filepath)
             known_file = True
         else:
-            logging.debug("Unknown file pattern %s for package format %s",
-                          filepath, pkg.format)
+            logging.debug(
+                "Unknown file pattern %s for package format %s", filepath, pkg.format
+            )
             continue
         result.append(pkg)
 
     if not known_file:
-        raise RiftError(
-            f"Unknown file pattern in '{pkg.name}' directory: {filepath}"
-        )
+        raise RiftError(f"Unknown file pattern in '{pkg.name}' directory: {filepath}")
 
     return result
 
@@ -235,7 +225,7 @@ def _patched_file_removed_packages(patched_file, config, modules, staff):
     fullpath = config.project_path(filepath)
 
     if not patched_file.is_deleted_file:
-        logging.debug('Ignoring not removed file: %s', filepath)
+        logging.debug("Ignoring not removed file: %s", filepath)
         return []
 
     pkgs = ProjectPackages.get(names[1], config, staff, modules)

--- a/lib/rift/proxy.py
+++ b/lib/rift/proxy.py
@@ -66,6 +66,7 @@ class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
     """
     Threading HTTP server for repository proxy.
     """
+
     # Handle each request in its own daemon thread so long-running RPM downloads
     # do not block other clients and do not prevent process exit.
     daemon_threads = True
@@ -81,6 +82,7 @@ class _TokenAuthRepositoryProxyHandler(BaseHTTPRequestHandler):
     """
     HTTP repository proxy request handler for bearer token protected repositories.
     """
+
     # Advertise a proxy-specific Server header for troubleshooting.
     server_version = "RiftAuthRepoProxy/1.0"
     # Use HTTP/1.1 responses to keep transfer/framing behavior aligned with
@@ -132,7 +134,9 @@ class _TokenAuthRepositoryProxyHandler(BaseHTTPRequestHandler):
         )
 
         try:
-            with urllib.request.urlopen(request, timeout=self.server.runtime.timeout) as response:
+            with urllib.request.urlopen(
+                request, timeout=self.server.runtime.timeout
+            ) as response:
                 self._log_proxy_request(upstream_url, response.getcode())
                 self._send_upstream_response(response)
         except urllib.error.HTTPError as err:
@@ -260,9 +264,7 @@ class AuthenticatedRepositoryProxyRuntime:
         self._config = config
         self._timeout = timeout
         self.repositories = {
-            repo.name: repo
-            for repo in repositories
-            if repo.authenticated()
+            repo.name: repo for repo in repositories if repo.authenticated()
         }
         self.token = None
         self.server = None

--- a/lib/rift/repository/__init__.py
+++ b/lib/rift/repository/__init__.py
@@ -33,3 +33,8 @@
 """Module to manage package repositories in a project."""
 
 from rift.repository._project import ProjectArchRepositories, StagingRepository
+
+__all__ = [
+    "ProjectArchRepositories",
+    "StagingRepository",
+]

--- a/lib/rift/repository/_base.py
+++ b/lib/rift/repository/_base.py
@@ -40,6 +40,7 @@ class ArchRepositoriesBase(ABC):
     Abstract base class to manipulate repositories defined in a project for a
     particular architecture and format.
     """
+
     def __init__(self, working_dir, arch):
         self.working_dir = working_dir
         self.arch = arch
@@ -57,6 +58,7 @@ class StagingRepositoryBase(ABC):
     """
     Abstract base class to manipulate staging repository for a specific format.
     """
+
     @abstractmethod
     def __init__(self, repo):
         self.repo = repo

--- a/lib/rift/repository/_project.py
+++ b/lib/rift/repository/_project.py
@@ -35,9 +35,9 @@
 import logging
 
 from rift import RiftError
-from rift.TempDir import TempDir
-from rift.repository.rpm import ArchRepositoriesRPM, StagingRepositoryRPM
 from rift.repository.oci import ArchRepositoriesOCI
+from rift.repository.rpm import ArchRepositoriesRPM, StagingRepositoryRPM
+from rift.TempDir import TempDir
 
 
 class ProjectArchRepositories:
@@ -46,15 +46,12 @@ class ProjectArchRepositories:
     formats.
     """
 
-    FORMAT_CLASSES = {
-        'rpm': ArchRepositoriesRPM,
-        'oci': ArchRepositoriesOCI
-    }
+    FORMAT_CLASSES = {"rpm": ArchRepositoriesRPM, "oci": ArchRepositoriesOCI}
 
     def __init__(self, config, arch):
         self.config = config
         self.arch = arch
-        self.working_dir = config.get('working_repo', arch=arch)
+        self.working_dir = config.get("working_repo", arch=arch)
 
     def can_publish(self):
         """
@@ -76,20 +73,18 @@ class ProjectArchRepositories:
         """Get concrete repository object for the provided format."""
         if _format not in ProjectArchRepositories.FORMAT_CLASSES:
             raise RiftError(f"Unsupported repository format {_format}")
-        return self.FORMAT_CLASSES[_format](
-            self.config, self.working_dir, self.arch)
+        return self.FORMAT_CLASSES[_format](self.config, self.working_dir, self.arch)
 
 
 class StagingRepository:
     """Handle staging repositories for all supported packages formats."""
-    FORMAT_CLASSES = {
-        'rpm': StagingRepositoryRPM
-    }
+
+    FORMAT_CLASSES = {"rpm": StagingRepositoryRPM}
 
     def __init__(self, config):
         self.config = config
-        logging.info('Creating temporary staging repository')
-        self.stagedir = TempDir('stagedir')
+        logging.info("Creating temporary staging repository")
+        self.stagedir = TempDir("stagedir")
         self.stagedir.create()
         self._repos = {}
         for _format, _class in self.FORMAT_CLASSES.items():

--- a/lib/rift/repository/oci.py
+++ b/lib/rift/repository/oci.py
@@ -34,22 +34,24 @@
 Manage OCI archive repository structure.
 """
 
-import os
 import glob
 import logging
+import os
 
 from rift.repository._base import ArchRepositoriesBase
+
 
 class ArchRepositoriesOCI(ArchRepositoriesBase):
     """
     Manipulate repositories defined in a project for a particular architecture.
     """
+
     def __init__(self, config, working_dir, arch):
         super().__init__(working_dir, arch)
         self.config = config
         self.path = None
         if working_dir:
-            self.path = os.path.join(working_dir, 'oci')
+            self.path = os.path.join(working_dir, "oci")
 
     def ensure_created(self):
         """Make sure OCI archives repository directory exists or create it."""

--- a/lib/rift/repository/rpm.py
+++ b/lib/rift/repository/rpm.py
@@ -34,28 +34,30 @@
 Helper class for YUM repository structure management.
 """
 
-import os
-import logging
-import shutil
 import glob
-import threading
+import logging
+import os
 import platform
-from subprocess import Popen, PIPE, STDOUT, run, CalledProcessError
+import shutil
+import threading
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen, run
 
 from rift import RiftError
+from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS
+from rift.Mock import Mock
 from rift.repository._base import ArchRepositoriesBase, StagingRepositoryBase
 from rift.RPM import RPM, Spec
-from rift.Mock import Mock
 from rift.TempDir import TempDir
-from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS
 
 repo_lock = threading.Lock()
+
 
 class ConsumableRepository:
     """
     Manipulate RPM packages repository to be consumed by dnf/yum and Mock.
     """
-    FILE_SCHEME = 'file://'
+
+    FILE_SCHEME = "file://"
 
     def __init__(
         self,
@@ -71,10 +73,10 @@ class ConsumableRepository:
         self.priority = priority
         if options is None:
             options = {}
-        self.auth = options.get('auth')
-        self.module_hotfixes = options.get('module_hotfixes')
-        self.excludepkgs = options.get('excludepkgs')
-        self.proxy = options.get('proxy', default_proxy)
+        self.auth = options.get("auth")
+        self.module_hotfixes = options.get("module_hotfixes")
+        self.excludepkgs = options.get("excludepkgs")
+        self.proxy = options.get("proxy", default_proxy)
         if variants is None:
             self.variants = _DEFAULT_REPOS_VARIANTS
         else:
@@ -82,11 +84,11 @@ class ConsumableRepository:
 
     def is_file(self):
         """True if repository URL looks like a file URI."""
-        return self.url.startswith(self.FILE_SCHEME) or self.url.startswith('/')
+        return self.url.startswith(self.FILE_SCHEME) or self.url.startswith("/")
 
     def authenticated(self):
         """True if repository is remote and uses idp_token auth."""
-        return (not self.is_file()) and self.auth == 'idp_token'
+        return (not self.is_file()) and self.auth == "idp_token"
 
     @property
     def path(self):
@@ -97,7 +99,7 @@ class ConsumableRepository:
         if not self.is_file():
             raise RiftError("Unable to return path of remote repository")
         if self.url.startswith(self.FILE_SCHEME):
-            return self.url[len(self.FILE_SCHEME):]
+            return self.url[len(self.FILE_SCHEME) :]
         return self.url
 
     def generic_url(self, arch):
@@ -125,10 +127,10 @@ class LocalRepository:
     def __init__(self, path, config, name=None, options=None):
         self.path = os.path.realpath(path)
         self.config = config
-        self.srpms_dir = os.path.join(self.path, 'SRPMS')
+        self.srpms_dir = os.path.join(self.path, "SRPMS")
         if options is None:
             options = {}
-        self.createrepo = config.get('createrepo', _DEFAULT_REPO_CMD)
+        self.createrepo = config.get("createrepo", _DEFAULT_REPO_CMD)
 
         self.consumables = {
             arch: ConsumableRepository(
@@ -137,16 +139,16 @@ class LocalRepository:
                 name=name or os.path.basename(self.path),
                 priority=1,  # top priority for local repositories
                 options=options,
-                default_proxy=config.get('proxy')
+                default_proxy=config.get("proxy"),
             )
-            for arch in self.config.get('arch')
+            for arch in self.config.get("arch")
         }
 
     def rpms_dir(self, arch):
         """
         Path to RPMS directory for the given architecture.
         """
-        if arch not in self.config.get('arch'):
+        if arch not in self.config.get("arch"):
             raise RiftError(
                 "Unable to get repository RPM directory for unsupported "
                 f"architecture {arch}"
@@ -165,7 +167,7 @@ class LocalRepository:
                 if not os.path.exists(path):
                     os.mkdir(path)
         # Create all architectures RPM sub-directories and their repodata.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             path = self.rpms_dir(arch)
             # Add lock to avoid race condition between arch build threads on
             # existence test and mkdir().
@@ -179,11 +181,12 @@ class LocalRepository:
         Update the repository metadata for SRPMS repository and all
         architectures RPMS repositories.
         """
+
         def run_update(path):
             # Add lock to avoid conflicts between parallel runs of createrepo.
             with repo_lock:
                 with Popen(
-                    [self.createrepo, '-q', '--update', path],
+                    [self.createrepo, "-q", "--update", path],
                     stdout=PIPE,
                     stderr=STDOUT,
                     universal_newlines=True,
@@ -193,7 +196,7 @@ class LocalRepository:
                         raise RiftError(stdout)
 
         run_update(self.srpms_dir)
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             run_update(self.rpms_dir(arch))
 
     def search(self, name):
@@ -204,13 +207,11 @@ class LocalRepository:
         packages and found in the repository.
         """
         src_rpms = []
-        logging.debug(
-            'Searching for package %s in repository %s', name, self.path
-        )
-        for srcrpm_p in glob.glob(os.path.join(self.srpms_dir, '*.src.rpm')):
+        logging.debug("Searching for package %s in repository %s", name, self.path)
+        for srcrpm_p in glob.glob(os.path.join(self.srpms_dir, "*.src.rpm")):
             src_rpm = RPM(srcrpm_p)
             if src_rpm.name == name:
-                logging.debug('Source package %s found: %s', name, srcrpm_p)
+                logging.debug("Source package %s found: %s", name, srcrpm_p)
                 src_rpms.append(src_rpm)
 
         bin_rpm_names = set()
@@ -221,11 +222,11 @@ class LocalRepository:
             tmp_dir = TempDir()
             tmp_dir.create()
             cmd = [
-                'rpm',
-                '-iv',
-                '--define',
+                "rpm",
+                "-iv",
+                "--define",
                 f"_topdir {tmp_dir.path}",
-                src_rpm.filepath
+                src_rpm.filepath,
             ]
             try:
                 run(cmd, check=True)
@@ -233,7 +234,7 @@ class LocalRepository:
                 raise RiftError(err) from err
             # Parse spec file
             spec = Spec(
-                os.path.join(tmp_dir.path, 'SPECS', f"{src_rpm.name}.spec"),
+                os.path.join(tmp_dir.path, "SPECS", f"{src_rpm.name}.spec"),
                 Mock(self.config, platform.machine()),
                 ArchRepositoriesRPM(self.config, None, platform.machine()).all,
             )
@@ -243,23 +244,17 @@ class LocalRepository:
             # duplicates)
             bin_rpm_names |= set(spec.pkgnames)
 
-        logging.debug(
-            'Binary built by source package %s: %s', name, bin_rpm_names
-        )
+        logging.debug("Binary built by source package %s: %s", name, bin_rpm_names)
 
         # Search all binary RPMs whose name match packages names extracted from
         # specs.
         bin_pkgs = []
 
-        for arch in self.config.get('arch'):
-            for bin_rpm_p in glob.glob(
-                    os.path.join(self.rpms_dir(arch), '*.rpm')
-                ):
+        for arch in self.config.get("arch"):
+            for bin_rpm_p in glob.glob(os.path.join(self.rpms_dir(arch), "*.rpm")):
                 bin_rpm = RPM(bin_rpm_p)
                 if bin_rpm.name in bin_rpm_names:
-                    logging.debug(
-                        'Binary package %s found: %s', name, bin_rpm_p
-                    )
+                    logging.debug("Binary package %s found: %s", name, bin_rpm_p)
                     bin_pkgs.append(bin_rpm)
 
         return src_rpms + bin_pkgs
@@ -269,19 +264,19 @@ class LocalRepository:
         Copy RPM file pointed `rpm' into the repository, in the correct
         subdirectory based on RPM type and architecture.
         """
+
         def add_bin_arch(arch):
-            logging.debug(
-                "Adding %s to repo %s", rpm.filepath, self.rpms_dir(arch)
-            )
+            logging.debug("Adding %s to repo %s", rpm.filepath, self.rpms_dir(arch))
             # rpms_dir already points to architecture directory
             shutil.copy(rpm.filepath, self.rpms_dir(arch))
+
         if rpm.is_source:
             logging.debug("Adding %s to repo %s", rpm.filepath, self.srpms_dir)
             shutil.copy(rpm.filepath, self.srpms_dir)
         else:
             # Add noarch binary package in all architectures repositories
-            if rpm.arch == 'noarch':
-                for arch in self.config.get('arch'):
+            if rpm.arch == "noarch":
+                for arch in self.config.get("arch"):
                     add_bin_arch(arch)
             else:
                 add_bin_arch(rpm.arch)
@@ -296,6 +291,7 @@ class ArchRepositoriesRPM(ArchRepositoriesBase):
     """
     Manipulate repositories defined in a project for a particular architecture.
     """
+
     def __init__(self, config, working_dir, arch):
         super().__init__(working_dir, arch)
         self.working = None
@@ -304,24 +300,22 @@ class ArchRepositoriesRPM(ArchRepositoriesBase):
             self.working = LocalRepository(
                 path=self.working_dir,
                 config=config,
-                name='working',
-                options={
-                    "module_hotfixes": "true"
-                },
+                name="working",
+                options={"module_hotfixes": "true"},
             )
             self.working.create()
         self.supplementaries = []
-        repos = config.get('repos', arch=arch)
+        repos = config.get("repos", arch=arch)
         if repos:
             for name, data in repos.items():
                 self.supplementaries.append(
                     ConsumableRepository(
-                        data['url'],
+                        data["url"],
                         name=name,
-                        priority=data.get('priority'),
+                        priority=data.get("priority"),
                         options=data,
-                        default_proxy=config.get('proxy'),
-                        variants=data.get('variants'),
+                        default_proxy=config.get("proxy"),
+                        variants=data.get("variants"),
                     )
                 )
 
@@ -333,12 +327,8 @@ class ArchRepositoriesRPM(ArchRepositoriesBase):
         defined).
         """
         return (
-            (
-                [self.working.consumables[self.arch]]
-                if self.working is not None
-                else []
-            ) + self.supplementaries
-        )
+            [self.working.consumables[self.arch]] if self.working is not None else []
+        ) + self.supplementaries
 
     def for_variant(self, variant):
         """
@@ -368,14 +358,14 @@ class StagingRepositoryRPM(StagingRepositoryBase):
     """Staging repository for RPM format"""
 
     def __init__(self, config, stagedir):
-        path = os.path.join(stagedir, 'rpm')
+        path = os.path.join(stagedir, "rpm")
         os.mkdir(path)
         super().__init__(
             LocalRepository(
                 path=path,
                 config=config,
-                name='staging',
-                options={'module_hotfixes': "true"},
+                name="staging",
+                options={"module_hotfixes": "true"},
             )
         )
         self.repo.create()

--- a/lib/rift/run.py
+++ b/lib/rift/run.py
@@ -35,15 +35,14 @@ Function to run a command with possibility to capture output while streaming
 live output on stdout/stderr.
 """
 
-import sys
-import io
 import collections
+import io
 import selectors
 import subprocess
+import sys
 
-RunResult = collections.namedtuple(
-    'RunResult', ['returncode', 'out', 'err']
-)
+RunResult = collections.namedtuple("RunResult", ["returncode", "out", "err"])
+
 
 def _handle_process_output(process, capture_output, live_output, merge_out_err):
     """Handle process output until it is terminated."""
@@ -63,6 +62,7 @@ def _handle_process_output(process, capture_output, live_output, merge_out_err):
             buf_out.write(line)
         if live_output:
             sys.stdout.write(line)
+
     def handle_stderr_line(line):
         if capture_output:
             buf_err.write(line)
@@ -72,6 +72,7 @@ def _handle_process_output(process, capture_output, live_output, merge_out_err):
     # Process output event handlers
     def handle_stdout_event(stream):
         handle_stdout_line(stream.readline())
+
     def handle_stderr_event(stream):
         handle_stderr_line(stream.readline())
 
@@ -105,13 +106,13 @@ def _handle_process_output(process, capture_output, live_output, merge_out_err):
 
 
 def run_command(
-        cmd,
-        live_output=True,
-        capture_output=False,
-        merge_out_err=False,
-        manage_output=True,
-        **kwargs
-    ):
+    cmd,
+    live_output=True,
+    capture_output=False,
+    merge_out_err=False,
+    manage_output=True,
+    **kwargs,
+):
     """
     Run a command and return a RunResult named tuple. When live_output is True,
     command stdout/stderr are redirected to current process stdout/stderr. When
@@ -141,9 +142,8 @@ def run_command(
         stdout=channel,
         stderr=channel,
         universal_newlines=True,
-        **kwargs
+        **kwargs,
     ) as process:
-
         if manage_output and (capture_output or live_output):
             # Handle process output
             buf_out, buf_err = _handle_process_output(

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -211,7 +211,7 @@ class RepoSyncIndexed(RepoSyncBase):
         if self.patterns.include:
             match_include = False
             for pattern in self.patterns.include:
-                if not re.match(pattern, relpath) is None:
+                if re.match(pattern, relpath) is not None:
                     match_include = True
                     break
             if not match_include:
@@ -222,7 +222,7 @@ class RepoSyncIndexed(RepoSyncBase):
 
         # Check file does not match any exclude pattern.
         for pattern in self.patterns.exclude:
-            if not re.search(pattern, relpath) is None:
+            if re.search(pattern, relpath) is not None:
                 logging.debug(
                     "Skipping file %s which matches exclude pattern %s",
                     relpath,
@@ -242,7 +242,7 @@ class RepoSyncIndexed(RepoSyncBase):
                 if skip_repodata and filename.startswith("repodata"):
                     continue
                 path = os.path.join(root, filename)
-                if not path in self.indexed_files:
+                if path not in self.indexed_files:
                     self.log_write(f"rm {path}")
                     logging.info("Removing unindexed file %s", path)
                     os.remove(path)

--- a/lib/rift/sync.py
+++ b/lib/rift/sync.py
@@ -33,56 +33,55 @@
 Synchronize remote repositories.
 """
 
-import os
-import time
-from datetime import datetime
-import shlex
-import subprocess
-import urllib
-import tempfile
-import glob
-import shutil
-import re
 import collections
+import glob
 import logging
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib
+from datetime import datetime
 
 import dnf
 
+from rift import RiftError
 from rift.TempDir import TempDir
 from rift.utils import download_file, setup_dl_opener
-from rift import RiftError
 
-SyncPatterns = collections.namedtuple('SyncPatterns', ['include', 'exclude'])
+SyncPatterns = collections.namedtuple("SyncPatterns", ["include", "exclude"])
 
 
 class RepoSyncBase:
     """Common parent to all RepoSync* classes."""
 
     def __init__(
-            self,
-            config,
-            name,
-            output,
-            sync,
-            max_size=None,
-            retries=0,
-            enable_log_file=False,
-            arch=None,
+        self,
+        config,
+        name,
+        output,
+        sync,
+        max_size=None,
+        retries=0,
+        enable_log_file=False,
+        arch=None,
     ):
         self.config = config
         self.name = name
-        subdir = sync.get('subdir', '').lstrip('/')
+        subdir = sync.get("subdir", "").lstrip("/")
         if arch is not None:
             self.output = os.path.join(output, self.name, subdir, arch)
         else:
             self.output = os.path.join(output, self.name, subdir)
-        self.source = urllib.parse.urlparse(os.path.join(sync['source'], subdir))
+        self.source = urllib.parse.urlparse(os.path.join(sync["source"], subdir))
         self.logfile = os.path.join(
-            output,
-            f"sync_{name}_{datetime.now().strftime('%Y-%m-%d_%H:%M')}.log"
+            output, f"sync_{name}_{datetime.now().strftime('%Y-%m-%d_%H:%M')}.log"
         )
         self._logfh = None  # Initialized in _log_open()
-        self.patterns = SyncPatterns(sync['include'], sync['exclude'])
+        self.patterns = SyncPatterns(sync["include"], sync["exclude"])
         self.max_size = max_size
         self.retries = retries
         self.enable_log_file = enable_log_file
@@ -98,7 +97,7 @@ class RepoSyncBase:
         and call _run() method on concrete class.
         """
         tic = time.perf_counter()
-        setup_dl_opener(self.config.get('proxy'), self.config.get('noproxy'))
+        setup_dl_opener(self.config.get("proxy"), self.config.get("noproxy"))
         self._ensure_repo_dir()
         self._run()
         self._log_close()
@@ -113,14 +112,14 @@ class RepoSyncBase:
 
     def _log_open(self):
         if self.enable_log_file:
-            self._logfh = open(self.logfile, 'w+', encoding='utf-8')
+            self._logfh = open(self.logfile, "w+", encoding="utf-8")
 
     def log_write(self, entry):
         """Add entry message in synchronizer log file."""
         if self.enable_log_file:
             if self._logfh is None:
                 self._log_open()
-            self._logfh.write(entry + '\n')
+            self._logfh.write(entry + "\n")
 
     def _log_close(self):
         if self._logfh is not None:
@@ -138,49 +137,44 @@ class RepoSyncLftp(RepoSyncBase):
     """Synchronize remote repositories with LFTP."""
 
     def __init__(
-            self,
-            config,
-            name,
-            output,
-            sync,
-            max_size=None,
-            retries=0,
-            enable_log_file=False,
-            arch=None,
+        self,
+        config,
+        name,
+        output,
+        sync,
+        max_size=None,
+        retries=0,
+        enable_log_file=False,
+        arch=None,
     ):
-        super().__init__(config, name, output, sync, max_size, retries, enable_log_file, arch)
-        self.include_arg = ' '.join(
+        super().__init__(
+            config, name, output, sync, max_size, retries, enable_log_file, arch
+        )
+        self.include_arg = " ".join(
             [f"--include={pattern}" for pattern in self.patterns.include]
         )
-        self.exclude_arg = ' '.join(
+        self.exclude_arg = " ".join(
             [f"--exclude={pattern}" for pattern in self.patterns.exclude]
         )
 
     @staticmethod
     def _cmd_str(cmd):
         """Transform a list of command arguments into a quoted string."""
-        return ' '.join([shlex.quote(arg) for arg in cmd])
+        return " ".join([shlex.quote(arg) for arg in cmd])
 
     def _run(self):
         """Run repository synchronization with LFTP."""
-        log_part = (
-            f"--log {self.logfile}"
-            if self.enable_log_file
-            else ""
-        )
+        log_part = f"--log {self.logfile}" if self.enable_log_file else ""
         cmd = [
-            'lftp',
+            "lftp",
             self.base_url,
-            '-e',
+            "-e",
             "set ssl:verify-certificate off; mirror --no-empty-dirs ",
             f"{self.include_arg} {self.exclude_arg} --delete",
             f"{log_part} {self.source.path} {self.output} --delete",
             "; quit",
         ]
-        logging.debug(
-            "running synchronization command: %s",
-            self._cmd_str(cmd)
-        )
+        logging.debug("running synchronization command: %s", self._cmd_str(cmd))
         try:
             subprocess.run(cmd, check=True)
         except subprocess.CalledProcessError as err:
@@ -197,17 +191,19 @@ class RepoSyncIndexed(RepoSyncBase):
     """
 
     def __init__(
-            self,
-            config,
-            name,
-            output,
-            sync,
-            max_size=None,
-            retries=0,
-            enable_log_file=False,
-            arch=None,
+        self,
+        config,
+        name,
+        output,
+        sync,
+        max_size=None,
+        retries=0,
+        enable_log_file=False,
+        arch=None,
     ):
-        super().__init__(config, name, output, sync, max_size, retries, enable_log_file, arch)
+        super().__init__(
+            config, name, output, sync, max_size, retries, enable_log_file, arch
+        )
         self.indexed_files = []
 
     def _relpath_matches(self, relpath):
@@ -220,8 +216,7 @@ class RepoSyncIndexed(RepoSyncBase):
                     break
             if not match_include:
                 logging.debug(
-                    "Skipping file %s which does not match any include pattern",
-                    relpath
+                    "Skipping file %s which does not match any include pattern", relpath
                 )
                 return False
 
@@ -244,7 +239,7 @@ class RepoSyncIndexed(RepoSyncBase):
         """
         for root, dirs, files in os.walk(self.output, topdown=False):
             for filename in files:
-                if skip_repodata and filename.startswith('repodata'):
+                if skip_repodata and filename.startswith("repodata"):
                     continue
                 path = os.path.join(root, filename)
                 if not path in self.indexed_files:
@@ -252,7 +247,7 @@ class RepoSyncIndexed(RepoSyncBase):
                     logging.info("Removing unindexed file %s", path)
                     os.remove(path)
             for dirname in dirs:
-                if skip_repodata and dirname.startswith('repodata'):
+                if skip_repodata and dirname.startswith("repodata"):
                     continue
                 path = os.path.join(root, dirname)
                 if not os.listdir(path):
@@ -271,29 +266,31 @@ class RepoSyncEpel(RepoSyncIndexed):
     PUB_ROOT = "/pub/epel"
 
     def __init__(
-            self,
-            config,
-            name,
-            output,
-            sync,
-            max_size=None,
-            retries=0,
-            enable_log_file=False,
-            arch=None,
+        self,
+        config,
+        name,
+        output,
+        sync,
+        max_size=None,
+        retries=0,
+        enable_log_file=False,
+        arch=None,
     ):
-        super().__init__(config, name, output, sync, max_size, retries, enable_log_file, arch)
+        super().__init__(
+            config, name, output, sync, max_size, retries, enable_log_file, arch
+        )
         self.pub_url = f"{self.base_url}{self.PUB_ROOT}"
 
     def _process_line(self, line):
         """Process one EPEL files index line."""
         try:
-            (timestamp_s, ftype, _, relpath) = line.split('\t')
+            (timestamp_s, ftype, _, relpath) = line.split("\t")
         except ValueError:
             # Ignore all lines outside [Files] section with less than 4
             # values separated with tabs
             logging.debug("Skipping non-file line '%s'", line)
             return
-        if ftype != 'f':
+        if ftype != "f":
             logging.debug("Skipping filetype '%s' for path %s", ftype, relpath)
             return
         # Prefix filepath with EPEL public root directory
@@ -308,7 +305,7 @@ class RepoSyncEpel(RepoSyncIndexed):
 
         # To check against include/exclude pattern, use path relative to
         # repository source URL.
-        relpath = abspath[len(self.source.path):].lstrip('/')
+        relpath = abspath[len(self.source.path) :].lstrip("/")
 
         # Check relative path against include/exclude pattern
         if not self._relpath_matches(relpath):
@@ -355,7 +352,7 @@ class RepoSyncEpel(RepoSyncIndexed):
         """Run EPEL repository synchronization."""
         # Download EPEL files index in temporary file
         with tempfile.NamedTemporaryFile(
-            mode='r', prefix='rift-epel-filelist-'
+            mode="r", prefix="rift-epel-filelist-"
         ) as tmp_file:
             filelist_url = f"{self.pub_url}/fullfiletimelist-epel"
             logging.debug("Downloading EPEL files index %s", filelist_url)
@@ -363,7 +360,6 @@ class RepoSyncEpel(RepoSyncIndexed):
                 download_file(filelist_url, tmp_file.name, self.max_size, self.retries)
             except RiftError as err:
                 logging.warning("Download failed, skipping entry: %s", str(err))
-
 
             # Open synchronization log file
             logging.debug("Creating synchronization log file %s", self.logfile)
@@ -382,7 +378,7 @@ class RepoSyncDnf(RepoSyncIndexed):
     def _process_package(self, package):
         """Process one package found in DNF repository."""
 
-        relpath = package.remote_location()[len(self.source.geturl()):].lstrip('/')
+        relpath = package.remote_location()[len(self.source.geturl()) :].lstrip("/")
 
         # Check relative path against include/exclude pattern
         if not self._relpath_matches(relpath):
@@ -429,9 +425,7 @@ class RepoSyncDnf(RepoSyncIndexed):
         base.conf.cachedir = dnf_metadata_cache_dir.path
 
         # Add repository in runtime DNF configuration
-        base.repos.add_new_repo(
-            self.name, base.conf, baseurl=[self.source.geturl()]
-        )
+        base.repos.add_new_repo(self.name, base.conf, baseurl=[self.source.geturl()])
         try:
             base.fill_sack(load_system_repo=False)
         except dnf.exceptions.RepoError as err:
@@ -453,25 +447,28 @@ class RepoSyncDnf(RepoSyncIndexed):
         self._clean_output(skip_repodata=True)
 
         # Copy repodata directory from cache
-        cached_repodata_dirs = glob.glob(f"{dnf_metadata_cache_dir.path}/"
-                                         f"{self.name}-*/repodata")
+        cached_repodata_dirs = glob.glob(
+            f"{dnf_metadata_cache_dir.path}/{self.name}-*/repodata"
+        )
         # Check there is only one result.
         try:
             assert len(cached_repodata_dirs) == 1
         except AssertionError as err:
-            raise RiftError("Unexpected number of repodata directory in DNF "
-                            f"cache: {cached_repodata_dirs}") from err
+            raise RiftError(
+                "Unexpected number of repodata directory in DNF "
+                f"cache: {cached_repodata_dirs}"
+            ) from err
 
         # Remove repodata destination directory, if existing
         repodata = os.path.join(self.output, "repodata")
         if os.path.exists(repodata):
-            logging.info("Removing existing repository metadata %s",
-                         repodata)
+            logging.info("Removing existing repository metadata %s", repodata)
             shutil.rmtree(repodata)
 
         # Copy new repodata downloaded in DNF metadata cache temporary directory
-        logging.info("Copying new cached repository metadata %s",
-                     cached_repodata_dirs[0])
+        logging.info(
+            "Copying new cached repository metadata %s", cached_repodata_dirs[0]
+        )
         shutil.copytree(cached_repodata_dirs[0], repodata)
 
         # Remove DNF metadata cache temporary directory
@@ -480,24 +477,32 @@ class RepoSyncDnf(RepoSyncIndexed):
 
 class RepoSyncFactory:
     """Factory class for all implementations of RepoSync."""
+
     METHODS = {
-        'lftp': RepoSyncLftp,
-        'epel': RepoSyncEpel,
-        'dnf':  RepoSyncDnf,
+        "lftp": RepoSyncLftp,
+        "epel": RepoSyncEpel,
+        "dnf": RepoSyncDnf,
     }
 
     @staticmethod
     def check_valid_method(method):
         """Check given method is supported or raise RiftError"""
         if method not in RepoSyncFactory.METHODS:
-            raise RiftError(
-                f"Unsupported repository synchronization method {method}"
-            )
+            raise RiftError(f"Unsupported repository synchronization method {method}")
 
     @staticmethod
-    def get(config, name, output, sync, max_size=None, retries=0, enable_log_file=False, arch=None):
+    def get(
+        config,
+        name,
+        output,
+        sync,
+        max_size=None,
+        retries=0,
+        enable_log_file=False,
+        arch=None,
+    ):
         """Return the concrete RepoSync* class corresponding to the method."""
-        RepoSyncFactory.check_valid_method(sync['method'])
-        return RepoSyncFactory.METHODS[sync['method']](
+        RepoSyncFactory.check_valid_method(sync["method"])
+        return RepoSyncFactory.METHODS[sync["method"]](
             config, name, output, sync, max_size, retries, enable_log_file, arch
         )

--- a/lib/rift/threads.py
+++ b/lib/rift/threads.py
@@ -32,14 +32,13 @@
 
 """Threads classes and utilities to build for architectures in parallel."""
 
+import contextlib
+import io
 import sys
 import threading
-import contextlib
 import traceback
-import io
 
 from rift.TestResults import TestResults
-
 
 # Python provides standards context managers contextlib.redirect_{stdout,stderr}
 # but they are not thread-safe unfortunately. For redirecting threads
@@ -49,8 +48,10 @@ from rift.TestResults import TestResults
 #   default process stdout/stderr
 # - thread-safe context manager which sets up a thread local stream.
 
+
 class _ThreadLocalStream:
     """Rift stdout/stderr proxies, to support threads local buffering."""
+
     def __init__(self, default):
         # Store the original global stream (real sys.stdout / sys.stderr)
         self._default = default
@@ -119,10 +120,11 @@ def redirect_output_threadsafe(output):
 
 class RiftThread(threading.Thread):
     """Base thread for Rift parallel processing"""
+
     def __init__(self, target, name, args):
         # Initializing the Thread class
         super().__init__(None, target, name, args=args)
-        self.output = io.StringIO()   # output buffer, for stdout/stderr
+        self.output = io.StringIO()  # output buffer, for stdout/stderr
         self.results = TestResults()  # build/validate tests results
 
     def run(self):

--- a/lib/rift/utils.py
+++ b/lib/rift/utils.py
@@ -33,15 +33,15 @@
 Set of utilities used in multiple Rift modules.
 """
 
+import logging
 import os
 import shutil
-import urllib
-import logging
 import time
-
+import urllib
 from datetime import datetime, timezone
 
 from rift import RiftError
+
 
 def message(msg):
     """
@@ -49,11 +49,13 @@ def message(msg):
     """
     print(f"> {msg}")
 
+
 def banner(title):
     """
     helper function to print a banner
     """
     print(f"** {title} **")
+
 
 def download_file(url, output, max_size=None, retries=0, bearer_token=None):
     """
@@ -71,7 +73,7 @@ def download_file(url, output, max_size=None, retries=0, bearer_token=None):
 
     req = urllib.request.Request(url)
     if bearer_token:
-        req.add_header('Authorization', f'Bearer {bearer_token}')
+        req.add_header("Authorization", f"Bearer {bearer_token}")
 
     for attempt in range(retries + 1):
         try:
@@ -79,17 +81,17 @@ def download_file(url, output, max_size=None, retries=0, bearer_token=None):
                 with urllib.request.urlopen(req) as opened_url:
                     meta = opened_url.info()
                     length = meta["Content-Length"]
-                    if (isinstance(length, str) and int(length) > max_size):
+                    if isinstance(length, str) and int(length) > max_size:
                         raise RiftError(
                             f"'{url}' has a size of '{length}' bytes, larger than "
                             f"max size '{max_size}', skipping download",
                         )
-                    with open(output, 'wb') as out_fh:
+                    with open(output, "wb") as out_fh:
                         shutil.copyfileobj(opened_url, out_fh)
                     break
             else:
                 with urllib.request.urlopen(req) as opened_url:
-                    with open(output, 'wb') as out_fh:
+                    with open(output, "wb") as out_fh:
                         shutil.copyfileobj(opened_url, out_fh)
                 break
 
@@ -105,9 +107,10 @@ def download_file(url, output, max_size=None, retries=0, bearer_token=None):
                 "Error while downloading %s: %s, will retry in %s seconds…",
                 url,
                 error,
-                delay
+                delay,
             )
             time.sleep(delay)
+
 
 def last_modified(url, bearer_token=None):
     """
@@ -117,27 +120,30 @@ def last_modified(url, bearer_token=None):
 
     If bearer_token is set, send Authorization: Bearer <token> on the request.
     """
-    req = urllib.request.Request(url, method='HEAD')
+    req = urllib.request.Request(url, method="HEAD")
     if bearer_token:
-        req.add_header('Authorization', f'Bearer {bearer_token}')
+        req.add_header("Authorization", f"Bearer {bearer_token}")
 
     try:
         with urllib.request.urlopen(req) as response:
-            return int(datetime.strptime(
-                response.getheader('Last-Modified'), '%a, %d %b %Y %H:%M:%S %Z'
-            ).replace(tzinfo=timezone.utc).timestamp())
+            return int(
+                datetime.strptime(
+                    response.getheader("Last-Modified"), "%a, %d %b %Y %H:%M:%S %Z"
+                )
+                .replace(tzinfo=timezone.utc)
+                .timestamp()
+            )
     except urllib.error.URLError as err:
         raise RiftError(
             f"Unable to send HTTP HEAD request for URL {url}: {err}"
         ) from err
     except TypeError as err:
-        raise RiftError(
-            f"Unable to get Last-Modified header for URL {url}"
-        ) from err
+        raise RiftError(f"Unable to get Last-Modified header for URL {url}") from err
     except ValueError as err:
         raise RiftError(
             f"Unable to convert Last-Modified header to datetime for URL {url}"
         ) from err
+
 
 def setup_dl_opener(proxy, no_proxy, fake_user_agent=True):
     """
@@ -148,18 +154,17 @@ def setup_dl_opener(proxy, no_proxy, fake_user_agent=True):
 
     handlers = []
     if proxy:
-        handlers = [
-            urllib.request.ProxyHandler({'http' : proxy, 'https': proxy})
-        ]
+        handlers = [urllib.request.ProxyHandler({"http": proxy, "https": proxy})]
     # If no_proxy is defined, set environment variable accordingly to
     # make urllib.request.ProxyHandler skip proxy for these targeted
     # hosts.
     if no_proxy is not None:
-        os.environ['no_proxy'] = no_proxy
+        os.environ["no_proxy"] = no_proxy
     opener = urllib.request.build_opener(*handlers)
     if fake_user_agent:
-        opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+        opener.addheaders = [("User-agent", "Mozilla/5.0")]
     urllib.request.install_opener(opener)
+
 
 def removesuffix(input_string, suffix):
     """
@@ -168,5 +173,5 @@ def removesuffix(input_string, suffix):
     a reimplementation
     """
     if suffix and input_string.endswith(suffix):
-        return input_string[:-len(suffix)]
+        return input_string[: -len(suffix)]
     return input_string

--- a/lib/unidiff.py
+++ b/lib/unidiff.py
@@ -1,4 +1,3 @@
-
 # The MIT License (MIT)
 # Copyright (c) 2012 Matias Bordese
 #
@@ -23,44 +22,46 @@
 
 """Unified diff parser module."""
 
-import re
 import difflib
+import re
 
-LINE_TYPE_ADD = '+'
-LINE_TYPE_DELETE = '-'
-LINE_TYPE_CONTEXT = ' '
+LINE_TYPE_ADD = "+"
+LINE_TYPE_DELETE = "-"
+LINE_TYPE_CONTEXT = " "
 
-RE_DIFF_PATCH = re.compile(r'^diff --git (?P<source>[^\t]+) (?P<target>[^\t]+)')
+RE_DIFF_PATCH = re.compile(r"^diff --git (?P<source>[^\t]+) (?P<target>[^\t]+)")
 
 # @@ (source offset, length) (target offset, length) @@ (section header)
-RE_HUNK_HEADER = re.compile(
-    r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?\ @@[ ]?(.*)")
+RE_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?\ @@[ ]?(.*)")
 
 # Binary pattern
-RE_BINARY_FILE = re.compile(r'^(GIT )?[Bb]inary (files .*differ|patch)$')
+RE_BINARY_FILE = re.compile(r"^(GIT )?[Bb]inary (files .*differ|patch)$")
 
 # Deleted patterne
-RE_DELETED_BINARY_FILE = re.compile(r'^(GIT )?[Bb]inary (files .* /dev/null differ)$')
+RE_DELETED_BINARY_FILE = re.compile(r"^(GIT )?[Bb]inary (files .* /dev/null differ)$")
 
 # renamed pattern
-RE_RENAMED_FILE = re.compile(r'^rename from .*$')
+RE_RENAMED_FILE = re.compile(r"^rename from .*$")
 
 #   kept line (context)
 # + added line
 # - deleted line
 # \ No newline case (ignore)
-RE_HUNK_BODY_LINE = re.compile(r'^([- \+\\])')
+RE_HUNK_BODY_LINE = re.compile(r"^([- \+\\])")
 
 
 class UnidiffParseException(Exception):
     """Exception when parsing the diff data."""
+
     pass
+
 
 class Hunk(object):
     """Each of the modified blocks of a file."""
 
-    def __init__(self, src_start=0, src_len=0, tgt_start=0, tgt_len=0,
-                 section_header=''):
+    def __init__(
+        self, src_start=0, src_len=0, tgt_start=0, tgt_len=0, section_header=""
+    ):
         if src_len is None:
             src_len = 1
         if tgt_len is None:
@@ -80,31 +81,40 @@ class Hunk(object):
         self._unidiff_generator = None
 
     def __repr__(self):
-        return "<@@ %d,%d %d,%d @@ %s>" % (self.source_start,
-                                           self.source_length,
-                                           self.target_start,
-                                           self.target_length,
-                                           self.section_header)
+        return "<@@ %d,%d %d,%d @@ %s>" % (
+            self.source_start,
+            self.source_length,
+            self.target_start,
+            self.target_length,
+            self.section_header,
+        )
 
     def as_unified_diff(self):
         """Output hunk data in unified diff format."""
         if self._unidiff_generator is None:
-            self._unidiff_generator = difflib.unified_diff(self.source_lines,
-                                                           self.target_lines)
+            self._unidiff_generator = difflib.unified_diff(
+                self.source_lines, self.target_lines
+            )
             # throw the header information
             for i in range(3):
                 next(self._unidiff_generator)
 
-        head = "@@ -%d,%d +%d,%d @@\n" % (self.source_start, self.source_length,
-                                          self.target_start, self.target_length)
+        head = "@@ -%d,%d +%d,%d @@\n" % (
+            self.source_start,
+            self.source_length,
+            self.target_start,
+            self.target_length,
+        )
         yield head
         while True:
             yield next(self._unidiff_generator)
 
     def is_valid(self):
         """Check hunk header data matches entered lines info."""
-        return (len(self.source_lines) == self.source_length and
-                len(self.target_lines) == self.target_length)
+        return (
+            len(self.source_lines) == self.source_length
+            and len(self.target_lines) == self.target_length
+        )
 
     def append_context_line(self, line):
         """Add a new context line to the hunk."""
@@ -135,7 +145,7 @@ class Hunk(object):
 class PatchedFile(list):
     """Data of a patched file, each element is a Hunk."""
 
-    def __init__(self, source='', target=''):
+    def __init__(self, source="", target=""):
         super(PatchedFile, self).__init__()
         self.source_file = source
         self.target_file = target
@@ -144,8 +154,7 @@ class PatchedFile(list):
         self._deleted = False
 
     def __repr__(self):
-        return "%s: %s" % (self.target_file,
-                           super(PatchedFile, self).__repr__())
+        return "%s: %s" % (self.target_file, super(PatchedFile, self).__repr__())
 
     def __str__(self):
         s = self.path + "\n"
@@ -173,11 +182,11 @@ class PatchedFile(list):
         # TODO: improve git/hg detection
         if self.renamed:
             filepath = self.target_file
-        elif self.source_file == '/dev/null':
+        elif self.source_file == "/dev/null":
             filepath = self.target_file
         else:
             filepath = self.source_file
-        if filepath.startswith('a/') or filepath.startswith('b/'):
+        if filepath.startswith("a/") or filepath.startswith("b/"):
             filepath = filepath[2:]
         return filepath.strip()
 
@@ -199,14 +208,16 @@ class PatchedFile(list):
     @property
     def is_added_file(self):
         """Return True if this patch adds a file."""
-        return (len(self) == 1 and self[0].source_start == 0 and
-                self[0].source_length == 0)
+        return (
+            len(self) == 1 and self[0].source_start == 0 and self[0].source_length == 0
+        )
 
     @property
     def is_deleted_file(self):
         """Return True if this patch deletes a file."""
-        return self._deleted or (len(self) == 1 and self[0].target_start == 0 and
-                                self[0].target_length == 0)
+        return self._deleted or (
+            len(self) == 1 and self[0].target_start == 0 and self[0].target_length == 0
+        )
 
     @property
     def is_modified_file(self):
@@ -229,20 +240,20 @@ class PatchSet(list):
                 yield line
 
     def __str__(self):
-        return ''.join([str(e) for e in self])
+        return "".join([str(e) for e in self])
 
 
-def _parse_hunk(diff, source_start, source_len, target_start, target_len,
-                section_header):
+def _parse_hunk(
+    diff, source_start, source_len, target_start, target_len, section_header
+):
     """Parse a diff hunk details."""
-    hunk = Hunk(source_start, source_len, target_start, target_len,
-                section_header)
+    hunk = Hunk(source_start, source_len, target_start, target_len, section_header)
     modified = 0
     deleting = 0
     for line in diff:
         valid_line = RE_HUNK_BODY_LINE.match(line)
         if not valid_line:
-            raise UnidiffParseException('Hunk diff data expected')
+            raise UnidiffParseException("Hunk diff data expected")
 
         action = valid_line.group(0)
         original_line = line[1:]
@@ -280,8 +291,8 @@ def parse_unidiff(diff):
         ## check for source file header
         check_source = RE_DIFF_PATCH.match(line)
         if check_source:
-            source_file = check_source.group('source')
-            target_file = check_source.group('target')
+            source_file = check_source.group("source")
+            target_file = check_source.group("target")
             current_patch = PatchedFile(source_file, target_file)
             ret.append(current_patch)
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,12 @@ py-version = "3.6"
 # E1101: Used when a variable is accessed for a nonexistent member.
 # W0511: Used when a warning note as FIXME or XXX is detected.
 disable = ["E1101", "W0511"]
+
+[tool.ruff]
+target-version = "py37"  # ruff >=0.16 dropped py36; pylint still targets 3.6
+src = ["lib", "tests"]
+extend-exclude = ["vendor"]
+
+# I: isort — sort and organize imports
+[tool.ruff.lint]
+select = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ target-version = "py37"  # ruff >=0.16 dropped py36; pylint still targets 3.6
 src = ["lib", "tests"]
 extend-exclude = ["vendor"]
 
+# E: pycodestyle errors
+# F: Pyflakes
 # I: isort — sort and organize imports
 [tool.ruff.lint]
-select = ["I"]
+select = ["E", "F", "I"]

--- a/setup.py
+++ b/setup.py
@@ -32,28 +32,34 @@
 #
 
 from lib.rift import __version__
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-setup(name='rift',
-      version=__version__,
-      license='CeCILL-C (French equivalent to LGPLv2+)',
-      description='RPM repository management',
-      author='Aurelien Cedeyn',
-      author_email='aurelien.cedeyn@cea.fr',
-      package_dir={'': 'lib'},
-      packages=find_packages('lib'),
-      install_requires=['boto3>=1.18.65', 'xmltodict'],
-      py_modules = ['unidiff'],
-      data_files = [
-                  ('/usr/share/rift/template', ['template/project.conf', 'template/local.conf', 'template/mock.tpl']),
-                  ('/usr/share/rift/template/packages', ['template/packages/modules.yaml', 'template/packages/staff.yaml']),
-                  ('/usr/share/rift/vendor', ['vendor/QEMU_EFI.fd', 'vendor/QEMU_EFI.silent.fd']),
-                  ('/usr/share/doc/rift', ['Changelog', 'AUTHORS']),
-              ],
-      entry_points = {
-        'console_scripts': [
-            'rift = rift.Controller:main',
+setup(
+    name="rift",
+    version=__version__,
+    license="CeCILL-C (French equivalent to LGPLv2+)",
+    description="RPM repository management",
+    author="Aurelien Cedeyn",
+    author_email="aurelien.cedeyn@cea.fr",
+    package_dir={"": "lib"},
+    packages=find_packages("lib"),
+    install_requires=["boto3>=1.18.65", "xmltodict"],
+    py_modules=["unidiff"],
+    data_files=[
+        (
+            "/usr/share/rift/template",
+            ["template/project.conf", "template/local.conf", "template/mock.tpl"],
+        ),
+        (
+            "/usr/share/rift/template/packages",
+            ["template/packages/modules.yaml", "template/packages/staff.yaml"],
+        ),
+        ("/usr/share/rift/vendor", ["vendor/QEMU_EFI.fd", "vendor/QEMU_EFI.silent.fd"]),
+        ("/usr/share/doc/rift", ["Changelog", "AUTHORS"]),
+    ],
+    entry_points={
+        "console_scripts": [
+            "rift = rift.Controller:main",
         ],
-      }
-     )
-
+    },
+)

--- a/template/local.conf
+++ b/template/local.conf
@@ -2,4 +2,4 @@
 working_repo:
 
 # User properties
-# maintainer: 
+# maintainer:

--- a/tests/Config.py
+++ b/tests/Config.py
@@ -2,177 +2,194 @@
 # Copyright (C) 2014-2018 CEA
 #
 
-import os.path
 import os
+import os.path
 import textwrap
 
-from .TestUtils import make_temp_file, make_temp_dir, RiftTestCase
-
 from rift import DeclError
-from rift.Config import Staff, Modules, Config, _DEFAULT_PKG_DIR, \
-                         _DEFAULT_STAFF_FILE, _DEFAULT_MODULES_FILE, \
-                         _DEFAULT_VM_CPUS, _DEFAULT_VM_ADDRESS, \
-                         _DEFAULT_VM_PORT_RANGE_MIN, \
-                         _DEFAULT_VM_PORT_RANGE_MAX, \
-                         _DEFAULT_QEMU_CMD, _DEFAULT_REPO_CMD, \
-                         _DEFAULT_SHARED_FS_TYPE, _DEFAULT_VIRTIOFSD, \
-                         _DEFAULT_SYNC_METHOD, _DEFAULT_SYNC_EXCLUDE, \
-                         _DEFAULT_REPOS_VARIANTS, _DEFAULT_DEPENDENCY_TRACKING, \
-                         RiftDeprecatedConfWarning
+from rift.Config import (
+    _DEFAULT_DEPENDENCY_TRACKING,
+    _DEFAULT_MODULES_FILE,
+    _DEFAULT_PKG_DIR,
+    _DEFAULT_QEMU_CMD,
+    _DEFAULT_REPO_CMD,
+    _DEFAULT_REPOS_VARIANTS,
+    _DEFAULT_SHARED_FS_TYPE,
+    _DEFAULT_STAFF_FILE,
+    _DEFAULT_SYNC_EXCLUDE,
+    _DEFAULT_SYNC_METHOD,
+    _DEFAULT_VIRTIOFSD,
+    _DEFAULT_VM_ADDRESS,
+    _DEFAULT_VM_CPUS,
+    _DEFAULT_VM_PORT_RANGE_MAX,
+    _DEFAULT_VM_PORT_RANGE_MIN,
+    Config,
+    Modules,
+    RiftDeprecatedConfWarning,
+    Staff,
+)
+
+from .TestUtils import RiftTestCase, make_temp_dir, make_temp_file
+
 
 class ConfigTest(RiftTestCase):
-
     def test_get(self):
         """get() default values"""
         config = Config()
 
         # Default config value
-        self.assertEqual(config.get('packages_dir'), _DEFAULT_PKG_DIR)
-        self.assertEqual(config.get('staff_file'), _DEFAULT_STAFF_FILE)
-        self.assertEqual(config.get('modules_file'), _DEFAULT_MODULES_FILE)
-        self.assertEqual(config.get('vm').get('cpus'), _DEFAULT_VM_CPUS)
-        self.assertEqual(config.get('vm').get('address'), _DEFAULT_VM_ADDRESS)
-        self.assertEqual(config.get('shared_fs_type'), _DEFAULT_SHARED_FS_TYPE)
-        self.assertEqual(config.get('virtiofsd'), _DEFAULT_VIRTIOFSD)
+        self.assertEqual(config.get("packages_dir"), _DEFAULT_PKG_DIR)
+        self.assertEqual(config.get("staff_file"), _DEFAULT_STAFF_FILE)
+        self.assertEqual(config.get("modules_file"), _DEFAULT_MODULES_FILE)
+        self.assertEqual(config.get("vm").get("cpus"), _DEFAULT_VM_CPUS)
+        self.assertEqual(config.get("vm").get("address"), _DEFAULT_VM_ADDRESS)
+        self.assertEqual(config.get("shared_fs_type"), _DEFAULT_SHARED_FS_TYPE)
+        self.assertEqual(config.get("virtiofsd"), _DEFAULT_VIRTIOFSD)
         self.assertEqual(
-            config.get('vm').get('port_range'),
-            {
-                'min': _DEFAULT_VM_PORT_RANGE_MIN,
-                'max': _DEFAULT_VM_PORT_RANGE_MAX
-            }
+            config.get("vm").get("port_range"),
+            {"min": _DEFAULT_VM_PORT_RANGE_MIN, "max": _DEFAULT_VM_PORT_RANGE_MAX},
         )
-        self.assertEqual(config.get('sync'), None)
+        self.assertEqual(config.get("sync"), None)
 
         # Default value argument
-        self.assertEqual(config.get('doesnotexist', 'default value'),
-                         'default value')
+        self.assertEqual(config.get("doesnotexist", "default value"), "default value")
         # Default external tools path
-        self.assertEqual(config.get('qemu'), _DEFAULT_QEMU_CMD)
-        self.assertEqual(config.get('createrepo'), _DEFAULT_REPO_CMD)
-        self.assertEqual(config.get('dependency_tracking'),
-                         _DEFAULT_DEPENDENCY_TRACKING)
+        self.assertEqual(config.get("qemu"), _DEFAULT_QEMU_CMD)
+        self.assertEqual(config.get("createrepo"), _DEFAULT_REPO_CMD)
+        self.assertEqual(
+            config.get("dependency_tracking"), _DEFAULT_DEPENDENCY_TRACKING
+        )
 
         # Default gpg settings
-        self.assertEqual(config.get('gpg'), None)
+        self.assertEqual(config.get("gpg"), None)
 
     def test_get_set(self):
         """simple set() and get()"""
         config = Config()
         # set an 'int'
-        config.set('vm', {'image': '/path/to/image', 'cpus': 42})
-        self.assertEqual(config.get('vm').get('cpus'), 42)
+        config.set("vm", {"image": "/path/to/image", "cpus": 42})
+        self.assertEqual(config.get("vm").get("cpus"), 42)
 
         # set a 'dict'
         config.set(
-            'vm',
-            {
-                'image': '/path/to/image',
-                'port_range': {'min': 5000, 'max': 6000}
-            }
+            "vm", {"image": "/path/to/image", "port_range": {"min": 5000, "max": 6000}}
         )
-        self.assertEqual(
-            config.get('vm').get('port_range'),
-            {'min': 5000, 'max': 6000}
-        )
+        self.assertEqual(config.get("vm").get("port_range"), {"min": 5000, "max": 6000})
 
         # set a 'record'
-        config.set('repos', {'os': {'url': 'http://myserver/pub'}})
+        config.set("repos", {"os": {"url": "http://myserver/pub"}})
         self.assertEqual(
-            config.get('repos'),
-            {'os': {'url': 'http://myserver/pub', 'variants': _DEFAULT_REPOS_VARIANTS}}
+            config.get("repos"),
+            {"os": {"url": "http://myserver/pub", "variants": _DEFAULT_REPOS_VARIANTS}},
         )
 
         # set a 'list'
-        config.set('arch', ['x86_64', 'aarch64'])
-        self.assertEqual(config.get('arch'), ['x86_64', 'aarch64'])
+        config.set("arch", ["x86_64", "aarch64"])
+        self.assertEqual(config.get("arch"), ["x86_64", "aarch64"])
 
         # set a 'enum'
-        config.set('shared_fs_type', 'virtiofs')
-        self.assertEqual(config.get('shared_fs_type'), 'virtiofs')
+        config.set("shared_fs_type", "virtiofs")
+        self.assertEqual(config.get("shared_fs_type"), "virtiofs")
 
     def test_set_bad_type(self):
         """set() using wrong type raises an error"""
-        self.assert_except(DeclError, "Bad data type str for 'cpus'",
-                Config().set, 'vm', {'image': '/path/to/image', 'cpus': 'a string'})
-        self.assert_except(DeclError, "Bad data type str for 'repos'",
-                           Config().set, 'repos', 'a string')
+        self.assert_except(
+            DeclError,
+            "Bad data type str for 'cpus'",
+            Config().set,
+            "vm",
+            {"image": "/path/to/image", "cpus": "a string"},
+        )
+        self.assert_except(
+            DeclError,
+            "Bad data type str for 'repos'",
+            Config().set,
+            "repos",
+            "a string",
+        )
         # Default check is 'string'
-        self.assert_except(DeclError, "Bad data type int for 'image'",
-                Config().set, 'vm', {'image': 42})
-        self.assert_except(DeclError,
-                           "Bad data type str for 'arch'",
-                           Config().set, 'arch', 'x86_64')
+        self.assert_except(
+            DeclError,
+            "Bad data type int for 'image'",
+            Config().set,
+            "vm",
+            {"image": 42},
+        )
+        self.assert_except(
+            DeclError, "Bad data type str for 'arch'", Config().set, "arch", "x86_64"
+        )
         # Check bad enum
-        self.assertRaises(DeclError, Config().set, 'shared_fs_type', 'badtype')
+        self.assertRaises(DeclError, Config().set, "shared_fs_type", "badtype")
 
     def test_set_bad_key(self):
         """set() an undefined key raises an error"""
-        self.assert_except(DeclError, "Unknown 'myval' key",
-                           Config().set, 'myval', 'value')
-        self.assert_except(DeclError, "Unknown 'myval' key",
-                           Config().set, 'myval', 'value')
+        self.assert_except(
+            DeclError, "Unknown 'myval' key", Config().set, "myval", "value"
+        )
+        self.assert_except(
+            DeclError, "Unknown 'myval' key", Config().set, "myval", "value"
+        )
 
     def test_get_arch_placeholder(self):
         """get() with $arch placeholder"""
         config = Config()
 
         # Declare supported architectures
-        config.set('arch', ['x86_64', 'aarch64'])
+        config.set("arch", ["x86_64", "aarch64"])
         # $arch placeholder replacement with string
-        config.set('vm', {'image': '/path/to/image-$arch.qcow2'})
+        config.set("vm", {"image": "/path/to/image-$arch.qcow2"})
         self.assertEqual(
-            config.get('vm', arch='x86_64').get('image'),
-            '/path/to/image-x86_64.qcow2'
+            config.get("vm", arch="x86_64").get("image"), "/path/to/image-x86_64.qcow2"
         )
         self.assertEqual(
-            config.get('vm', arch='aarch64').get('image'),
-            '/path/to/image-aarch64.qcow2'
+            config.get("vm", arch="aarch64").get("image"),
+            "/path/to/image-aarch64.qcow2",
         )
         # $arch placeholder replacement with dict
         config.set(
-            'repos',
+            "repos",
             {
-                'os': {
-                    'url': 'file:///rift/packages/$arch/os',
-                    'priority': 90,
-                    'variants': _DEFAULT_REPOS_VARIANTS,
+                "os": {
+                    "url": "file:///rift/packages/$arch/os",
+                    "priority": 90,
+                    "variants": _DEFAULT_REPOS_VARIANTS,
                 },
-                'extra': {
-                    'url': 'file:///rift/packages/$arch/extra',
-                    'priority': 90,
-                    'variants': _DEFAULT_REPOS_VARIANTS,
+                "extra": {
+                    "url": "file:///rift/packages/$arch/extra",
+                    "priority": 90,
+                    "variants": _DEFAULT_REPOS_VARIANTS,
                 },
-            }
+            },
         )
         self.assertEqual(
-            config.get('repos', arch='x86_64'),
+            config.get("repos", arch="x86_64"),
             {
-                'os': {
-                    'url': 'file:///rift/packages/x86_64/os',
-                    'priority': 90,
-                    'variants': _DEFAULT_REPOS_VARIANTS,
+                "os": {
+                    "url": "file:///rift/packages/x86_64/os",
+                    "priority": 90,
+                    "variants": _DEFAULT_REPOS_VARIANTS,
                 },
-                'extra': {
-                    'url': 'file:///rift/packages/x86_64/extra',
-                    'priority': 90,
-                    'variants': _DEFAULT_REPOS_VARIANTS,
+                "extra": {
+                    "url": "file:///rift/packages/x86_64/extra",
+                    "priority": 90,
+                    "variants": _DEFAULT_REPOS_VARIANTS,
                 },
-            }
+            },
         )
         self.assertEqual(
-            config.get('repos', arch='aarch64'),
+            config.get("repos", arch="aarch64"),
             {
-                'os': {
-                    'url': 'file:///rift/packages/aarch64/os',
-                    'priority': 90,
-                    'variants': _DEFAULT_REPOS_VARIANTS,
+                "os": {
+                    "url": "file:///rift/packages/aarch64/os",
+                    "priority": 90,
+                    "variants": _DEFAULT_REPOS_VARIANTS,
                 },
-                'extra': {
-                    'url': 'file:///rift/packages/aarch64/extra',
-                    'priority': 90,
-                    'variants': _DEFAULT_REPOS_VARIANTS,
+                "extra": {
+                    "url": "file:///rift/packages/aarch64/extra",
+                    "priority": 90,
+                    "variants": _DEFAULT_REPOS_VARIANTS,
                 },
-            }
+            },
         )
 
     def test_get_arch_specific_override(self):
@@ -180,17 +197,16 @@ class ConfigTest(RiftTestCase):
         config = Config()
 
         # Declare supported architectures
-        config.set('arch', ['x86_64', 'aarch64'])
+        config.set("arch", ["x86_64", "aarch64"])
         # Override with arch specific value
-        config.set('vm', {'image': '/path/to/image-$arch.qcow2'})
-        config.set('vm', {'image': '/path/to/other-image.qcow2'}, arch='x86_64')
+        config.set("vm", {"image": "/path/to/image-$arch.qcow2"})
+        config.set("vm", {"image": "/path/to/other-image.qcow2"}, arch="x86_64")
         self.assertEqual(
-            config.get('vm', arch='aarch64').get('image'),
-            '/path/to/image-aarch64.qcow2'
+            config.get("vm", arch="aarch64").get("image"),
+            "/path/to/image-aarch64.qcow2",
         )
         self.assertEqual(
-            config.get('vm', arch='x86_64').get('image'),
-            '/path/to/other-image.qcow2'
+            config.get("vm", arch="x86_64").get("image"), "/path/to/other-image.qcow2"
         )
 
     def test_get_unsupported_arch(self):
@@ -200,10 +216,9 @@ class ConfigTest(RiftTestCase):
         # Get with unsupported arch must fail
         with self.assertRaisesRegex(
             DeclError,
-            "^Unable to get configuration option for unsupported architecture "
-            "'fail'$"
+            "^Unable to get configuration option for unsupported architecture 'fail'$",
         ):
-            config.get('vm', arch='fail')
+            config.get("vm", arch="fail")
 
     def test_set_unsupported_arch(self):
         """set() with unsupported arch"""
@@ -211,29 +226,28 @@ class ConfigTest(RiftTestCase):
 
         with self.assertRaisesRegex(
             DeclError,
-            "^Unable to set configuration option for unsupported architecture "
-            "'fail'$"
+            "^Unable to set configuration option for unsupported architecture 'fail'$",
         ):
-            config.set('vm', {'image': '/path/to/image.qcow2'}, arch='fail')
-
+            config.set("vm", {"image": "/path/to/image.qcow2"}, arch="fail")
 
     def test_load(self):
         """load() checks mandatory options are present"""
         emptyfile = make_temp_file("")
-        self.assert_except(DeclError, "'set_annex' is not defined",
-                           Config().load, emptyfile.name)
+        self.assert_except(
+            DeclError, "'set_annex' is not defined", Config().load, emptyfile.name
+        )
 
         cfgfile = make_temp_file(
-                textwrap.dedent(
-                    """
+            textwrap.dedent(
+                """
                     set_annex:
                       address: /a/dir
                       type: directory
                     vm:
                       image: /a/image.img
                     """
-                )
             )
+        )
         config = Config()
         # Simple filename
         config.load(cfgfile.name)
@@ -243,8 +257,7 @@ class ConfigTest(RiftTestCase):
         config.load([cfgfile.name])
 
         # Default config files
-        self.assert_except(DeclError, "'set_annex' is not defined",
-                           Config().load)
+        self.assert_except(DeclError, "'set_annex' is not defined", Config().load)
 
     def test_load_multiple_files(self):
         """load() loads multiple files"""
@@ -275,12 +288,12 @@ class ConfigTest(RiftTestCase):
         config = Config()
         config.load([conf_file.name for conf_file in conf_files])
         # Value from 1st file should be loaded
-        self.assertEqual(config.get('set_annex').get('address'), '/a/dir')
-        self.assertEqual(config.get('set_annex').get('type'), 'directory')
+        self.assertEqual(config.get("set_annex").get("address"), "/a/dir")
+        self.assertEqual(config.get("set_annex").get("type"), "directory")
         # Value from 2nd file should override value from 1st file
-        self.assertEqual(config.get('vm').get('image'), '/b/image.img')
+        self.assertEqual(config.get("vm").get("image"), "/b/image.img")
         # Value from 2nd file should be loaded
-        self.assertEqual(config.get('arch'), ['x86_64', 'aarch64'])
+        self.assertEqual(config.get("arch"), ["x86_64", "aarch64"])
 
     def test_load_arch_specific(self):
         """load() properly loads architecture specific options"""
@@ -306,9 +319,9 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('vm').get('image'), '/a/image.img')
-        self.assertEqual(config.get('vm', arch='x86_64').get('image'), '/b/image.img')
-        self.assertEqual(config.get('vm', arch='aarch64').get('image'), '/c/image.img')
+        self.assertEqual(config.get("vm").get("image"), "/a/image.img")
+        self.assertEqual(config.get("vm", arch="x86_64").get("image"), "/b/image.img")
+        self.assertEqual(config.get("vm", arch="aarch64").get("image"), "/c/image.img")
 
     def test_load_arch_specific_invalid_mapping(self):
         """load() fail with not mapping architecture specific options"""
@@ -327,7 +340,7 @@ class ConfigTest(RiftTestCase):
         config = Config()
         with self.assertRaisesRegex(
             DeclError,
-            '^Architecture specific override for x86_64 must be a mapping$',
+            "^Architecture specific override for x86_64 must be a mapping$",
         ):
             config.load(cfgfile.name)
 
@@ -373,7 +386,7 @@ class ConfigTest(RiftTestCase):
             x86_64:
               vm:
                 image: /a/image.img
-            """
+            """,
         }
         for content in contents:
             cfgfile = make_temp_file(textwrap.dedent(content))
@@ -411,12 +424,17 @@ class ConfigTest(RiftTestCase):
         """load() an non-existent file raises a nice error"""
         config = Config()
         config.ALLOW_MISSING = False
-        self.assert_except(DeclError, "Could not find '/does/not/exist'",
-                           config.load, "/does/not/exist")
+        self.assert_except(
+            DeclError,
+            "Could not find '/does/not/exist'",
+            config.load,
+            "/does/not/exist",
+        )
 
         # Wrong file type
-        self.assert_except(DeclError, "[Errno 21] Is a directory: '/'",
-                           config.load, "/")
+        self.assert_except(
+            DeclError, "[Errno 21] Is a directory: '/'", config.load, "/"
+        )
 
     def test_load_bad_syntax(self):
         """load() an bad YAML syntax file raises an error"""
@@ -460,15 +478,15 @@ class ConfigTest(RiftTestCase):
         ]
         config = Config()
         config.load([conf_file.name for conf_file in conf_files])
-        repos = config.get('repos')
-        self.assertTrue('os' in repos)
-        self.assertTrue('update' in repos)
-        self.assertTrue('extra' in repos)
-        self.assertEqual(repos['os']['url'], 'https://os/url/file2')
-        self.assertTrue('module_hotfixes' in repos['os'])
-        self.assertCountEqual(repos['os']['variants'], ['mofed4', 'mofed5'])
-        self.assertEqual(repos['update']['url'], 'https://update/url/file2')
-        self.assertEqual(repos['extra']['url'], 'https://extra/url/file1')
+        repos = config.get("repos")
+        self.assertTrue("os" in repos)
+        self.assertTrue("update" in repos)
+        self.assertTrue("extra" in repos)
+        self.assertEqual(repos["os"]["url"], "https://os/url/file2")
+        self.assertTrue("module_hotfixes" in repos["os"])
+        self.assertCountEqual(repos["os"]["variants"], ["mofed4", "mofed5"])
+        self.assertEqual(repos["update"]["url"], "https://update/url/file2")
+        self.assertEqual(repos["extra"]["url"], "https://extra/url/file1")
 
     def test_load_port_partial_port_range(self):
         """Load partial port range dict"""
@@ -487,10 +505,9 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('vm').get('port_range').get('min'), 2000)
+        self.assertEqual(config.get("vm").get("port_range").get("min"), 2000)
         self.assertEqual(
-            config.get('vm').get('port_range').get('max'),
-            _DEFAULT_VM_PORT_RANGE_MAX
+            config.get("vm").get("port_range").get("max"), _DEFAULT_VM_PORT_RANGE_MAX
         )
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -507,10 +524,9 @@ class ConfigTest(RiftTestCase):
         )
         config.load(cfgfile.name)
         self.assertEqual(
-            config.get('vm').get('port_range').get('min'),
-            _DEFAULT_VM_PORT_RANGE_MIN
+            config.get("vm").get("port_range").get("min"), _DEFAULT_VM_PORT_RANGE_MIN
         )
-        self.assertEqual(config.get('vm').get('port_range').get('max'), 30000)
+        self.assertEqual(config.get("vm").get("port_range").get("max"), 30000)
 
     def test_load_vm_kernel(self):
         """Load vm.kernel parameter"""
@@ -528,7 +544,7 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('vm').get('kernel'), '4.18.0-513.el8')
+        self.assertEqual(config.get("vm").get("kernel"), "4.18.0-513.el8")
 
     def test_load_gpg(self):
         """Load gpg parameters"""
@@ -549,9 +565,9 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('gpg').get('keyring'), '/path/to/keyring')
-        self.assertEqual(config.get('gpg').get('key'), 'rift')
-        self.assertEqual(config.get('gpg').get('passphrase'), None)
+        self.assertEqual(config.get("gpg").get("keyring"), "/path/to/keyring")
+        self.assertEqual(config.get("gpg").get("key"), "rift")
+        self.assertEqual(config.get("gpg").get("passphrase"), None)
 
         # Check with passphrase
         cfgfile = make_temp_file(
@@ -571,14 +587,14 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('gpg').get('keyring'), '/path/to/keyring')
-        self.assertEqual(config.get('gpg').get('key'), 'rift')
-        self.assertEqual(config.get('gpg').get('passphrase'), 'secr3t')
+        self.assertEqual(config.get("gpg").get("keyring"), "/path/to/keyring")
+        self.assertEqual(config.get("gpg").get("key"), "rift")
+        self.assertEqual(config.get("gpg").get("passphrase"), "secr3t")
 
     def test_load_gpg_missing_keyring_or_key(self):
         """Skip gpg parameters load if missing keyring or key"""
         # Check missing both key and keyring or one of them
-        for gpg_config in ['{}', '{keyring: /path/to/keyring}', '{key: rift}']:
+        for gpg_config in ["{}", "{keyring: /path/to/keyring}", "{key: rift}"]:
             cfgfile = make_temp_file(
                 textwrap.dedent(
                     f"""
@@ -593,9 +609,8 @@ class ConfigTest(RiftTestCase):
             )
             config = Config()
             with self.assertRaisesRegex(
-                    DeclError,
-                    '^Key (key|keyring) is required in dict parameter gpg$'
-                ):
+                DeclError, "^Key (key|keyring) is required in dict parameter gpg$"
+            ):
                 config.load(cfgfile.name)
 
     def test_load_gpg_unknown_key(self):
@@ -616,7 +631,7 @@ class ConfigTest(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(DeclError, '^Unknown gpg keys: epic$'):
+        with self.assertRaisesRegex(DeclError, "^Unknown gpg keys: epic$"):
             config.load(cfgfile.name)
 
     def test_load_sync(self):
@@ -654,36 +669,30 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('sync_output'), '/sync/output')
+        self.assertEqual(config.get("sync_output"), "/sync/output")
         self.assertEqual(
-            config.get('repos')['repo1']['sync']['source'], 'https://server1/repo1'
+            config.get("repos")["repo1"]["sync"]["source"], "https://server1/repo1"
+        )
+        self.assertEqual(config.get("repos")["repo1"]["sync"]["method"], "epel")
+        self.assertEqual(
+            config.get("repos")["repo1"]["sync"]["include"], ["include1", "include2"]
         )
         self.assertEqual(
-            config.get('repos')['repo1']['sync']['method'], 'epel'
+            config.get("repos")["repo1"]["sync"]["exclude"], _DEFAULT_SYNC_EXCLUDE
         )
         self.assertEqual(
-            config.get('repos')['repo1']['sync']['include'],
-            ['include1', 'include2']
+            config.get("repos")["repo2"]["sync"]["source"], "https://server2/repo2"
         )
         self.assertEqual(
-            config.get('repos')['repo1']['sync']['exclude'],
-            _DEFAULT_SYNC_EXCLUDE
+            config.get("repos")["repo2"]["sync"]["method"], _DEFAULT_SYNC_METHOD
         )
         self.assertEqual(
-            config.get('repos')['repo2']['sync']['source'], 'https://server2/repo2'
+            config.get("repos")["repo2"]["sync"]["include"], _DEFAULT_SYNC_EXCLUDE
         )
         self.assertEqual(
-            config.get('repos')['repo2']['sync']['method'], _DEFAULT_SYNC_METHOD
+            config.get("repos")["repo2"]["sync"]["exclude"], ["exclude1", "exclude2"]
         )
-        self.assertEqual(
-            config.get('repos')['repo2']['sync']['include'],
-            _DEFAULT_SYNC_EXCLUDE
-        )
-        self.assertEqual(
-            config.get('repos')['repo2']['sync']['exclude'],
-            ['exclude1', 'exclude2']
-        )
-        self.assertIsNone(config.get('repos')['repo3'].get('sync'))
+        self.assertIsNone(config.get("repos")["repo3"].get("sync"))
 
     def test_load_sync_repo_missing_source(self):
         """load() fails with DeclError when repositories synchronization source URL is missing."""
@@ -704,8 +713,7 @@ class ConfigTest(RiftTestCase):
         )
         config = Config()
         with self.assertRaisesRegex(
-            DeclError,
-            r"Key url is required in dict parameter repos"
+            DeclError, r"Key url is required in dict parameter repos"
         ):
             config.load(cfgfile.name)
 
@@ -732,7 +740,7 @@ class ConfigTest(RiftTestCase):
         with self.assertRaisesRegex(
             DeclError,
             r"Bad value fail \(str\) for 'method' \(correct values: lftp, "
-            r"epel, dnf\)"
+            r"epel, dnf\)",
         ):
             config.load(cfgfile.name)
 
@@ -753,9 +761,9 @@ class ConfigTest(RiftTestCase):
         config = Config()
         with self.assertWarns(RiftDeprecatedConfWarning):
             config.load(cfgfile.name)
-        self.assertEqual(config.get('vm').get('image'), '/my/custom/image.img')
-        self.assertEqual(config.get('vm').get('cpus'), 42)
-        self.assertEqual(config.get('vm').get('memory'), 1234)
+        self.assertEqual(config.get("vm").get("image"), "/my/custom/image.img")
+        self.assertEqual(config.get("vm").get("cpus"), 42)
+        self.assertEqual(config.get("vm").get("memory"), 1234)
 
     def test_load_deprecated_gerrit_parameters(self):
         """load() deprecated gerrit_* parameters."""
@@ -776,13 +784,14 @@ class ConfigTest(RiftTestCase):
         config = Config()
         with self.assertWarns(RiftDeprecatedConfWarning):
             config.load(cfgfile.name)
-        self.assertEqual(config.get('gerrit').get('realm'), 'Rift')
-        self.assertEqual(config.get('gerrit').get('url'), 'https://localhost')
-        self.assertEqual(config.get('gerrit').get('username'), 'rift')
+        self.assertEqual(config.get("gerrit").get("realm"), "Rift")
+        self.assertEqual(config.get("gerrit").get("url"), "https://localhost")
+        self.assertEqual(config.get("gerrit").get("username"), "rift")
 
 
 class ConfigTestSyntax(RiftTestCase):
     """Test Config with modified syntax."""
+
     def setUp(self):
         # Save reference to original Config syntax class attribute. There is no
         # need to copy the dict as a new dict is allocated and assigned to class
@@ -791,9 +800,9 @@ class ConfigTestSyntax(RiftTestCase):
         # Initialize syntax with arch which is the only hard requirement in
         # class logic.
         Config.SYNTAX = {
-            'arch': {
-                'check': 'list',
-                'default': ['x86_64'],
+            "arch": {
+                "check": "list",
+                "default": ["x86_64"],
             }
         }
 
@@ -803,11 +812,13 @@ class ConfigTestSyntax(RiftTestCase):
 
     def test_load_bool(self):
         """Load bool parameter"""
-        Config.SYNTAX.update({
-            'bool0': {
-                'check': 'bool',
+        Config.SYNTAX.update(
+            {
+                "bool0": {
+                    "check": "bool",
+                }
             }
-        })
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -818,15 +829,17 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('bool0'), True)
+        self.assertEqual(config.get("bool0"), True)
 
     def test_load_invalid_bool(self):
         """Test load invalid bool parameter"""
-        Config.SYNTAX.update({
-            'bool0': {
-                'check': 'bool',
+        Config.SYNTAX.update(
+            {
+                "bool0": {
+                    "check": "bool",
+                }
             }
-        })
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -836,18 +849,18 @@ class ConfigTestSyntax(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(
-            DeclError, "^Bad data type str for 'bool0'$"
-        ):
+        with self.assertRaisesRegex(DeclError, "^Bad data type str for 'bool0'$"):
             config.load(cfgfile.name)
 
     def test_load_dict_without_syntax(self):
         """Load dict without syntax"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'dict',
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "dict",
+                }
             }
-        })
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -860,16 +873,18 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('param0').get('key1'), 'value1')
-        self.assertEqual(config.get('param0').get('with'), 'anything')
+        self.assertEqual(config.get("param0").get("key1"), "value1")
+        self.assertEqual(config.get("param0").get("with"), "anything")
 
     def test_load_dict_with_arch(self):
         """Load dict with archs"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'dict',
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "dict",
+                }
             }
-        })
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -889,40 +904,27 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('param0').get('key1'), 'value1')
-        self.assertEqual(config.get('param0').get('with'), 'anything')
-        self.assertEqual(
-            config.get('param0', arch='x86_64').get('key1'), 'value1'
-        )
-        self.assertEqual(
-            config.get('param0', arch='x86_64').get('with'), 'anything'
-        )
-        self.assertEqual(
-            config.get('param0', arch='aarch64').get('key1'), 'value2'
-        )
-        self.assertEqual(
-            config.get('param0', arch='aarch64').get('with'), 'another'
-        )
+        self.assertEqual(config.get("param0").get("key1"), "value1")
+        self.assertEqual(config.get("param0").get("with"), "anything")
+        self.assertEqual(config.get("param0", arch="x86_64").get("key1"), "value1")
+        self.assertEqual(config.get("param0", arch="x86_64").get("with"), "anything")
+        self.assertEqual(config.get("param0", arch="aarch64").get("key1"), "value2")
+        self.assertEqual(config.get("param0", arch="aarch64").get("with"), "another")
 
     def _add_fake_params(self):
         """Load dict with syntax"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'dict',
-                'syntax': {
-                    'key1': {
-                        'required': True
-                    },
-                    'key2': {
-                        'check': 'digit'
-                    }
-                }
-            },
-            'record0': {
-                'check': 'record',
-                'content': 'digit',
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "dict",
+                    "syntax": {"key1": {"required": True}, "key2": {"check": "digit"}},
+                },
+                "record0": {
+                    "check": "record",
+                    "content": "digit",
+                },
             }
-        })
+        )
 
     def test_load_dict_with_syntax(self):
         """Load dict with syntax"""
@@ -938,8 +940,8 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('param0').get('key1'), 'value1')
-        self.assertEqual(config.get('param0').get('key2'), 2)
+        self.assertEqual(config.get("param0").get("key1"), "value1")
+        self.assertEqual(config.get("param0").get("key2"), 2)
 
         # Test with another value for key1 and key2 undefined.
         cfgfile = make_temp_file(
@@ -952,8 +954,8 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('param0').get('key1'), 'value2')
-        self.assertEqual(config.get('param0').get('key2'), None)
+        self.assertEqual(config.get("param0").get("key1"), "value2")
+        self.assertEqual(config.get("param0").get("key2"), None)
 
     def test_load_dict_bad_subkey_type(self):
         """Load dict with bad subkey type"""
@@ -968,10 +970,7 @@ class ConfigTestSyntax(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(
-                DeclError,
-                "^Bad data type str for 'key2'$"
-            ):
+        with self.assertRaisesRegex(DeclError, "^Bad data type str for 'key2'$"):
             config.load(cfgfile.name)
 
     def test_load_dict_missing_subkey(self):
@@ -987,9 +986,8 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         with self.assertRaisesRegex(
-                DeclError,
-                "^Key key1 is required in dict parameter param0$"
-            ):
+            DeclError, "^Key key1 is required in dict parameter param0$"
+        ):
             config.load(cfgfile.name)
 
     def test_load_dict_unknown_subkey(self):
@@ -1005,32 +1003,27 @@ class ConfigTestSyntax(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(
-                DeclError,
-                "^Unknown param0 keys: key3$"
-            ):
+        with self.assertRaisesRegex(DeclError, "^Unknown param0 keys: key3$"):
             config.load(cfgfile.name)
 
     def test_load_dict_recursive_syntax(self):
         """Load dict with resursive syntax"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'dict',
-                'syntax': {
-                    'key1': {
-                        'check': 'dict',
-                        'syntax': {
-                            'subkey2': {
-                                'required': True
-                            },
-                            'subkey3': {
-                                'check': 'digit'
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "dict",
+                    "syntax": {
+                        "key1": {
+                            "check": "dict",
+                            "syntax": {
+                                "subkey2": {"required": True},
+                                "subkey3": {"check": "digit"},
                             },
                         },
                     },
                 },
-            },
-        })
+            }
+        )
         # Check load of valid param0
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -1044,12 +1037,8 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(
-            config.get('param0').get('key1').get('subkey2'), 'value2'
-        )
-        self.assertEqual(
-            config.get('param0').get('key1').get('subkey3'), 5
-        )
+        self.assertEqual(config.get("param0").get("key1").get("subkey2"), "value2")
+        self.assertEqual(config.get("param0").get("key1").get("subkey3"), 5)
 
         # Check syntax is really enforced on sub-sub-dict
         cfgfile = make_temp_file(
@@ -1063,41 +1052,40 @@ class ConfigTestSyntax(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(
-                DeclError,
-                "^Bad data type str for 'subkey3'$"
-            ):
+        with self.assertRaisesRegex(DeclError, "^Bad data type str for 'subkey3'$"):
             config.load(cfgfile.name)
 
     def test_load_dict_with_syntax_default_value_partial_def(self):
         """Load dict with default value defined in syntax and partial definition"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'dict',
-                'syntax': {
-                    'key1': {
-                        'default': 'default_key1',
-                    },
-                    'key2': {
-                        'check': 'dict',
-                        'syntax': {
-                            'subkey2': {
-                                'default': 'default_subkey2',
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "dict",
+                    "syntax": {
+                        "key1": {
+                            "default": "default_key1",
+                        },
+                        "key2": {
+                            "check": "dict",
+                            "syntax": {
+                                "subkey2": {
+                                    "default": "default_subkey2",
+                                },
+                                "subkey3": {
+                                    "default": "default_subkey3",
+                                },
                             },
-                            'subkey3': {
-                                'default': 'default_subkey3',
-                            }
-                        }
-                    },
-                    'key3': {
-                        'check': 'dict',
-                        'default': {
-                            'subkey5': 'default_subkey5',
+                        },
+                        "key3": {
+                            "check": "dict",
+                            "default": {
+                                "subkey5": "default_subkey5",
+                            },
                         },
                     },
                 }
             }
-        })
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1109,74 +1097,75 @@ class ConfigTestSyntax(RiftTestCase):
         config = Config()
         config.load(cfgfile.name)
         self.assertEqual(
-            config.get('param0'),
+            config.get("param0"),
             {
-                'key1': 'overriden_subkey1',
-                'key2': {
-                    'subkey2': 'default_subkey2',
+                "key1": "overriden_subkey1",
+                "key2": {
+                    "subkey2": "default_subkey2",
                     # Value defined in config file must be properly loaded
-                    'subkey3': 'default_subkey3',
+                    "subkey3": "default_subkey3",
                 },
-                'key3': {
-                    'subkey5': 'default_subkey5',
-                }
-            }
+                "key3": {
+                    "subkey5": "default_subkey5",
+                },
+            },
         )
-
 
     def test_load_dict_with_syntax_default_value(self):
         """Load dict with default value defined in syntax"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'dict',
-                'syntax': {
-                    'key1': {
-                        'default': 'default_key1',
-                    },
-                    'key2': {
-                        'check': 'dict',
-                        'syntax': {
-                            'subkey2': {
-                                'default': 'default_subkey2',
-                            },
-                            'subkey3': {
-                                'default': 'default_subkey3',
-                            }
-                        }
-                    },
-                    'key3': {
-                        'check': 'dict',
-                        'default': {
-                            'subkey5': 'default_subkey5',
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "dict",
+                    "syntax": {
+                        "key1": {
+                            "default": "default_key1",
                         },
-                        'syntax': {
-                            'subkey4': {
-                                'default': 'default_subkey4',
+                        "key2": {
+                            "check": "dict",
+                            "syntax": {
+                                "subkey2": {
+                                    "default": "default_subkey2",
+                                },
+                                "subkey3": {
+                                    "default": "default_subkey3",
+                                },
                             },
-                            'subkey5': {}
+                        },
+                        "key3": {
+                            "check": "dict",
+                            "default": {
+                                "subkey5": "default_subkey5",
+                            },
+                            "syntax": {
+                                "subkey4": {
+                                    "default": "default_subkey4",
+                                },
+                                "subkey5": {},
+                            },
                         },
                     },
                 }
             }
-        })
-        cfgfile = make_temp_file('')
+        )
+        cfgfile = make_temp_file("")
         config = Config()
         config.load(cfgfile.name)
         self.assertEqual(
-            config.get('param0'),
+            config.get("param0"),
             {
-                'key1': 'default_key1',
-                'key2': {
+                "key1": "default_key1",
+                "key2": {
                     # Default values must be extracted from key2 syntax.
-                    'subkey2': 'default_subkey2',
-                    'subkey3': 'default_subkey3',
+                    "subkey2": "default_subkey2",
+                    "subkey3": "default_subkey3",
                 },
-                'key3': {
+                "key3": {
                     # Default value defined at key3 level has the priority over
                     # the default value defined at subkeys level in syntax.
-                    'subkey5': 'default_subkey5',
-                }
-            }
+                    "subkey5": "default_subkey5",
+                },
+            },
         )
 
     def test_load_dict_merged_syntax(self):
@@ -1203,11 +1192,11 @@ class ConfigTestSyntax(RiftTestCase):
         ]
         config = Config()
         config.load([conf_file.name for conf_file in conf_files])
-        param0 = config.get('param0')
-        self.assertTrue('key1' in param0)
-        self.assertTrue('key2' in param0)
-        self.assertEqual(param0['key1'], 'value2')
-        self.assertEqual(param0['key2'], 1)
+        param0 = config.get("param0")
+        self.assertTrue("key1" in param0)
+        self.assertTrue("key2" in param0)
+        self.assertEqual(param0["key1"], "value2")
+        self.assertEqual(param0["key2"], 1)
 
     def test_load_dict_merged_syntax_missing_required(self):
         """load() merges dict from multiple files with syntax and required param missing in one file"""
@@ -1232,19 +1221,21 @@ class ConfigTestSyntax(RiftTestCase):
         ]
         config = Config()
         config.load([conf_file.name for conf_file in conf_files])
-        param0 = config.get('param0')
-        self.assertTrue('key1' in param0)
-        self.assertTrue('key2' in param0)
-        self.assertEqual(param0['key1'], 'value1')
-        self.assertEqual(param0['key2'], 1)
+        param0 = config.get("param0")
+        self.assertTrue("key1" in param0)
+        self.assertTrue("key2" in param0)
+        self.assertEqual(param0["key1"], "value1")
+        self.assertEqual(param0["key2"], 1)
 
     def test_load_record(self):
         """Load record without content"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'record',
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "record",
+                }
             }
-        })
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -1257,34 +1248,34 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('param0').get('key1'), 'value1')
-        self.assertEqual(config.get('param0').get('key2'), 'value2')
+        self.assertEqual(config.get("param0").get("key1"), "value1")
+        self.assertEqual(config.get("param0").get("key2"), "value2")
 
     def test_load_record_with_content(self):
         """Load record with content specification."""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'record',
-                'content': 'digit',
-            },
-            'param1': {
-                'check': 'record',
-                'content': 'dict',
-            },
-            'param2': {
-                'check': 'record',
-                'content': 'dict',
-                'syntax': {
-                    'p2subkey1': {
-                        'check': 'digit',
-                        'default': -1,
-                    },
-                    'p2subkey2': {
-                        'required': True
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "record",
+                    "content": "digit",
+                },
+                "param1": {
+                    "check": "record",
+                    "content": "dict",
+                },
+                "param2": {
+                    "check": "record",
+                    "content": "dict",
+                    "syntax": {
+                        "p2subkey1": {
+                            "check": "digit",
+                            "default": -1,
+                        },
+                        "p2subkey2": {"required": True},
                     },
                 },
-            },
-        })
+            }
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -1310,39 +1301,20 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         config.load(cfgfile.name)
-        self.assertEqual(config.get('param0').get('p0key1'), 1)
-        self.assertEqual(config.get('param0').get('p0key2'), 2)
-        self.assertEqual(
-            config.get('param1')['p1key1'].get('p1k1key1'), 'p1k1value1'
-        )
-        self.assertEqual(
-            config.get('param1')['p1key1'].get('p1k1key2'), 'p1k1value2'
-        )
-        self.assertEqual(
-            config.get('param1')['p1key2'].get('p1k1key3'), 'p1k1value3'
-        )
-        self.assertEqual(
-            config.get('param1')['p1key2'].get('p1k1key4'), 'p1k1value4'
-        )
-        self.assertEqual(
-            config.get('param2')['p2key1'].get('p2subkey1'), 0
-        )
-        self.assertEqual(
-            config.get('param2')['p2key1'].get('p2subkey2'), 'p2k2value1'
-        )
-        self.assertEqual(config.get('param2')['p2key2'].get('p2subkey1'), -1)
-        self.assertEqual(
-            config.get('param2')['p2key2'].get('p2subkey2'), 'p2k2value2'
-        )
+        self.assertEqual(config.get("param0").get("p0key1"), 1)
+        self.assertEqual(config.get("param0").get("p0key2"), 2)
+        self.assertEqual(config.get("param1")["p1key1"].get("p1k1key1"), "p1k1value1")
+        self.assertEqual(config.get("param1")["p1key1"].get("p1k1key2"), "p1k1value2")
+        self.assertEqual(config.get("param1")["p1key2"].get("p1k1key3"), "p1k1value3")
+        self.assertEqual(config.get("param1")["p1key2"].get("p1k1key4"), "p1k1value4")
+        self.assertEqual(config.get("param2")["p2key1"].get("p2subkey1"), 0)
+        self.assertEqual(config.get("param2")["p2key1"].get("p2subkey2"), "p2k2value1")
+        self.assertEqual(config.get("param2")["p2key2"].get("p2subkey1"), -1)
+        self.assertEqual(config.get("param2")["p2key2"].get("p2subkey2"), "p2k2value2")
 
     def test_load_record_with_invalid_content(self):
         """Load record with invalid content type"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'record',
-                'content': 'digit'
-            }
-        })
+        Config.SYNTAX.update({"param0": {"check": "record", "content": "digit"}})
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -1354,24 +1326,23 @@ class ConfigTestSyntax(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(
-            DeclError,
-            "^Bad data type str for 'key1'$"
-        ):
+        with self.assertRaisesRegex(DeclError, "^Bad data type str for 'key1'$"):
             config.load(cfgfile.name)
 
     def test_load_record_with_invalid_dict_content(self):
         """Load record with invalid dict syntax"""
-        Config.SYNTAX.update({
-            'param0': {
-                'check': 'record',
-                'content': 'dict',
-                'syntax': {
-                    'key1': {},
-                    'key2': {},
+        Config.SYNTAX.update(
+            {
+                "param0": {
+                    "check": "record",
+                    "content": "dict",
+                    "syntax": {
+                        "key1": {},
+                        "key2": {},
+                    },
                 },
-            },
-        })
+            }
+        )
 
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -1386,10 +1357,7 @@ class ConfigTestSyntax(RiftTestCase):
             )
         )
         config = Config()
-        with self.assertRaisesRegex(
-            DeclError,
-            "^Unknown item2 keys: key3$"
-        ):
+        with self.assertRaisesRegex(DeclError, "^Unknown item2 keys: key3$"):
             config.load(cfgfile.name)
 
     def test_load_record_merged(self):
@@ -1417,22 +1385,24 @@ class ConfigTestSyntax(RiftTestCase):
         ]
         config = Config()
         config.load([conf_file.name for conf_file in conf_files])
-        record0 = config.get('record0')
-        self.assertTrue('value1' in record0)
-        self.assertTrue('value2' in record0)
-        self.assertTrue('value3' in record0)
-        self.assertEqual(record0['value1'], 1)
-        self.assertEqual(record0['value2'], 20)
-        self.assertEqual(record0['value3'], 3)
+        record0 = config.get("record0")
+        self.assertTrue("value1" in record0)
+        self.assertTrue("value2" in record0)
+        self.assertTrue("value3" in record0)
+        self.assertEqual(record0["value1"], 1)
+        self.assertEqual(record0["value2"], 20)
+        self.assertEqual(record0["value3"], 3)
 
     def test_deprecated_param(self):
         """Load deprecated parameter"""
-        Config.SYNTAX.update({
-            'new_parameter': {},
-            'old_parameter': {
-                'deprecated': 'new_parameter',
-            },
-        })
+        Config.SYNTAX.update(
+            {
+                "new_parameter": {},
+                "old_parameter": {
+                    "deprecated": "new_parameter",
+                },
+            }
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1443,35 +1413,34 @@ class ConfigTestSyntax(RiftTestCase):
         config = Config()
         with self.assertWarns(RiftDeprecatedConfWarning) as cm:
             config.load(cfgfile.name)
-        self.assertEqual(
-            config.get('new_parameter'), 'test_value'
-        )
-        self.assertIsNone(config.get('old_parameter'))
+        self.assertEqual(config.get("new_parameter"), "test_value")
+        self.assertIsNone(config.get("old_parameter"))
         self.assertEqual(
             str(cm.warning),
             "Configuration parameter old_parameter is deprecated, use "
-            "new_parameter instead"
+            "new_parameter instead",
         )
         # Check set() on deprecated parameter raise declaration error.
         with self.assertRaisesRegex(
             DeclError,
-            "^Parameter old_parameter is deprecated, use new_parameter instead$"
+            "^Parameter old_parameter is deprecated, use new_parameter instead$",
         ):
-            config.set('old_parameter', 'another value')
-
+            config.set("old_parameter", "another value")
 
     def test_deprecated_param_with_arch(self):
         """Load deprecated parameter with arch override"""
-        Config.SYNTAX.update({
-            'new_parameter_1': {},
-            'old_parameter_1': {
-                'deprecated': 'new_parameter_1',
-            },
-            'new_parameter_2': {},
-            'old_parameter_2': {
-                'deprecated': 'new_parameter_2',
-            },
-        })
+        Config.SYNTAX.update(
+            {
+                "new_parameter_1": {},
+                "old_parameter_1": {
+                    "deprecated": "new_parameter_1",
+                },
+                "new_parameter_2": {},
+                "old_parameter_2": {
+                    "deprecated": "new_parameter_2",
+                },
+            }
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1488,41 +1457,36 @@ class ConfigTestSyntax(RiftTestCase):
         config = Config()
         with self.assertWarns(RiftDeprecatedConfWarning):
             config.load(cfgfile.name)
-        self.assertEqual(config.get('new_parameter_1'), 'generic_value')
+        self.assertEqual(config.get("new_parameter_1"), "generic_value")
+        self.assertEqual(config.get("new_parameter_1", arch="x86_64"), "generic_value")
+        self.assertEqual(config.get("new_parameter_1", arch="aarch64"), "aarch64_value")
         self.assertEqual(
-            config.get('new_parameter_1', arch='x86_64'), 'generic_value'
+            config.get("new_parameter_2", arch="x86_64"), "generic_value_x86_64"
         )
         self.assertEqual(
-            config.get('new_parameter_1', arch='aarch64'), 'aarch64_value'
+            config.get("new_parameter_2", arch="aarch64"), "generic_value_aarch64"
         )
-        self.assertEqual(
-            config.get('new_parameter_2', arch='x86_64'), 'generic_value_x86_64'
-        )
-        self.assertEqual(
-            config.get('new_parameter_2', arch='aarch64'),
-            'generic_value_aarch64'
-        )
-        self.assertIsNone(config.get('old_parameter_1'))
-        self.assertIsNone(config.get('old_parameter_2'))
+        self.assertIsNone(config.get("old_parameter_1"))
+        self.assertIsNone(config.get("old_parameter_2"))
 
     def test_deprecated_param_subdict(self):
         """Load deprecated parameter moved in subdict"""
-        Config.SYNTAX.update({
-            'new_parameter': {
-                'check': 'dict',
-                'syntax': {
-                    'sub_dict1': {
-                        'check': 'dict',
-                        'syntax': {
-                            'new_key1': {}
+        Config.SYNTAX.update(
+            {
+                "new_parameter": {
+                    "check": "dict",
+                    "syntax": {
+                        "sub_dict1": {
+                            "check": "dict",
+                            "syntax": {"new_key1": {}},
                         },
                     },
                 },
-            },
-            'old_parameter': {
-                'deprecated': 'new_parameter.sub_dict1.new_key1',
-            },
-        })
+                "old_parameter": {
+                    "deprecated": "new_parameter.sub_dict1.new_key1",
+                },
+            }
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1534,25 +1498,27 @@ class ConfigTestSyntax(RiftTestCase):
         with self.assertWarns(RiftDeprecatedConfWarning) as cm:
             config.load(cfgfile.name)
         self.assertEqual(
-            config.get('new_parameter').get('sub_dict1').get('new_key1'), 'test_value'
+            config.get("new_parameter").get("sub_dict1").get("new_key1"), "test_value"
         )
-        self.assertIsNone(config.get('old_parameter'))
+        self.assertIsNone(config.get("old_parameter"))
         self.assertEqual(
             str(cm.warning),
             "Configuration parameter old_parameter is deprecated, use "
-            "new_parameter > sub_dict1 > new_key1 instead"
+            "new_parameter > sub_dict1 > new_key1 instead",
         )
 
     def test_deprecated_param_invalid_type(self):
         """Deprecated parameter with invalid type error"""
-        Config.SYNTAX.update({
-            'new_parameter': {
-                'check': 'digit',
-            },
-            'old_parameter': {
-                'deprecated': 'new_parameter',
-            },
-        })
+        Config.SYNTAX.update(
+            {
+                "new_parameter": {
+                    "check": "digit",
+                },
+                "old_parameter": {
+                    "deprecated": "new_parameter",
+                },
+            }
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1565,23 +1531,24 @@ class ConfigTestSyntax(RiftTestCase):
         # new_parameter. Also check warning is emited for old_parameter.
         with self.assertWarns(RiftDeprecatedConfWarning) as aw:
             with self.assertRaisesRegex(
-                DeclError,
-                "Bad data type str for 'new_parameter'"
+                DeclError, "Bad data type str for 'new_parameter'"
             ):
                 config.load(cfgfile.name)
         self.assertEqual(
             str(aw.warning),
             "Configuration parameter old_parameter is deprecated, use "
-            "new_parameter instead"
+            "new_parameter instead",
         )
 
     def test_deprecated_param_unexisting_replacement(self):
         """Deprecated parameter without replacement error"""
-        Config.SYNTAX.update({
-            'old_parameter': {
-                'deprecated': 'new_parameter',
-            },
-        })
+        Config.SYNTAX.update(
+            {
+                "old_parameter": {
+                    "deprecated": "new_parameter",
+                },
+            }
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1592,23 +1559,24 @@ class ConfigTestSyntax(RiftTestCase):
         config = Config()
         # In this case, Config.set() should emit a declaration error.
         with self.assertWarns(RiftDeprecatedConfWarning) as aw:
-            with self.assertRaisesRegex(
-                DeclError, "Unknown 'new_parameter' key"):
+            with self.assertRaisesRegex(DeclError, "Unknown 'new_parameter' key"):
                 config.load(cfgfile.name)
         self.assertEqual(
             str(aw.warning),
             "Configuration parameter old_parameter is deprecated, use "
-            "new_parameter instead"
+            "new_parameter instead",
         )
 
     def test_deprecated_param_conflict(self):
         """Load deprecated parameter conflict with replacement parameter"""
-        Config.SYNTAX.update({
-            'new_parameter': {},
-            'old_parameter': {
-                'deprecated': 'new_parameter',
-            },
-        })
+        Config.SYNTAX.update(
+            {
+                "new_parameter": {},
+                "old_parameter": {
+                    "deprecated": "new_parameter",
+                },
+            }
+        )
         cfgfile = make_temp_file(
             textwrap.dedent(
                 """
@@ -1619,32 +1587,32 @@ class ConfigTestSyntax(RiftTestCase):
         )
         config = Config()
         with self.assertWarns(RiftDeprecatedConfWarning) as aw:
-            with self.assertLogs(level='WARNING') as al:
+            with self.assertLogs(level="WARNING") as al:
                 config.load(cfgfile.name)
-        self.assertEqual(
-            config.get('new_parameter'), 'test_new_value'
-        )
-        self.assertIsNone(config.get('old_parameter'))
+        self.assertEqual(config.get("new_parameter"), "test_new_value")
+        self.assertIsNone(config.get("old_parameter"))
         self.assertEqual(
             str(aw.warning),
             "Configuration parameter old_parameter is deprecated, use "
-            "new_parameter instead"
+            "new_parameter instead",
         )
         self.assertEqual(
             al.output,
-            ['WARNING:root:Both deprecated parameter old_parameter and new '
-             'parameter new_parameter are declared in configuration, '
-             'deprecated parameter old_parameter is ignored']
+            [
+                "WARNING:root:Both deprecated parameter old_parameter and new "
+                "parameter new_parameter are declared in configuration, "
+                "deprecated parameter old_parameter is ignored"
+            ],
         )
 
-class ProjectConfigTest(RiftTestCase):
 
+class ProjectConfigTest(RiftTestCase):
     def setUp(self):
         self.cwd = os.getcwd()
         self.projdir = make_temp_dir()
-        self.packagesdir = os.path.join(self.projdir, 'packages')
+        self.packagesdir = os.path.join(self.projdir, "packages")
         os.mkdir(self.packagesdir)
-        self.foodir = os.path.join(self.projdir, 'packages', 'foo')
+        self.foodir = os.path.join(self.projdir, "packages", "foo")
         os.mkdir(self.foodir)
         self.projectpath = os.path.join(self.projdir, Config._DEFAULT_FILES[0])
         os.mknod(self.projectpath)
@@ -1664,21 +1632,20 @@ class ProjectConfigTest(RiftTestCase):
 
     def test_project_path_absolute(self):
         """project_path() using absolute path is ok"""
-        absolutepath = os.path.abspath('foo')
+        absolutepath = os.path.abspath("foo")
         for path in (self.projdir, self.packagesdir, self.foodir):
             os.chdir(path)
             self.assertEqual(Config().project_path(absolutepath), absolutepath)
 
     def test_project_path_relative(self):
         """project_path() using project root relative dir is ok"""
-        relativepath = os.path.join('relative', 'path')
+        relativepath = os.path.join("relative", "path")
         realpath = os.path.join(self.projdir, relativepath)
         os.chdir(self.projdir)
         self.assertEqual(Config().project_path(relativepath), realpath)
 
 
 class StaffTest(RiftTestCase):
-
     def setUp(self):
         config = Config()
         self.staff = Staff(config)
@@ -1691,21 +1658,25 @@ class StaffTest(RiftTestCase):
         """load a staff file"""
         tmp = make_temp_file("{staff: {'J. Doe': {email: 'j.doe@rift.org'}} }")
         self.staff.load(tmp.name)
-        self.assertEqual(self.staff.get('J. Doe'), {'email': 'j.doe@rift.org'})
+        self.assertEqual(self.staff.get("J. Doe"), {"email": "j.doe@rift.org"})
 
     def test_load_default_ok(self):
         """load a staff file using default path"""
-        self.assertFalse(self.staff.get('J. Doe'))
+        self.assertFalse(self.staff.get("J. Doe"))
 
         tmp = make_temp_file("{staff: {'J. Doe': {email: 'j.doe@rift.org'}} }")
         self.staff.DEFAULT_PATH = tmp.name
         self.staff.load()
-        self.assertEqual(self.staff.get('J. Doe'), {'email': 'j.doe@rift.org'})
+        self.assertEqual(self.staff.get("J. Doe"), {"email": "j.doe@rift.org"})
 
     def test_load_missing_file(self):
         """load a missing staff file"""
-        self.assert_except(DeclError, "Could not find '/tmp/does_not_exist'",
-                           self.staff.load, '/tmp/does_not_exist')
+        self.assert_except(
+            DeclError,
+            "Could not find '/tmp/does_not_exist'",
+            self.staff.load,
+            "/tmp/does_not_exist",
+        )
 
     def test_load_unreadable_file(self):
         """load an unaccessible staff file"""
@@ -1723,31 +1694,40 @@ class StaffTest(RiftTestCase):
     def test_load_bad_format(self):
         """load a staff file with a bad yaml structure (list instead of dict)"""
         tmp = make_temp_file("{staff: ['John Doe', 'Ben Harper']}")
-        self.assert_except(DeclError, "Bad data format in staff file",
-                           self.staff.load, tmp.name)
+        self.assert_except(
+            DeclError, "Bad data format in staff file", self.staff.load, tmp.name
+        )
 
     def test_load_bad_syntax(self):
         """load a staff file with a bad yaml structure (missing 'staff')"""
         tmp = make_temp_file("{people: ['John Doe', 'Ben Harper']}")
-        self.assert_except(DeclError, "Missing 'staff' at top level in staff file",
-                           self.staff.load, tmp.name)
+        self.assert_except(
+            DeclError,
+            "Missing 'staff' at top level in staff file",
+            self.staff.load,
+            tmp.name,
+        )
 
     def test_load_useless_items(self):
         """load a staff file with unknown items"""
         tmp = make_temp_file("""{staff:
            {'J. Doe': {email: 'john.doe@rift.org', id: 145, reg: 'foo'}} }""")
-        self.assert_except(DeclError, "Unknown 'id', 'reg' item(s) for J. Doe",
-                           self.staff.load, tmp.name)
+        self.assert_except(
+            DeclError,
+            "Unknown 'id', 'reg' item(s) for J. Doe",
+            self.staff.load,
+            tmp.name,
+        )
 
     def test_load_missing_item(self):
         """load a staff file with missing items"""
         tmp = make_temp_file("""{staff: {'John Doe': {id: 145}} }""")
-        self.assert_except(DeclError, "Missing 'email' item(s) for John Doe",
-                           self.staff.load, tmp.name)
+        self.assert_except(
+            DeclError, "Missing 'email' item(s) for John Doe", self.staff.load, tmp.name
+        )
 
 
 class ModulesTest(RiftTestCase):
-
     def setUp(self):
         config = Config()
         self.staff = Staff(config)
@@ -1764,26 +1744,28 @@ class ModulesTest(RiftTestCase):
 
     def test_load_ok(self):
         """load a modules file"""
-        self.staff._data['John Doe'] = {'email': 'john.doe@rift.org'}
+        self.staff._data["John Doe"] = {"email": "john.doe@rift.org"}
 
         tmp = make_temp_file("{modules: {Kernel: {manager: 'John Doe'}} }")
         self.modules.load(tmp.name)
-        self.assertEqual(self.modules.get('Kernel'), {'manager': ['John Doe']})
+        self.assertEqual(self.modules.get("Kernel"), {"manager": ["John Doe"]})
 
     def test_load_managers(self):
         """load a modules file with several managers"""
-        self.staff._data['John Doe'] = {'email': 'john.doe@rift.org'}
-        self.staff._data['Boo'] = {'email': 'boo@rift.org'}
+        self.staff._data["John Doe"] = {"email": "john.doe@rift.org"}
+        self.staff._data["Boo"] = {"email": "boo@rift.org"}
 
         tmp = make_temp_file("""{modules: {Kernel:
                                 {manager: ['John Doe', 'Boo']}} }""")
         self.modules.load(tmp.name)
-        self.assertEqual(self.modules.get('Kernel'),
-                         {'manager': ['John Doe', 'Boo']})
+        self.assertEqual(self.modules.get("Kernel"), {"manager": ["John Doe", "Boo"]})
 
     def test_load_missing_managers(self):
         """load a modules file with a undeclared manager"""
         tmp = make_temp_file("{modules: {Kernel: {manager: 'John Doe'}} }")
-        self.assert_except(DeclError,
-                           "Manager 'John Doe' does not exist in staff list",
-                           self.modules.load, tmp.name)
+        self.assert_except(
+            DeclError,
+            "Manager 'John Doe' does not exist in staff list",
+            self.modules.load,
+            tmp.name,
+        )

--- a/tests/Config.py
+++ b/tests/Config.py
@@ -695,7 +695,7 @@ class ConfigTest(RiftTestCase):
         self.assertIsNone(config.get("repos")["repo3"].get("sync"))
 
     def test_load_sync_repo_missing_source(self):
-        """load() fails with DeclError when repositories synchronization source URL is missing."""
+        """load() fails when sync repo source URL is missing."""
         # Load minimal config
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -718,7 +718,7 @@ class ConfigTest(RiftTestCase):
             config.load(cfgfile.name)
 
     def test_load_sync_repo_invalid_method(self):
-        """load() fails with DeclError when repositories synchronization method is invalid."""
+        """load() fails when sync repo method is invalid."""
         # Load minimal config
         cfgfile = make_temp_file(
             textwrap.dedent(
@@ -1199,7 +1199,7 @@ class ConfigTestSyntax(RiftTestCase):
         self.assertEqual(param0["key2"], 1)
 
     def test_load_dict_merged_syntax_missing_required(self):
-        """load() merges dict from multiple files with syntax and required param missing in one file"""
+        """load() merges dicts and reports missing required param."""
         self._add_fake_params()
         conf_files = [
             make_temp_file(

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2018 CEA
 #
 
+# Wide expected query-table fixtures contain long lines that must stay intact.
+# ruff: noqa: E501
+
 import atexit
 import os.path
 import shutil
@@ -334,7 +337,8 @@ class ControllerProjectActionQueryTest(RiftProjectTestCase):
                 [
                     "query",
                     "--format",
-                    "%name %module %origin %reason %format %tests %version %arch %release "
+                    "%name %module %origin %reason %format %tests %version "
+                    "%arch %release "
                     "%changelogname %changelogtime %maintainers %modulemanager "
                     "%buildrequires",
                 ]
@@ -680,8 +684,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
     """
 
     def _check_qemuuserstatic(self):
-        """Skip the test if none qemu-$arch-static executable is found for all
-        architectures declared in project configuration."""
+        """Skip if no qemu-$arch-static binary for configured architectures."""
         if not any(
             [
                 os.path.exists(f"/usr/bin/qemu-{arch}-static")
@@ -1565,7 +1568,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
 
     @patch("rift.Controller.PackagesDependencyGraph")
     def test_build_graph(self, mock_graph_class):
-        """Test build generates graph of packages dependencies with dependency tracking enabled."""
+        """Test build builds dependency graph when tracking is enabled."""
         # Enable dependency tracking in configuration
         self.config.set("dependency_tracking", True)
         self.update_project_conf()
@@ -1577,7 +1580,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
     def test_build_graph_tracking_disabled(
         self, mock_graph_class, mock_project_packages_class
     ):
-        """Test build does not build graph of packages dependencies with dependency tracking disabled."""
+        """Test build skips dependency graph when tracking is disabled."""
         # Return empty list of packages with Package.list() to avoid actual
         # build iterations.
         mock_project_packages_class.list.return_value = []
@@ -1600,7 +1603,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
 
     @patch("rift.Controller.PackagesDependencyGraph")
     def test_validate_graph(self, mock_graph_class):
-        """Test validate generates graph of packages dependencies with dependency tracking enabled."""
+        """Test validate builds dependency graph when tracking is enabled."""
         # Enable dependency tracking in configuration
         self.config.set("dependency_tracking", True)
         self.update_project_conf()
@@ -1612,7 +1615,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
     def test_validate_graph_tracking_disabled(
         self, mock_graph_class, mock_project_packages_class
     ):
-        """Test validate does not build graph of packages dependencies with dependency tracking disabled."""
+        """Test validate skips dependency graph when tracking is disabled."""
         # Return empty list of packages with Package.list() to avoid actual
         # build iterations.
         mock_project_packages_class.list.return_value = []
@@ -1635,7 +1638,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_graph_class.from_project.assert_not_called()
 
     def test_get_packages_to_build_tracking_disabled(self):
-        """Test get_packages_to_build() with tracking disabled (by default) returns user provided packages."""
+        """Test get_packages_to_build() returns given pkgs when tracking off."""
         args = Mock()
         args.skip_deps = False
         args.packages = ["pkg"]
@@ -1643,7 +1646,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         self.assertEqual([pkg.name for pkg in pkgs], ["pkg"])
 
     def test_get_packages_to_build_skip_deps(self):
-        """Test get_packages_to_build() with skip deps (tracking enabled) returns user provided packages."""
+        """Test get_packages_to_build() returns given pkgs with skip_deps."""
         self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = True
@@ -1652,7 +1655,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         self.assertEqual([pkg.name for pkg in pkgs], ["pkg"])
 
     def test_get_packages_to_build_no_package(self):
-        """Test get_packages_to_build() (tracking enabled, w/o skip deps) returns empty with unexisting package."""
+        """Test get_packages_to_build() is empty for unknown package."""
         self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = False
@@ -1664,7 +1667,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
 
     @patch("rift.package.rpm.Mock")
     def test_get_packages_to_build_package_order(self, mock_mock):
-        """Test get_packages_to_build() returns correctly ordered list of reverse dependencies."""
+        """Test get_packages_to_build() orders reverse dependencies."""
         """
         Test get_packages_to_build() returns correctly ordered list of reverse
         dependencies.
@@ -1765,7 +1768,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
 
     @patch("rift.package.rpm.Mock")
     def test_get_packages_to_build_cyclic_deps(self, mock_mock):
-        """Test get_packages_to_build() returns correctly ordered list of reverse dependencies."""
+        """Test get_packages_to_build() orders reverse dependencies."""
         self.make_pkg(name="libone", metadata={"depends": "libtwo"})
         self.make_pkg(name="libtwo", metadata={"depends": "libthree"})
         self.make_pkg(name="libthree", metadata={"depends": "libone"})

--- a/tests/Controller.py
+++ b/tests/Controller.py
@@ -2,61 +2,59 @@
 # Copyright (C) 2018 CEA
 #
 
+import atexit
 import os.path
 import shutil
-import atexit
-from unittest.mock import patch, Mock, call
 import subprocess
 import textwrap
 from io import StringIO
+from unittest.mock import Mock, call, patch
+
+from rift import DeclError, RiftError
+from rift.Config import _DEFAULT_VARIANT
+from rift.Controller import (
+    get_packages_in_graph,
+    get_packages_to_build,
+    main,
+    make_parser,
+    remove_packages,
+)
+from rift.package._virtual import PackageVirtual
+from rift.package.oci import ActionableArchPackageOCI, PackageOCI
+from rift.package.rpm import ActionableArchPackageRPM, PackageRPM
+from rift.RPM import RPM
+from rift.TestResults import TestCase, TestResults
 
 from .TestUtils import (
+    RiftProjectTestCase,
+    RiftTestCase,
+    SubPackage,
+    gen_rpm_spec,
+    host_rpmlint,
     make_temp_dir,
     make_temp_file,
     make_temp_tar,
-    gen_rpm_spec,
     read_file,
-    host_rpmlint,
-    RiftTestCase,
-    RiftProjectTestCase,
-    SubPackage,
 )
-
-from .VM import GLOBAL_CACHE, VALID_IMAGE_URL, PROXY
-from rift.Controller import (
-    main,
-    get_packages_in_graph,
-    get_packages_to_build,
-    remove_packages,
-    make_parser,
-)
-from rift.Config import _DEFAULT_VARIANT
-from rift.package.rpm import PackageRPM, ActionableArchPackageRPM
-from rift.package.oci import PackageOCI, ActionableArchPackageOCI
-from rift.package._virtual import PackageVirtual
-from rift.TestResults import TestResults, TestCase
-from rift.RPM import RPM
-from rift import RiftError, DeclError
-
+from .VM import GLOBAL_CACHE, PROXY, VALID_IMAGE_URL
 
 VALID_REPOS = {
-    'os': {
-        'url': 'https://repo.almalinux.org/almalinux/8/BaseOS/$arch/os/',
+    "os": {
+        "url": "https://repo.almalinux.org/almalinux/8/BaseOS/$arch/os/",
     },
-    'appstream': {
-        'url': 'https://repo.almalinux.org/almalinux/8/AppStream/$arch/os/',
+    "appstream": {
+        "url": "https://repo.almalinux.org/almalinux/8/AppStream/$arch/os/",
     },
-    'powertools': {
-        'url': 'https://repo.almalinux.org/almalinux/8/PowerTools/$arch/os/',
+    "powertools": {
+        "url": "https://repo.almalinux.org/almalinux/8/PowerTools/$arch/os/",
     },
 }
 
 
 class ControllerTest(RiftTestCase):
-
     def test_main_version(self):
         """simple 'rift --version'"""
-        self.assert_except(SystemExit, "0", main, ['--version'])
+        self.assert_except(SystemExit, "0", main, ["--version"])
 
 
 class ControllerProjectActionCreateTest(RiftProjectTestCase):
@@ -66,136 +64,198 @@ class ControllerProjectActionCreateTest(RiftProjectTestCase):
 
     def test_create_missing_pkg_module_reason(self):
         """create without package, module or reason fails"""
-        for cmd in (['create', '-m', 'Great module', '-r', 'Good reason'],
-                    ['create', 'pkg', '-r', 'Good reason'],
-                    ['create', 'pkg', '-m', 'Great module']):
+        for cmd in (
+            ["create", "-m", "Great module", "-r", "Good reason"],
+            ["create", "pkg", "-r", "Good reason"],
+            ["create", "pkg", "-m", "Great module"],
+        ):
             with self.assertRaisesRegex(SystemExit, "2"):
                 main(cmd)
 
     def test_create_missing_maintainer(self):
         """create without maintainer"""
         with self.assertRaisesRegex(RiftError, "You must specify a maintainer"):
-            main(['create', 'pkg', '-m', 'Great module', '-r', 'Good reason'])
+            main(["create", "pkg", "-m", "Great module", "-r", "Good reason"])
 
     def test_create(self):
         """simple create"""
-        main(['create', 'pkg', '-m', 'Great module', '-r', 'Good reason',
-              '--maintainer', 'Myself'])
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        main(
+            [
+                "create",
+                "pkg",
+                "-m",
+                "Great module",
+                "-r",
+                "Good reason",
+                "--maintainer",
+                "Myself",
+            ]
+        )
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         pkg.load_info()
-        self.assertEqual(pkg.module, 'Great module')
-        self.assertEqual(pkg.reason, 'Good reason')
-        self.assertCountEqual(pkg.maintainers, ['Myself'])
+        self.assertEqual(pkg.module, "Great module")
+        self.assertEqual(pkg.reason, "Good reason")
+        self.assertCountEqual(pkg.maintainers, ["Myself"])
         os.unlink(pkg.metafile)
         os.rmdir(os.path.dirname(pkg.metafile))
 
     def test_create_unknown_maintainer(self):
         """create with unknown maintainer fails"""
-        with self.assertRaisesRegex(
-            RiftError, "Maintainer 'Fail' is not defined"):
-            main(['create', 'pkg', '-m', 'Great module', '-r', 'Good reason',
-                  '--maintainer', 'Fail'])
+        with self.assertRaisesRegex(RiftError, "Maintainer 'Fail' is not defined"):
+            main(
+                [
+                    "create",
+                    "pkg",
+                    "-m",
+                    "Great module",
+                    "-r",
+                    "Good reason",
+                    "--maintainer",
+                    "Fail",
+                ]
+            )
 
 
 class ControllerProjectActionImportTest(RiftProjectTestCase):
     """
     Tests class for Controller action import
     """
+
     @property
     def src_rpm(self):
         return os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'materials', 'pkg-1.0-1.src.rpm'
+            os.path.dirname(os.path.abspath(__file__)), "materials", "pkg-1.0-1.src.rpm"
         )
 
     @property
     def bin_rpm(self):
         return os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'materials', 'pkg-1.0-1.noarch.rpm'
+            os.path.dirname(os.path.abspath(__file__)),
+            "materials",
+            "pkg-1.0-1.noarch.rpm",
         )
 
     def test_import_missing_pkg_module_reason(self):
         """import without package, module or reason fails"""
-        for cmd in (['import', '-m', 'Great module', '-r', 'Good reason'],
-                    ['import', 'pkg.src.rpm', '-r', 'Good reason'],
-                    ['import', 'pkg.src.rpm', '-m', 'Great module']):
+        for cmd in (
+            ["import", "-m", "Great module", "-r", "Good reason"],
+            ["import", "pkg.src.rpm", "-r", "Good reason"],
+            ["import", "pkg.src.rpm", "-m", "Great module"],
+        ):
             with self.assertRaisesRegex(SystemExit, "2"):
                 main(cmd)
 
     def test_import_missing_maintainer(self):
         """import without maintainer"""
         with self.assertRaisesRegex(RiftError, "You must specify a maintainer"):
-            main(['import', self.src_rpm, '-m', 'Great module', '-r', 'Good reason'])
+            main(["import", self.src_rpm, "-m", "Great module", "-r", "Good reason"])
 
     def test_import_bin_rpm(self):
         """import binary rpm"""
         with self.assertRaisesRegex(
-            RiftError,
-            ".*pkg-1.0-1.noarch.rpm is not a source RPM$"):
-            main(['import', self.bin_rpm, '-m', 'Great module',
-                  '-r', 'Good reason', '--maintainer', 'Myself'])
+            RiftError, ".*pkg-1.0-1.noarch.rpm is not a source RPM$"
+        ):
+            main(
+                [
+                    "import",
+                    self.bin_rpm,
+                    "-m",
+                    "Great module",
+                    "-r",
+                    "Good reason",
+                    "--maintainer",
+                    "Myself",
+                ]
+            )
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_import(self, mock_mock):
         """simple import"""
-        main(['import', self.src_rpm, '-m', 'Great module', '-r', 'Good reason',
-              '--maintainer', 'Myself'])
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        main(
+            [
+                "import",
+                self.src_rpm,
+                "-m",
+                "Great module",
+                "-r",
+                "Good reason",
+                "--maintainer",
+                "Myself",
+            ]
+        )
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         pkg.load()
-        self.assertEqual(pkg.module, 'Great module')
-        self.assertEqual(pkg.reason, 'Good reason')
-        self.assertCountEqual(pkg.maintainers, ['Myself'])
-        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(pkg.spec.version, '1.0')
-        self.assertEqual(pkg.spec.release, '1')
+        self.assertEqual(pkg.module, "Great module")
+        self.assertEqual(pkg.reason, "Good reason")
+        self.assertCountEqual(pkg.maintainers, ["Myself"])
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1"
+        )
+        self.assertEqual(pkg.spec.version, "1.0")
+        self.assertEqual(pkg.spec.release, "1")
         self.assertTrue(os.path.exists(f"{pkg.buildfile}.orig"))
         shutil.rmtree(os.path.dirname(pkg.metafile))
 
     def test_import_unknown_maintainer(self):
         """import with unknown maintainer fails"""
-        with self.assertRaisesRegex(
-            RiftError, "Maintainer 'Fail' is not defined"):
-            main(['import', self.src_rpm, '-m', 'Great module',
-                    '-r', 'Good reason', '--maintainer', 'Fail'])
+        with self.assertRaisesRegex(RiftError, "Maintainer 'Fail' is not defined"):
+            main(
+                [
+                    "import",
+                    self.src_rpm,
+                    "-m",
+                    "Great module",
+                    "-r",
+                    "Good reason",
+                    "--maintainer",
+                    "Fail",
+                ]
+            )
 
 
 class ControllerProjectActionReimportTest(RiftProjectTestCase):
     """
     Tests class for Controller actionre import
     """
+
     @property
     def src_rpm(self):
         return os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'materials', 'pkg-1.0-1.src.rpm'
+            os.path.dirname(os.path.abspath(__file__)), "materials", "pkg-1.0-1.src.rpm"
         )
 
     @property
     def bin_rpm(self):
         return os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'materials', 'pkg-1.0-1.noarch.rpm'
+            os.path.dirname(os.path.abspath(__file__)),
+            "materials",
+            "pkg-1.0-1.noarch.rpm",
         )
 
     def test_reimport_missing_maintainer(self):
         """reimport without maintainer"""
         with self.assertRaisesRegex(RiftError, "You must specify a maintainer"):
-            main(['reimport', self.src_rpm, '-m', 'Great module', '-r', 'Good reason'])
+            main(["reimport", self.src_rpm, "-m", "Great module", "-r", "Good reason"])
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_reimport(self, mock_mock):
         """simple reimport"""
-        self.make_pkg(name='pkg')
+        self.make_pkg(name="pkg")
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        main(['reimport', self.src_rpm, '--maintainer', 'Myself'])
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        main(["reimport", self.src_rpm, "--maintainer", "Myself"])
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         pkg.load()
-        self.assertEqual(pkg.module, 'Great module')
-        self.assertEqual(pkg.reason, 'Missing feature')
-        self.assertCountEqual(pkg.maintainers, ['Myself'])
-        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(pkg.spec.version, '1.0')
-        self.assertEqual(pkg.spec.release, '1')
+        self.assertEqual(pkg.module, "Great module")
+        self.assertEqual(pkg.reason, "Missing feature")
+        self.assertCountEqual(pkg.maintainers, ["Myself"])
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1"
+        )
+        self.assertEqual(pkg.spec.version, "1.0")
+        self.assertEqual(pkg.spec.release, "1")
         self.assertTrue(os.path.exists(f"{pkg.buildfile}.orig"))
         os.unlink(f"{pkg.buildfile}.orig")
 
@@ -204,86 +264,99 @@ class ControllerProjectActionQueryTest(RiftProjectTestCase):
     """
     Tests class for Controller action query
     """
-    def test_action_query(self):
-        """simple 'rift query' is ok """
-        self.assertEqual(main(['query']), 0)
 
-    @patch('rift.package.rpm.Mock')
+    def test_action_query(self):
+        """simple 'rift query' is ok"""
+        self.assertEqual(main(["query"]), 0)
+
+    @patch("rift.package.rpm.Mock")
     def test_action_query_on_pkg(self, mock_mock):
-        """ Test query on one package """
+        """Test query on one package"""
         self.make_pkg()
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        self.assertEqual(main(['query', 'pkg']), 0)
+        self.assertEqual(main(["query", "pkg"]), 0)
 
     def test_action_query_formats(self):
-        """ Test query with format filter """
+        """Test query with format filter"""
         self.make_pkg()
-        with self.assertLogs(level='INFO') as log:
-            self.assertEqual(main(['query', '--formats', 'rpm']), 0)
+        with self.assertLogs(level="INFO") as log:
+            self.assertEqual(main(["query", "--formats", "rpm"]), 0)
 
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping query oci package pkg due to restriction on '
-            'package formats',
-            log.output
+            "INFO:root:Skipping query oci package pkg due to restriction on "
+            "package formats",
+            log.output,
         )
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_action_query_on_bad_pkg(self, mock_mock):
-        """ Test query on multiple packages with one errorneous package """
+        """Test query on multiple packages with one errorneous package"""
         self.make_pkg()
         ## A package with no name should be wrong but the command should not fail
-        self.make_pkg(name='pkg2', metadata={})
+        self.make_pkg(name="pkg2", metadata={})
         mock_mock.return_value.read_spec = read_file
-        self.assertEqual(main(['query']), 0)
+        self.assertEqual(main(["query"]), 0)
 
-    @patch('rift.package.rpm.Mock')
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("rift.package.rpm.Mock")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_action_query_output_default(self, mock_stdout, mock_mock):
         self.make_pkg(name="pkg1")
-        self.make_pkg(name="pkg2", version='2.1', release='3')
+        self.make_pkg(name="pkg2", version="2.1", release="3")
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        self.assertEqual(main(['query']), 0)
+        self.assertEqual(main(["query"]), 0)
         self.assertIn(
             "NAME MODULE       MAINTAINERS FORMAT VERSION RELEASE MODULEMANAGER",
-            mock_stdout.getvalue())
-        self.assertIn(textwrap.dedent("""
+            mock_stdout.getvalue(),
+        )
+        self.assertIn(
+            textwrap.dedent("""
             ---- ------       ----------- ------ ------- ------- -------------
             pkg1 Great module Myself      rpm    1.0     1       buddy@somewhere.org
             pkg1 Great module Myself      oci    1.0     1       buddy@somewhere.org
             pkg2 Great module Myself      rpm    2.1     3       buddy@somewhere.org
             pkg2 Great module Myself      oci    2.1     3       buddy@somewhere.org
             """),
-            mock_stdout.getvalue())
+            mock_stdout.getvalue(),
+        )
 
-    @patch('rift.package.rpm.Mock')
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("rift.package.rpm.Mock")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_action_query_output_format(self, mock_stdout, mock_mock):
         self.make_pkg(name="pkg1")
-        self.make_pkg(name="pkg2", version='2.1', release='3')
+        self.make_pkg(name="pkg2", version="2.1", release="3")
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         self.assertEqual(
-            main([
-                'query', '--format',
-                '%name %module %origin %reason %format %tests %version %arch %release '
-                '%changelogname %changelogtime %maintainers %modulemanager '
-                '%buildrequires']), 0)
+            main(
+                [
+                    "query",
+                    "--format",
+                    "%name %module %origin %reason %format %tests %version %arch %release "
+                    "%changelogname %changelogtime %maintainers %modulemanager "
+                    "%buildrequires",
+                ]
+            ),
+            0,
+        )
         self.assertIn(
             "NAME MODULE       ORIGIN REASON          FORMAT TESTS VERSION "
             "ARCH   RELEASE CHANGELOGNAME                      CHANGELOGTIME "
             "MAINTAINERS MODULEMANAGER       BUILDREQUIRES",
-            mock_stdout.getvalue())
-        self.assertIn(textwrap.dedent("""
+            mock_stdout.getvalue(),
+        )
+        self.assertIn(
+            textwrap.dedent("""
             ---- ------       ------ ------          ------ ----- ------- ----   ------- -------------                      ------------- ----------- -------------       -------------
             pkg1 Great module Vendor Missing feature rpm    1     1.0     noarch 1       Myself <buddy@somewhere.org> 1.0-1 2019-02-26    Myself      buddy@somewhere.org br-package
             pkg1 Great module Vendor Missing feature oci    1     1.0            1                                                        Myself      buddy@somewhere.org
             pkg2 Great module Vendor Missing feature rpm    1     2.1     noarch 3       Myself <buddy@somewhere.org> 2.1-3 2019-02-26    Myself      buddy@somewhere.org br-package
             pkg2 Great module Vendor Missing feature oci    1     2.1            3                                                        Myself      buddy@somewhere.org
             """),
-            mock_stdout.getvalue())
+            mock_stdout.getvalue(),
+        )
 
 
 class ControllerProjectActionCheckTest(RiftProjectTestCase):
@@ -294,187 +367,166 @@ class ControllerProjectActionCheckTest(RiftProjectTestCase):
     def test_check_without_type(self):
         """check without type fails"""
         with self.assertRaisesRegex(SystemExit, "2"):
-            main(['check'])
+            main(["check"])
 
     def test_check_staff(self):
         """simple check staff"""
-        with self.assertLogs(level='INFO') as log:
-            exit_code = main(['check', 'staff'])
+        with self.assertLogs(level="INFO") as log:
+            exit_code = main(["check", "staff"])
         self.assertEqual(exit_code, 0)
-        self.assertIn(
-            'INFO:root:Staff file is OK.',
-            log.output
-        )
+        self.assertIn("INFO:root:Staff file is OK.", log.output)
 
     def test_check_staff_not_found(self):
         """check staff file not found fails"""
         with self.assertRaisesRegex(DeclError, "Could not find '/dev/fail'"):
-            exit_code = main(['check', 'staff', '-f', '/dev/fail'])
+            exit_code = main(["check", "staff", "-f", "/dev/fail"])
             self.assertEqual(exit_code, 1)
 
     def test_check_modules(self):
         """simple check modules"""
-        with self.assertLogs(level='INFO') as log:
-            exit_code = main(['check', 'modules'])
+        with self.assertLogs(level="INFO") as log:
+            exit_code = main(["check", "modules"])
         self.assertEqual(exit_code, 0)
-        self.assertIn(
-            'INFO:root:Modules file is OK.',
-            log.output
-        )
+        self.assertIn("INFO:root:Modules file is OK.", log.output)
 
     def test_check_modules_not_found(self):
         """check modules file not found fails"""
         with self.assertRaisesRegex(DeclError, "Could not find '/dev/fail'"):
-            exit_code = main(['check', 'modules', '-f', '/dev/fail'])
+            exit_code = main(["check", "modules", "-f", "/dev/fail"])
             self.assertEqual(exit_code, 1)
 
     def test_check_info_without_file(self):
         """check info without file fails"""
-        with self.assertRaisesRegex(
-            RiftError, r"You must specify a file path \(-f\)"
-        ):
-            exit_code = main(['check', 'info'])
+        with self.assertRaisesRegex(RiftError, r"You must specify a file path \(-f\)"):
+            exit_code = main(["check", "info"])
             self.assertEqual(exit_code, 1)
 
     def test_check_info(self):
         """simple check info"""
         self.make_pkg()
-        with self.assertLogs(level='INFO') as log:
+        with self.assertLogs(level="INFO") as log:
             exit_code = main(
-                ['check', 'info', '-f',
-                 os.path.join(self.pkgdirs['pkg'], 'info.yaml')]
+                ["check", "info", "-f", os.path.join(self.pkgdirs["pkg"], "info.yaml")]
             )
         self.assertEqual(exit_code, 0)
-        self.assertIn(
-            'INFO:root:Info file is OK.',
-            log.output
-        )
+        self.assertIn("INFO:root:Info file is OK.", log.output)
 
     def test_check_info_not_found(self):
         """check info file not found fails"""
         self.make_pkg()
         with self.assertRaises(FileNotFoundError):
-            exit_code = main(['check', 'info', '-f', '/dev/fail'])
+            exit_code = main(["check", "info", "-f", "/dev/fail"])
             self.assertEqual(exit_code, 1)
 
     def test_check_spec_without_file(self):
         """check spec without file fails"""
-        with self.assertRaisesRegex(
-            RiftError, r"You must specify a file path \(-f\)"
-        ):
-            exit_code = main(['check', 'spec'])
+        with self.assertRaisesRegex(RiftError, r"You must specify a file path \(-f\)"):
+            exit_code = main(["check", "spec"])
             self.assertEqual(exit_code, 1)
 
-    @patch('rift.Controller.Mock')
+    @patch("rift.Controller.Mock")
     def test_check_spec(self, mock_mock):
         """simple check spec"""
         self.make_pkg()
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
-            with self.assertLogs(level='INFO') as log:
-                exit_code = main(
-                    ['check', 'spec', '-f', self.buildfiles['pkg:rpm']]
-                )
+        with patch.object(mock_mock.return_value, "rpmlint", host_rpmlint):
+            with self.assertLogs(level="INFO") as log:
+                exit_code = main(["check", "spec", "-f", self.buildfiles["pkg:rpm"]])
         self.assertEqual(exit_code, 0)
-        self.assertIn(
-            'INFO:root:Spec file is OK.',
-            log.output
-        )
+        self.assertIn("INFO:root:Spec file is OK.", log.output)
 
     def test_check_spec_not_found(self):
         """check spec file not found fails"""
         self.make_pkg()
         with self.assertRaisesRegex(RiftError, "/dev/fail does not exist"):
-            main(['check', 'spec', '-f', '/dev/fail'])
+            main(["check", "spec", "-f", "/dev/fail"])
 
     def test_check_containerfile_without_file(self):
         """check containerfile without file fails"""
-        with self.assertRaisesRegex(
-            RiftError, r"You must specify a file path \(-f\)"):
-            main(['check', 'containerfile'])
+        with self.assertRaisesRegex(RiftError, r"You must specify a file path \(-f\)"):
+            main(["check", "containerfile"])
 
     def test_check_containerfile(self):
         """simple check containerfile"""
-        self.make_pkg(formats=['oci'])
-        with self.assertLogs(level='INFO') as log:
-            main(
-                ['check', 'containerfile', '-f', self.buildfiles['pkg:oci']]
-            )
-        self.assertIn(
-            'INFO:root:Containerfile is OK.',
-            log.output
-        )
+        self.make_pkg(formats=["oci"])
+        with self.assertLogs(level="INFO") as log:
+            main(["check", "containerfile", "-f", self.buildfiles["pkg:oci"]])
+        self.assertIn("INFO:root:Containerfile is OK.", log.output)
 
     def test_check_containerfile_not_found(self):
         """check containerfile file not found fails"""
         self.make_pkg()
-        with self.assertRaisesRegex(RiftError, "Unable to find Containerfile /dev/fail"):
-            main(['check', 'containerfile', '-f', '/dev/fail'])
+        with self.assertRaisesRegex(
+            RiftError, "Unable to find Containerfile /dev/fail"
+        ):
+            main(["check", "containerfile", "-f", "/dev/fail"])
 
 
 class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
     """
     Tests class for Controller action validdiff
     """
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.Controller.remove_packages')
-    @patch('rift.Controller.validate_pkgs')
-    @patch('rift.Controller.get_packages_from_patch')
+
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.Controller.remove_packages")
+    @patch("rift.Controller.validate_pkgs")
+    @patch("rift.Controller.get_packages_from_patch")
     def test_action_validdiff(
-            self,
-            mock_get_packages_from_patch,
-            mock_validate_pkgs,
-            mock_remove_packages,
-            mock_stdout,
+        self,
+        mock_get_packages_from_patch,
+        mock_validate_pkgs,
+        mock_remove_packages,
+        mock_stdout,
     ):
-        """ Test validdiff action calls expected functions """
+        """Test validdiff action calls expected functions"""
         updated = [
-                PackageRPM('pkg', self.config, self.staff, self.modules),
-                PackageOCI('oci', self.config, self.staff, self.modules),
+            PackageRPM("pkg", self.config, self.staff, self.modules),
+            PackageOCI("oci", self.config, self.staff, self.modules),
         ]
         removed = []
         mock_get_packages_from_patch.return_value = (updated, removed)
         mock_validate_pkgs.return_value = TestResults()
-        self.config.set('arch', ['x86_64'])
+        self.config.set("arch", ["x86_64"])
         self.update_project_conf()
-        self.assertEqual(main(['validdiff', '/dev/null']), 0)
+        self.assertEqual(main(["validdiff", "/dev/null"]), 0)
 
         mock_get_packages_from_patch.assert_called_once()
         mock_validate_pkgs.assert_called_once()
         mock_remove_packages.assert_called_once()
 
         out = mock_stdout.getvalue()
-        self.assertIn(
-            '** Validate thread validate-x86_64 output: **', out)
+        self.assertIn("** Validate thread validate-x86_64 output: **", out)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.Controller.validate_pkgs')
-    @patch('rift.Controller.remove_packages')
-    @patch('rift.Controller.get_packages_from_patch')
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.Controller.validate_pkgs")
+    @patch("rift.Controller.remove_packages")
+    @patch("rift.Controller.get_packages_from_patch")
     def test_action_validdiff_quiet_success(
-            self,
-            mock_get_packages_from_patch,
-            mock_remove_packages,
-            mock_validate_pkgs,
-            mock_stdout):
+        self,
+        mock_get_packages_from_patch,
+        mock_remove_packages,
+        mock_validate_pkgs,
+        mock_stdout,
+    ):
         """validiff --quiet does not print build output on success."""
         mock_get_packages_from_patch.return_value = (
-            [PackageRPM('pkg', self.config, self.staff, self.modules)], []
+            [PackageRPM("pkg", self.config, self.staff, self.modules)],
+            [],
         )
         mock_validate_pkgs.return_value = TestResults()
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
-        self.assertEqual(main(['validdiff', '/dev/null', '--quiet']), 0)
+        self.assertEqual(main(["validdiff", "/dev/null", "--quiet"]), 0)
 
         out = mock_stdout.getvalue()
-        self.assertNotIn('Validate thread', out)
+        self.assertNotIn("Validate thread", out)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.Controller.get_packages_from_patch')
-    @patch('rift.Controller.remove_packages')
-    @patch('rift.Controller.validate_pkgs')
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.Controller.get_packages_from_patch")
+    @patch("rift.Controller.remove_packages")
+    @patch("rift.Controller.validate_pkgs")
     def test_action_validdiff_quiet_failure(
         self,
         mock_validate_pkgs,
@@ -485,41 +537,42 @@ class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
         """validiff --quiet prints build output on failure."""
 
         mock_get_packages_from_patch.return_value = (
-            [PackageRPM('pkg', self.config, self.staff, self.modules)], []
+            [PackageRPM("pkg", self.config, self.staff, self.modules)],
+            [],
         )
 
         validate_failed = TestResults()
         validate_failed.add_failure(
-            TestCase('build', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'),
+            TestCase("build", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"),
             1.0,
-            err='simulated validate failure',
+            err="simulated validate failure",
         )
         mock_validate_pkgs.return_value = validate_failed
 
-        self.config.set('arch', ['x86_64'])
+        self.config.set("arch", ["x86_64"])
         self.update_project_conf()
 
-        self.assertEqual(main(['validdiff', '/dev/null', '--quiet']), 1)
+        self.assertEqual(main(["validdiff", "/dev/null", "--quiet"]), 1)
 
         self.assertIn(
-            '** Validate thread validate-x86_64 output: **',
+            "** Validate thread validate-x86_64 output: **",
             mock_stdout.getvalue(),
         )
 
-    @patch('rift.Controller.remove_packages')
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
-    @patch('rift.Controller.get_packages_from_patch')
+    @patch("rift.Controller.remove_packages")
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
+    @patch("rift.Controller.get_packages_from_patch")
     def test_action_validdiff_formats(
-            self,
-            mock_get_packages_from_patch,
-            mock_pkg_rpm,
-            mock_staging_repo_cls,
-            mock_remove_packages,
+        self,
+        mock_get_packages_from_patch,
+        mock_pkg_rpm,
+        mock_staging_repo_cls,
+        mock_remove_packages,
     ):
         """validdiff --formats restricts validation to specific package formats."""
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -528,7 +581,8 @@ class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
         # Get PackageRPM instances mock
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         mock_get_packages_from_patch.return_value = ([mock_pkg_rpm_objs], [])
         # Make PackageRPM.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -543,12 +597,11 @@ class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
         mock_staging_repo_cls.return_value = mock_staging_repo
 
         # Run validdiff on patch with format restriction
-        self.assertEqual(
-            main(['validdiff', '/dev/null', '--formats', 'rpm']), 0)
+        self.assertEqual(main(["validdiff", "/dev/null", "--formats", "rpm"]), 0)
 
         # Check RPM package supports_arch() method is called for all supported
         # archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
 
         # Check RPM package check() method is called for all supported arch
@@ -558,17 +611,25 @@ class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
         # Check actionable RPM package build(), publish(staging), test() and
         # clean() methods are called for all supported arch (ie. twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo)])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False),
-             call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+            ]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls(
-            [call(noquit=False), call(noquit=False)])
+            [call(noquit=False), call(noquit=False)]
+        )
 
-    @patch('rift.Controller.ProjectArchRepositories')
+    @patch("rift.Controller.ProjectArchRepositories")
     def test_remove_packages(self, mock_parepository_class):
         """remove_packages() search, delete and update repository."""
         mock_parepository_objects = mock_parepository_class.return_value
@@ -578,15 +639,13 @@ class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
         args.publish = True
 
         # Define a list of packages to remove
-        pkgs_to_remove = [
-            PackageVirtual('pkg', self.config, self.staff, self.modules)
-        ]
+        pkgs_to_remove = [PackageVirtual("pkg", self.config, self.staff, self.modules)]
 
         # Define working_repo in configuration
-        self.config.options['working_repo'] = '/path/to/working/repo'
+        self.config.options["working_repo"] = "/path/to/working/repo"
 
         # Call remove_packages()
-        remove_packages(self.config, args, pkgs_to_remove, 'x86_64')
+        remove_packages(self.config, args, pkgs_to_remove, "x86_64")
 
         # Check ProjectArchRepository object has been instanciated
         mock_parepository_class.assert_called()
@@ -595,25 +654,23 @@ class ControllerProjectActionValiddiffTest(RiftProjectTestCase):
             pkgs_to_remove[0].name
         )
 
-    @patch('rift.Controller.ProjectArchRepositories.delete_matching')
+    @patch("rift.Controller.ProjectArchRepositories.delete_matching")
     def test_remove_packages_noop(self, mock_delete_matching):
         """remove_packages() is noop if no publish arg or no working_repo"""
 
-        pkgs_to_remove = [
-            PackageVirtual('pkg', self.config, self.staff, self.modules)
-        ]
+        pkgs_to_remove = [PackageVirtual("pkg", self.config, self.staff, self.modules)]
         args = Mock()
 
         # publish is False, remove_packages() must be noop
         args.publish = False
-        self.config.options['working_repo'] = '/path/to/working/repo'
-        remove_packages(self.config, args, pkgs_to_remove, 'x86_64')
+        self.config.options["working_repo"] = "/path/to/working/repo"
+        remove_packages(self.config, args, pkgs_to_remove, "x86_64")
         mock_delete_matching.assert_not_called()
 
         # working_repo is not defined, remove_packages() must be noop
         args.publish = True
-        del self.config.options['working_repo']
-        remove_packages(self.config, args, pkgs_to_remove, 'x86_64')
+        del self.config.options["working_repo"]
+        remove_packages(self.config, args, pkgs_to_remove, "x86_64")
         mock_delete_matching.assert_not_called()
 
 
@@ -621,30 +678,31 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
     """
     Tests class for Controller actions build, test and validate
     """
+
     def _check_qemuuserstatic(self):
         """Skip the test if none qemu-$arch-static executable is found for all
         architectures declared in project configuration."""
         if not any(
             [
                 os.path.exists(f"/usr/bin/qemu-{arch}-static")
-                for arch in self.config.get('arch')
+                for arch in self.config.get("arch")
             ]
         ):
             self.skipTest("qemu-user-static is not available")
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_build(self, mock_pkg_rpm, mock_pkg_oci, mock_stdout):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
 
         # Create temporary working repo and register its deletion at exit
         working_repo = make_temp_dir()
         atexit.register(shutil.rmtree, working_repo)
 
-        self.config.set('working_repo', working_repo)
+        self.config.set("working_repo", working_repo)
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -655,9 +713,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
         mock_pkg_oci_objs.supports_arch.return_value = True
@@ -668,48 +728,50 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
         mock_pkg_oci_objs.for_arch.return_value = mock_act_arch_pkg_oci
 
-        self.assertEqual(main(['build', 'pkg', '--publish']), 0)
+        self.assertEqual(main(["build", "pkg", "--publish"]), 0)
 
         # Check RPM and OCI package supports_arch() method is called for all
         # supported archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
             mock_pkg_oci_objs.supports_arch.assert_any_call(arch)
 
         # Check actionable RPM and OCI package build(), publish() and clean()
         # methods are called for all supported arch (ie. twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=None), call(sign=False, staging=None)])
+            [call(sign=False, staging=None), call(sign=False, staging=None)]
+        )
         mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=None), call(sign=False, staging=None)])
+            [call(sign=False, staging=None), call(sign=False, staging=None)]
+        )
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
             [
                 call(updaterepo=True, sign=False),
                 call(updaterepo=True, sign=False),
-            ])
+            ]
+        )
         mock_act_arch_pkg_oci.publish.assert_has_calls(
             [
                 call(updaterepo=True, sign=False),
                 call(updaterepo=True, sign=False),
-            ])
+            ]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls([call(), call()])
         mock_act_arch_pkg_oci.clean.assert_has_calls([call(), call()])
 
         out = mock_stdout.getvalue()
-        self.assertIn(
-            '** Build thread build-x86_64 output: **', out)
-        self.assertIn(
-            '** Build thread build-aarch64 output: **', out)
+        self.assertIn("** Build thread build-x86_64 output: **", out)
+        self.assertIn("** Build thread build-aarch64 output: **", out)
 
         # Remove temporary working repo and unregister its deletion at exit
         shutil.rmtree(working_repo)
         atexit.unregister(shutil.rmtree)
 
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_build_formats(self, mock_pkg_rpm):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -719,7 +781,8 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         # Initialize PackageRPM object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         # Make PackageRPM.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
 
@@ -727,54 +790,52 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
 
-        with self.assertLogs(level='INFO') as log:
-            self.assertEqual(
-                main(['build', 'pkg', '--formats', 'rpm']), 0)
+        with self.assertLogs(level="INFO") as log:
+            self.assertEqual(main(["build", "pkg", "--formats", "rpm"]), 0)
 
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping build of oci package pkg due to restriction on '
-            'package formats',
-            log.output
+            "INFO:root:Skipping build of oci package pkg due to restriction on "
+            "package formats",
+            log.output,
         )
 
         # Check RPM package supports_arch() method is called for all supported
         # archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
 
         # Check actionable RPM package build(), publish() and clean() methods
         # are called for all supported arch (ie. twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=None), call(sign=False, staging=None)])
+            [call(sign=False, staging=None), call(sign=False, staging=None)]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls([call(), call()])
 
     def test_action_build_publish_functional(self):
         """Functional RPM build and publish test"""
         # Declare supported archs and check qemu-user-static is available for
         # these architectures or skip the test.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self._check_qemuuserstatic()
 
         # Create temporary working repo and register its deletion at exit
         working_repo = make_temp_dir()
         atexit.register(shutil.rmtree, working_repo)
 
-        self.config.set('working_repo', working_repo)
-        self.config.options['repos'] = VALID_REPOS
+        self.config.set("working_repo", working_repo)
+        self.config.options["repos"] = VALID_REPOS
         self.update_project_conf()
 
         # Create fake package without build requirement
         self.make_pkg(build_requires=[])
 
-        self.assertEqual(main(['build', 'pkg', '--publish']), 0)
-        for arch in self.config.get('arch'):
+        self.assertEqual(main(["build", "pkg", "--publish"]), 0)
+        for arch in self.config.get("arch"):
             self.assertTrue(
                 os.path.exists(f"{working_repo}/{arch}/pkg-1.0-1.noarch.rpm")
             )
-            self.assertTrue(
-                os.path.exists(f"{working_repo}/oci/pkg_1.0-1.{arch}.tar")
-            )
+            self.assertTrue(os.path.exists(f"{working_repo}/oci/pkg_1.0-1.{arch}.tar"))
 
         # Remove mock build environments
         self.clean_mock_environments()
@@ -787,22 +848,22 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         """Functional RPM build and publish test with variants"""
         # Declare supported archs and check qemu-user-static is available for
         # these architectures or skip the test.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self._check_qemuuserstatic()
 
         # Create temporary working repo and register its deletion at exit
         working_repo = make_temp_dir()
         atexit.register(shutil.rmtree, working_repo)
 
-        self.config.set('working_repo', working_repo)
-        self.config.options['repos'] = VALID_REPOS
+        self.config.set("working_repo", working_repo)
+        self.config.options["repos"] = VALID_REPOS
         self.update_project_conf()
 
         # Create fake package without build requirement but 2 variants
-        self.make_pkg(build_requires=[], variants=['variant1', 'variant2'])
+        self.make_pkg(build_requires=[], variants=["variant1", "variant2"])
 
-        main(['build', 'pkg', '--publish'])
-        for arch in self.config.get('arch'):
+        main(["build", "pkg", "--publish"])
+        for arch in self.config.get("arch"):
             self.assertTrue(
                 os.path.exists(f"{working_repo}/{arch}/pkg-variant1-1.0-1.noarch.rpm")
             )
@@ -817,8 +878,8 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         shutil.rmtree(working_repo)
         atexit.unregister(shutil.rmtree)
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_build_load_failure(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Create fake package without build requirement
@@ -829,9 +890,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.load() raise RiftError
         mock_pkg_rpm_objs.load.side_effect = RiftError("fake rpm load failure")
@@ -843,16 +906,14 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
         mock_pkg_oci_objs.for_arch.return_value = mock_act_arch_pkg_oci
 
-        with self.assertLogs(level='ERROR') as log:
+        with self.assertLogs(level="ERROR") as log:
             # Check main returns non-zero exit code
-            self.assertEqual(main(['build', 'pkg']), 2)
+            self.assertEqual(main(["build", "pkg"]), 2)
         self.assertIn(
-            'ERROR:root:Unable to load rpm package: fake rpm load failure',
-            log.output
+            "ERROR:root:Unable to load rpm package: fake rpm load failure", log.output
         )
         self.assertIn(
-            'ERROR:root:Unable to load oci package: fake oci load failure',
-            log.output
+            "ERROR:root:Unable to load oci package: fake oci load failure", log.output
         )
         # Check actionable RPM package build(), publish() and clean() have not
         # been called.
@@ -860,12 +921,12 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.publish.assert_not_called()
         mock_act_arch_pkg_rpm.clean.assert_not_called()
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_build_skip_unsupported_arch(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare multiple supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -876,9 +937,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
         # Mock ActionableArchPackage{RPM,OCI} objects
         mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
         mock_act_arch_pkg_oci = Mock(spec=ActionableArchPackageOCI)
@@ -889,46 +952,44 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # x86_64 and PackageOCI.supports_arch() that returns True only for
         # aarch64.
         with patch.object(
-            mock_pkg_rpm_objs, "supports_arch",
-            new=lambda arch: arch == 'x86_64'):
+            mock_pkg_rpm_objs, "supports_arch", new=lambda arch: arch == "x86_64"
+        ):
             with patch.object(
-                mock_pkg_oci_objs, "supports_arch",
-                new=lambda arch: arch == 'aarch64'):
-                with self.assertLogs(level='INFO') as log:
-                    self.assertEqual(main(['build', 'pkg']), 0)
+                mock_pkg_oci_objs, "supports_arch", new=lambda arch: arch == "aarch64"
+            ):
+                with self.assertLogs(level="INFO") as log:
+                    self.assertEqual(main(["build", "pkg"]), 0)
         # Check skipping arch info in logs.
         self.assertIn(
-            'INFO:root:Skipping build on architecture aarch64 not supported by '
-            'rpm package pkg',
-            log.output
+            "INFO:root:Skipping build on architecture aarch64 not supported by "
+            "rpm package pkg",
+            log.output,
         )
         self.assertIn(
-            'INFO:root:Skipping build on architecture x86_64 not supported by '
-            'oci package pkg',
-            log.output
+            "INFO:root:Skipping build on architecture x86_64 not supported by "
+            "oci package pkg",
+            log.output,
         )
 
         # Check actionable RPM and OCI package build() and clean() have been
         # called only once for x86_64.
-        mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=None)])
-        mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=None)])
+        mock_act_arch_pkg_rpm.build.assert_has_calls([call(sign=False, staging=None)])
+        mock_act_arch_pkg_oci.build.assert_has_calls([call(sign=False, staging=None)])
         mock_act_arch_pkg_rpm.clean.assert_has_calls([call()])
         mock_act_arch_pkg_oci.clean.assert_has_calls([call()])
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_build_failure(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare multiple supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
 
         # Create temporary working repo and register its deletion at exit
         working_repo = make_temp_dir()
         atexit.register(shutil.rmtree, working_repo)
 
-        self.config.set('working_repo', working_repo)
+        self.config.set("working_repo", working_repo)
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -939,9 +1000,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -957,28 +1020,27 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.build.side_effect = RiftError("fake rpm build failure")
         mock_act_arch_pkg_oci.build.side_effect = RiftError("fake oci build failure")
 
-        with self.assertLogs(level='ERROR') as log:
+        with self.assertLogs(level="ERROR") as log:
             # Check main returns non-zero exit code
-            self.assertEqual(main(['build', '--publish', 'pkg']), 2)
+            self.assertEqual(main(["build", "--publish", "pkg"]), 2)
 
         # Check build failure error in logs.
         self.assertIn(
-            'ERROR:root:rpm build failure: fake rpm build failure',
-            log.output
+            "ERROR:root:rpm build failure: fake rpm build failure", log.output
         )
         self.assertIn(
-            'ERROR:root:oci build failure: fake oci build failure',
-            log.output
+            "ERROR:root:oci build failure: fake oci build failure", log.output
         )
 
         # Check actionable RPM and OCI package build() and clean() have been
         # called for all supported arch (ie. twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=None), call(sign=False, staging=None)])
-        mock_act_arch_pkg_rpm.clean.assert_has_calls(
-            [call(), call()])
+            [call(sign=False, staging=None), call(sign=False, staging=None)]
+        )
+        mock_act_arch_pkg_rpm.clean.assert_has_calls([call(), call()])
         mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=None), call(sign=False, staging=None)])
+            [call(sign=False, staging=None), call(sign=False, staging=None)]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls([call(), call()])
         mock_act_arch_pkg_oci.clean.assert_has_calls([call(), call()])
         # Check actionable RPM and OCI package publish() have not been called
@@ -990,30 +1052,30 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         shutil.rmtree(working_repo)
         atexit.unregister(shutil.rmtree)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_build_quiet_success(self, mock_pkg_rpm, mock_stdout):
         """build --quiet does not print build output on success."""
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
         self.make_pkg(build_requires=[])
 
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         mock_pkg_rpm_objs.supports_arch.return_value = True
         mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
 
-        self.assertEqual(
-            main(['build', 'pkg', '--formats', 'rpm', '--quiet']), 0)
+        self.assertEqual(main(["build", "pkg", "--formats", "rpm", "--quiet"]), 0)
 
         out = mock_stdout.getvalue()
-        self.assertNotIn('Build thread', out)
+        self.assertNotIn("Build thread", out)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
-    @patch('rift.Controller.build_architecture')
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
+    @patch("rift.Controller.build_architecture")
     def test_action_build_quiet_failure(
         self,
         mock_build_architecture,
@@ -1022,35 +1084,35 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
     ):
         """build --quiet prints build output on failure."""
 
-        self.config.set('arch', ['x86_64'])
+        self.config.set("arch", ["x86_64"])
         self.update_project_conf()
         self.make_pkg(build_requires=[])
 
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
-        build_failed = TestResults('build-x86_64')
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
+        build_failed = TestResults("build-x86_64")
         build_failed.add_failure(
-            TestCase('build', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'),
+            TestCase("build", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"),
             1.0,
-            err='simulated build failure',
+            err="simulated build failure",
         )
         mock_build_architecture.return_value = build_failed
 
-        self.assertEqual(
-            main(['build', 'pkg', '--formats', 'rpm', '--quiet']), 2)
+        self.assertEqual(main(["build", "pkg", "--formats", "rpm", "--quiet"]), 2)
 
         self.assertIn(
-            '** Build thread build-x86_64 output: **',
+            "** Build thread build-x86_64 output: **",
             mock_stdout.getvalue(),
         )
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_test(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1061,9 +1123,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -1081,29 +1145,29 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_oci.test.return_value = TestResults()
 
         # Run test on package
-        self.assertEqual(main(['test', 'pkg']), 0)
+        self.assertEqual(main(["test", "pkg"]), 0)
 
         # Check RPM and OCI package supports_arch() method is called for all
         # supported archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
             mock_pkg_oci_objs.supports_arch.assert_any_call(arch)
 
         # Check actionable RPM and OCI package test() method is called for all
         # supported arch (ie. twice).
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, noquit=False),
-             call(noauto=False, noquit=False)])
+            [call(noauto=False, noquit=False), call(noauto=False, noquit=False)]
+        )
         mock_act_arch_pkg_oci.test.assert_has_calls(
-            [call(noauto=False, noquit=False),
-             call(noauto=False, noquit=False)])
+            [call(noauto=False, noquit=False), call(noauto=False, noquit=False)]
+        )
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_test_formats(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1114,9 +1178,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -1134,19 +1200,19 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_oci.test.return_value = TestResults()
 
         # Run test on package
-        with self.assertLogs(level='INFO') as log:
-            self.assertEqual(main(['test', 'pkg', '--formats', 'rpm']), 0)
+        with self.assertLogs(level="INFO") as log:
+            self.assertEqual(main(["test", "pkg", "--formats", "rpm"]), 0)
 
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping tests oci package pkg due to restriction on '
-            'package formats',
-            log.output
+            "INFO:root:Skipping tests oci package pkg due to restriction on "
+            "package formats",
+            log.output,
         )
 
         # Check RPM package supports_arch() method is called for all supported
         # archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
 
         # Check OCI package supports_arch() method has not been called called.
@@ -1156,12 +1222,12 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # supported arch (ie. twice), as opposed to actionable OCI package
         # test() method.
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, noquit=False),
-             call(noauto=False, noquit=False)])
+            [call(noauto=False, noquit=False), call(noauto=False, noquit=False)]
+        )
         mock_act_arch_pkg_oci.test.assert_not_called()
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_test_load_failure(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Create fake package without build requirement
@@ -1172,9 +1238,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.load() raise RiftError
         mock_pkg_rpm_objs.load.side_effect = RiftError("fake rpm load failure")
@@ -1186,15 +1254,13 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
         mock_pkg_oci_objs.for_arch.return_value = mock_act_arch_pkg_oci
 
-        with self.assertLogs(level='ERROR') as log:
-            self.assertEqual(main(['test', 'pkg']), 2)
+        with self.assertLogs(level="ERROR") as log:
+            self.assertEqual(main(["test", "pkg"]), 2)
         self.assertIn(
-            'ERROR:root:Unable to load rpm package: fake rpm load failure',
-            log.output
+            "ERROR:root:Unable to load rpm package: fake rpm load failure", log.output
         )
         self.assertIn(
-            'ERROR:root:Unable to load oci package: fake oci load failure',
-            log.output
+            "ERROR:root:Unable to load oci package: fake oci load failure", log.output
         )
 
         # Check actionable RPM and OCI package test() method has not been
@@ -1202,12 +1268,12 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.test.assert_not_called()
         mock_act_arch_pkg_oci.test.assert_not_called()
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_test_failure(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1218,9 +1284,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -1236,35 +1304,35 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # failure.
         test_results = TestResults()
         test_results.add_failure(
-            TestCase('fake', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 0, None, None
+            TestCase("fake", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 0, None, None
         )
         mock_act_arch_pkg_rpm.test.return_value = test_results
         mock_act_arch_pkg_oci.test.return_value = test_results
 
         # Run test on package and check main returns non-zero exit code
-        self.assertEqual(main(['test', 'pkg']), 2)
+        self.assertEqual(main(["test", "pkg"]), 2)
 
         # Check RPM and OCI package supports_arch() method is called for all
         # supported archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
             mock_pkg_oci_objs.supports_arch.assert_any_call(arch)
 
         # Check actionable RPM and OCI package test() method is called for all
         # supported arch (ie. twice).
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, noquit=False),
-             call(noauto=False, noquit=False)])
+            [call(noauto=False, noquit=False), call(noauto=False, noquit=False)]
+        )
         mock_act_arch_pkg_oci.test.assert_has_calls(
-            [call(noauto=False, noquit=False),
-             call(noauto=False, noquit=False)])
+            [call(noauto=False, noquit=False), call(noauto=False, noquit=False)]
+        )
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_test_skip_unsupported_arch(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare multiple supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1275,9 +1343,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Mock ActionableArchPackage{RPM,OCI} objects
         mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
@@ -1294,40 +1364,40 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # x86_64 and PackageOCI.supports_arch() that returns True only for
         # aarch64.
         with patch.object(
-            mock_pkg_rpm_objs, "supports_arch",
-            new=lambda arch: arch == 'x86_64'):
+            mock_pkg_rpm_objs, "supports_arch", new=lambda arch: arch == "x86_64"
+        ):
             with patch.object(
-                mock_pkg_oci_objs, "supports_arch",
-                new=lambda arch: arch == 'aarch64'):
-                with self.assertLogs(level='INFO') as log:
-                    self.assertEqual(main(['test', 'pkg']), 0)
+                mock_pkg_oci_objs, "supports_arch", new=lambda arch: arch == "aarch64"
+            ):
+                with self.assertLogs(level="INFO") as log:
+                    self.assertEqual(main(["test", "pkg"]), 0)
         # Check skipping arch info in logs.
         self.assertIn(
-            'INFO:root:Skipping test on architecture aarch64 not supported by '
-            'rpm package pkg',
-            log.output
+            "INFO:root:Skipping test on architecture aarch64 not supported by "
+            "rpm package pkg",
+            log.output,
         )
         self.assertIn(
-            'INFO:root:Skipping test on architecture x86_64 not supported by '
-            'oci package pkg',
-            log.output
+            "INFO:root:Skipping test on architecture x86_64 not supported by "
+            "oci package pkg",
+            log.output,
         )
 
         # Check actionable RPM and OCI package test() has been called only once
         # (for x86_64).
-        mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, noquit=False)])
-        mock_act_arch_pkg_oci.test.assert_has_calls(
-            [call(noauto=False, noquit=False)])
+        mock_act_arch_pkg_rpm.test.assert_has_calls([call(noauto=False, noquit=False)])
+        mock_act_arch_pkg_oci.test.assert_has_calls([call(noauto=False, noquit=False)])
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
-    def test_action_validate(self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls, mock_stdout):
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
+    def test_action_validate(
+        self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls, mock_stdout
+    ):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1338,9 +1408,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -1361,17 +1433,15 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_staging_repo_cls.return_value = mock_staging_repo
 
         # Run validate on pkg
-        self.assertEqual(main(['validate', 'pkg']), 0)
+        self.assertEqual(main(["validate", "pkg"]), 0)
 
         out = mock_stdout.getvalue()
-        self.assertIn(
-            '** Validate thread validate-x86_64 output: **', out)
-        self.assertIn(
-            '** Validate thread validate-aarch64 output: **', out)
+        self.assertIn("** Validate thread validate-x86_64 output: **", out)
+        self.assertIn("** Validate thread validate-aarch64 output: **", out)
 
         # Check RPM package supports_arch() method is called for all supported
         # archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
             mock_pkg_oci_objs.supports_arch.assert_any_call(arch)
 
@@ -1384,43 +1454,62 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # test() and clean() methods are called for all supported arch (ie.
         # twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo)])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
         mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo)])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_oci.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False),
-             call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+            ]
+        )
         mock_act_arch_pkg_oci.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False),
-             call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+            ]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls(
-            [call(noquit=False), call(noquit=False)])
+            [call(noquit=False), call(noquit=False)]
+        )
         mock_act_arch_pkg_oci.clean.assert_has_calls(
-            [call(noquit=False), call(noquit=False)])
+            [call(noquit=False), call(noquit=False)]
+        )
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_quiet_success(
-            self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls, mock_stdout):
+        self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls, mock_stdout
+    ):
         """validate --quiet does not print build output on success."""
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
         self.make_pkg(build_requires=[])
 
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
         mock_pkg_rpm_objs.supports_arch.return_value = True
         mock_pkg_oci_objs.supports_arch.return_value = True
         mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
@@ -1432,339 +1521,295 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_staging_repo = Mock()
         mock_staging_repo_cls.return_value = mock_staging_repo
 
-        self.assertEqual(main(['validate', 'pkg', '--quiet']), 0)
+        self.assertEqual(main(["validate", "pkg", "--quiet"]), 0)
 
         out = mock_stdout.getvalue()
-        self.assertNotIn('Validate thread', out)
+        self.assertNotIn("Validate thread", out)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
-    @patch('rift.Controller.validate_pkgs')
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
+    @patch("rift.Controller.validate_pkgs")
     def test_action_validate_quiet_failure(
-            self,
-            mock_validate_pkgs,
-            mock_pkg_rpm,
-            mock_pkg_oci,
-            mock_stdout):
+        self, mock_validate_pkgs, mock_pkg_rpm, mock_pkg_oci, mock_stdout
+    ):
         """validate --quiet prints build output on failure."""
 
         validate_failed = TestResults()
         validate_failed.add_failure(
-            TestCase('build', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'),
+            TestCase("build", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"),
             1.0,
-            err='simulated validate failure',
+            err="simulated validate failure",
         )
         mock_validate_pkgs.return_value = validate_failed
 
-        self.config.set('arch', ['x86_64'])
+        self.config.set("arch", ["x86_64"])
         self.update_project_conf()
         self.make_pkg(build_requires=[])
 
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
-        self.assertEqual(main(['validate', 'pkg', '--quiet']), 2)
+        self.assertEqual(main(["validate", "pkg", "--quiet"]), 2)
 
         self.assertIn(
-            '** Validate thread validate-x86_64 output: **',
+            "** Validate thread validate-x86_64 output: **",
             mock_stdout.getvalue(),
         )
 
-    @patch('rift.Controller.PackagesDependencyGraph')
+    @patch("rift.Controller.PackagesDependencyGraph")
     def test_build_graph(self, mock_graph_class):
-        """ Test build generates graph of packages dependencies with dependency tracking enabled. """
+        """Test build generates graph of packages dependencies with dependency tracking enabled."""
         # Enable dependency tracking in configuration
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         self.update_project_conf()
-        main(['build', 'pkg'])
+        main(["build", "pkg"])
         mock_graph_class.from_project.assert_called_once()
 
-    @patch('rift.Controller.ProjectPackages')
-    @patch('rift.Controller.PackagesDependencyGraph')
-    def test_build_graph_tracking_disabled(self, mock_graph_class, mock_project_packages_class):
-        """ Test build does not build graph of packages dependencies with dependency tracking disabled. """
+    @patch("rift.Controller.ProjectPackages")
+    @patch("rift.Controller.PackagesDependencyGraph")
+    def test_build_graph_tracking_disabled(
+        self, mock_graph_class, mock_project_packages_class
+    ):
+        """Test build does not build graph of packages dependencies with dependency tracking disabled."""
         # Return empty list of packages with Package.list() to avoid actual
         # build iterations.
         mock_project_packages_class.list.return_value = []
         # By default, dependency tracking is disabled
-        main(['build', 'pkg'])
+        main(["build", "pkg"])
         mock_graph_class.from_project.assert_not_called()
 
-    @patch('rift.Controller.ProjectPackages')
-    @patch('rift.Controller.PackagesDependencyGraph')
+    @patch("rift.Controller.ProjectPackages")
+    @patch("rift.Controller.PackagesDependencyGraph")
     def test_build_graph_skip_deps(self, mock_graph_class, mock_project_packages_class):
-        """ Test build --skip-deps does not build graph of packages dependencies. """
+        """Test build --skip-deps does not build graph of packages dependencies."""
         # Return empty list of packages with Package.list() to avoid actual
         # build iterations.
         mock_project_packages_class.list.return_value = []
         # Enable dependency tracking in configuration
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         self.update_project_conf()
-        main(['build', '--skip-deps', 'pkg'])
+        main(["build", "--skip-deps", "pkg"])
         mock_graph_class.from_project.assert_not_called()
 
-    @patch('rift.Controller.PackagesDependencyGraph')
+    @patch("rift.Controller.PackagesDependencyGraph")
     def test_validate_graph(self, mock_graph_class):
-        """ Test validate generates graph of packages dependencies with dependency tracking enabled. """
+        """Test validate generates graph of packages dependencies with dependency tracking enabled."""
         # Enable dependency tracking in configuration
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         self.update_project_conf()
-        main(['validate', 'pkg'])
+        main(["validate", "pkg"])
         mock_graph_class.from_project.assert_called_once()
 
-    @patch('rift.Controller.ProjectPackages')
-    @patch('rift.Controller.PackagesDependencyGraph')
-    def test_validate_graph_tracking_disabled(self, mock_graph_class, mock_project_packages_class):
-        """ Test validate does not build graph of packages dependencies with dependency tracking disabled. """
+    @patch("rift.Controller.ProjectPackages")
+    @patch("rift.Controller.PackagesDependencyGraph")
+    def test_validate_graph_tracking_disabled(
+        self, mock_graph_class, mock_project_packages_class
+    ):
+        """Test validate does not build graph of packages dependencies with dependency tracking disabled."""
         # Return empty list of packages with Package.list() to avoid actual
         # build iterations.
         mock_project_packages_class.list.return_value = []
         # By default, dependency tracking is disabled
-        main(['validate', 'pkg'])
+        main(["validate", "pkg"])
         mock_graph_class.from_project.assert_not_called()
 
-    @patch('rift.Controller.ProjectPackages')
-    @patch('rift.Controller.PackagesDependencyGraph')
-    def test_validate_graph_skip_deps(self, mock_graph_class, mock_project_packages_class):
-        """ Test validate --skip-deps does not build graph of packages dependencies. """
+    @patch("rift.Controller.ProjectPackages")
+    @patch("rift.Controller.PackagesDependencyGraph")
+    def test_validate_graph_skip_deps(
+        self, mock_graph_class, mock_project_packages_class
+    ):
+        """Test validate --skip-deps does not build graph of packages dependencies."""
         # Return empty list of packages with Package.list() to avoid actual
         # build iterations.
         mock_project_packages_class.list.return_value = []
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         self.update_project_conf()
-        main(['validate', '--skip-deps', 'pkg'])
+        main(["validate", "--skip-deps", "pkg"])
         mock_graph_class.from_project.assert_not_called()
 
     def test_get_packages_to_build_tracking_disabled(self):
-        """ Test get_packages_to_build() with tracking disabled (by default) returns user provided packages. """
+        """Test get_packages_to_build() with tracking disabled (by default) returns user provided packages."""
         args = Mock()
         args.skip_deps = False
-        args.packages = ['pkg']
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
-        self.assertEqual([pkg.name for pkg in pkgs], ['pkg'])
+        args.packages = ["pkg"]
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
+        self.assertEqual([pkg.name for pkg in pkgs], ["pkg"])
 
     def test_get_packages_to_build_skip_deps(self):
-        """ Test get_packages_to_build() with skip deps (tracking enabled) returns user provided packages. """
-        self.config.set('dependency_tracking', True)
+        """Test get_packages_to_build() with skip deps (tracking enabled) returns user provided packages."""
+        self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = True
-        args.packages = ['pkg']
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
-        self.assertEqual([pkg.name for pkg in pkgs], ['pkg'])
+        args.packages = ["pkg"]
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
+        self.assertEqual([pkg.name for pkg in pkgs], ["pkg"])
 
     def test_get_packages_to_build_no_package(self):
-        """ Test get_packages_to_build() (tracking enabled, w/o skip deps) returns empty with unexisting package. """
-        self.config.set('dependency_tracking', True)
+        """Test get_packages_to_build() (tracking enabled, w/o skip deps) returns empty with unexisting package."""
+        self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = False
-        args.packages = ['pkg']
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
+        args.packages = ["pkg"]
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
         # Package 'pkg' does not exist in project directory, graph solving must
-        # return an empty list.
+        # return an empty list.
         self.assertEqual(pkgs, [])
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_get_packages_to_build_package_order(self, mock_mock):
-        """ Test get_packages_to_build() returns correctly ordered list of reverse dependencies. """
+        """Test get_packages_to_build() returns correctly ordered list of reverse dependencies."""
         """
         Test get_packages_to_build() returns correctly ordered list of reverse
         dependencies.
         """
+        self.make_pkg(name="libone", metadata={"depends": "libtwo"})
         self.make_pkg(
-            name='libone',
-            metadata={
-                'depends': 'libtwo'
-            }
+            name="libtwo",
         )
-        self.make_pkg(
-            name='libtwo',
-        )
-        self.make_pkg(
-            name='my-software',
-            metadata={
-                'depends': ['libone', 'libtwo']
-            }
-        )
+        self.make_pkg(name="my-software", metadata={"depends": ["libone", "libtwo"]})
         # Enable tracking, disable --skip-deps
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = False
-        args.packages = ['libone']
+        args.packages = ["libone"]
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
         # Package my-software must be present after libone in the ordered list
         # of build requirements, for all supported formats.
         self.assertEqual(len(pkgs), 4)
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageRPM)],
-            ['libone', 'my-software']
+            ["libone", "my-software"],
         )
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageOCI)],
-            ['libone', 'my-software']
+            ["libone", "my-software"],
         )
 
         args.skip_deps = False
-        args.packages = ['libone', 'libtwo']
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
+        args.packages = ["libone", "libtwo"]
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
         # Package libone must be present after libtwo and my-software must be
         # present after both libtwo and libone in the ordered list of build
         # requirements, for all supported formats.
         self.assertEqual(len(pkgs), 6)
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageRPM)],
-            ['libtwo', 'libone', 'my-software']
+            ["libtwo", "libone", "my-software"],
         )
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageOCI)],
-            ['libtwo', 'libone', 'my-software']
+            ["libtwo", "libone", "my-software"],
         )
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_get_packages_to_build_package_order_rpm_spec(self, mock_mock):
         """
         Test get_packages_to_build() returns correctly ordered list of reverse
         dependencies when expressed in spec files for RPM format.
         """
         self.make_pkg(
-            name='libone',
-            build_requires=['libtwo-devel'],
-            subpackages=[
-                SubPackage('libone-bin'),
-                SubPackage('libone-devel')
-            ]
+            name="libone",
+            build_requires=["libtwo-devel"],
+            subpackages=[SubPackage("libone-bin"), SubPackage("libone-devel")],
         )
         self.make_pkg(
-            name='libtwo',
-            subpackages=[
-                SubPackage('libtwo-bin'),
-                SubPackage('libtwo-devel')
-            ]
+            name="libtwo",
+            subpackages=[SubPackage("libtwo-bin"), SubPackage("libtwo-devel")],
         )
-        self.make_pkg(
-            name='my-software',
-            build_requires=['libone-devel, libtwo-devel']
-        )
+        self.make_pkg(name="my-software", build_requires=["libone-devel, libtwo-devel"])
         # Enable tracking, disable --skip-deps
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = False
-        args.packages = ['libone']
+        args.packages = ["libone"]
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
         # RPM package my-software must be present after RPM libone in the
         # ordered list of build requirements.
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageRPM)],
-            ['libone', 'my-software']
+            ["libone", "my-software"],
         )
         # Dependency solving does not work in OCI format because dependencies
         # are expressed in RPM spec file only.
         self.assertEqual(
-            [pkg.name for pkg in pkgs if isinstance(pkg, PackageOCI)],
-            ['libone']
+            [pkg.name for pkg in pkgs if isinstance(pkg, PackageOCI)], ["libone"]
         )
 
         args.skip_deps = False
-        args.packages = ['libone', 'libtwo']
-        pkgs = get_packages_to_build(
-            self.config, self.staff, self.modules, args
-        )
+        args.packages = ["libone", "libtwo"]
+        pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
         # RPM package libone must be present after RPM libtwo and RPM
         # my-software must be present after both RPM libtwo and RPM libone in
         # the ordered list of build requirements.
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageRPM)],
-            ['libtwo', 'libone', 'my-software']
+            ["libtwo", "libone", "my-software"],
         )
         # Dependency solving does not work in OCI format because dependencies
         # are expressed in RPM spec file only.
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageOCI)],
-            ['libone', 'libtwo']
+            ["libone", "libtwo"],
         )
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_get_packages_to_build_cyclic_deps(self, mock_mock):
-        """ Test get_packages_to_build() returns correctly ordered list of reverse dependencies. """
-        self.make_pkg(
-            name='libone',
-            metadata={
-                'depends': 'libtwo'
-            }
-        )
-        self.make_pkg(
-            name='libtwo',
-            metadata={
-                'depends': 'libthree'
-            }
-        )
-        self.make_pkg(
-            name='libthree',
-            metadata={
-                'depends': 'libone'
-            }
-        )
+        """Test get_packages_to_build() returns correctly ordered list of reverse dependencies."""
+        self.make_pkg(name="libone", metadata={"depends": "libtwo"})
+        self.make_pkg(name="libtwo", metadata={"depends": "libthree"})
+        self.make_pkg(name="libthree", metadata={"depends": "libone"})
         # Enable tracking, disable --skip-deps
-        self.config.set('dependency_tracking', True)
+        self.config.set("dependency_tracking", True)
         args = Mock()
         args.skip_deps = False
-        args.packages = ['libone']
+        args.packages = ["libone"]
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         with self.assertLogs(level="DEBUG") as cm:
-            pkgs = get_packages_to_build(
-                self.config, self.staff, self.modules, args
-            )
+            pkgs = get_packages_to_build(self.config, self.staff, self.modules, args)
         # Package libone must be present after libtwo and my-software must be
         # present after both libtwo and libone in the order list of build
         # requirements.
         self.assertEqual(len(pkgs), 6)
         self.assertCountEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageRPM)],
-            ['libthree', 'libtwo', 'libone']
+            ["libthree", "libtwo", "libone"],
         )
         self.assertEqual(
             [pkg.name for pkg in pkgs if isinstance(pkg, PackageOCI)],
-            ['libthree', 'libtwo', 'libone']
+            ["libthree", "libtwo", "libone"],
         )
         self.assertIn(
-            'DEBUG:root:       ⥀ Loop detected on node rpm:libone at depth 2: '
-            'rpm:libone→rpm:libthree→rpm:libtwo→rpm:libone',
-            cm.output
+            "DEBUG:root:       ⥀ Loop detected on node rpm:libone at depth 2: "
+            "rpm:libone→rpm:libthree→rpm:libtwo→rpm:libone",
+            cm.output,
         )
         self.assertIn(
-            'DEBUG:root:       ⥀ Loop detected on node oci:libone at depth 2: '
-            'oci:libone→oci:libthree→oci:libtwo→oci:libone',
-            cm.output
+            "DEBUG:root:       ⥀ Loop detected on node oci:libone at depth 2: "
+            "oci:libone→oci:libthree→oci:libtwo→oci:libone",
+            cm.output,
         )
 
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
-    def test_action_validate_formats(self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls):
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
+    def test_action_validate_formats(
+        self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls
+    ):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1775,9 +1820,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -1798,19 +1845,19 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_staging_repo_cls.return_value = mock_staging_repo
 
         # Run validate on pkg
-        with self.assertLogs(level='INFO') as log:
-            self.assertEqual(main(['validate', 'pkg', '--formats', 'rpm']), 0)
+        with self.assertLogs(level="INFO") as log:
+            self.assertEqual(main(["validate", "pkg", "--formats", "rpm"]), 0)
 
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping validation of oci package pkg due to '
-            'restriction on package formats',
-            log.output
+            "INFO:root:Skipping validation of oci package pkg due to "
+            "restriction on package formats",
+            log.output,
         )
 
         # Check RPM package supports_arch() method is called for all supported
         # archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
 
         # Check OCI package supports_arch() method has not been called called.
@@ -1825,22 +1872,30 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # clean() methods are called for all supported arch (ie. twice), as
         # opposed to actionable OCI package method.
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo)])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
         mock_act_arch_pkg_oci.build.assert_not_called()
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_oci.publish.assert_not_called()
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False),
-             call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+            ]
+        )
         mock_act_arch_pkg_oci.test.assert_not_called()
         mock_act_arch_pkg_rpm.clean.assert_has_calls(
-            [call(noquit=False), call(noquit=False)])
+            [call(noquit=False), call(noquit=False)]
+        )
         mock_act_arch_pkg_oci.clean.assert_not_called()
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_load_failure(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Create fake package without build requirement
@@ -1851,9 +1906,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.load() raise RiftError
         mock_pkg_rpm_objs.load.side_effect = RiftError("fake rpm load failure")
@@ -1865,15 +1922,13 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
         mock_pkg_oci_objs.for_arch.return_value = mock_act_arch_pkg_oci
 
-        with self.assertLogs(level='ERROR') as log:
-            self.assertEqual(main(['validate', 'pkg']), 2)
+        with self.assertLogs(level="ERROR") as log:
+            self.assertEqual(main(["validate", "pkg"]), 2)
         self.assertIn(
-            'ERROR:root:Unable to load rpm package: fake rpm load failure',
-            log.output
+            "ERROR:root:Unable to load rpm package: fake rpm load failure", log.output
         )
         self.assertIn(
-            'ERROR:root:Unable to load oci package: fake oci load failure',
-            log.output
+            "ERROR:root:Unable to load oci package: fake oci load failure", log.output
         )
 
         # Check RPM and OCI package check() method has not been called.
@@ -1891,12 +1946,12 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.clean.assert_not_called()
         mock_act_arch_pkg_oci.clean.assert_not_called()
 
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_check_failure(self, mock_pkg_rpm, mock_pkg_oci):
 
         # Declare multiple supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1907,9 +1962,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -1925,15 +1982,15 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_rpm_objs.for_arch.return_value = mock_act_arch_pkg_rpm
         mock_pkg_oci_objs.for_arch.return_value = mock_act_arch_pkg_oci
 
-        with self.assertLogs(level='ERROR') as log:
-            self.assertEqual(main(['validate', 'pkg']), 2)
+        with self.assertLogs(level="ERROR") as log:
+            self.assertEqual(main(["validate", "pkg"]), 2)
         self.assertIn(
-            'ERROR:root:Static analysis of rpm package failed: fake rpm check failure',
-            log.output
+            "ERROR:root:Static analysis of rpm package failed: fake rpm check failure",
+            log.output,
         )
         self.assertIn(
-            'ERROR:root:Static analysis of oci package failed: fake oci check failure',
-            log.output
+            "ERROR:root:Static analysis of oci package failed: fake oci check failure",
+            log.output,
         )
 
         # Check RPM and OCI package load() and check() methods are called for
@@ -1954,15 +2011,15 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.clean.assert_not_called()
         mock_act_arch_pkg_oci.clean.assert_not_called()
 
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_build_failure(
         self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls
     ):
 
         # Declare multiple supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -1973,9 +2030,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
         # Mock StagingRepository object.
         mock_staging_repo = Mock()
         mock_staging_repo_cls.return_value = mock_staging_repo
@@ -1993,18 +2052,16 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.build.side_effect = RiftError("fake rpm build failure")
         mock_act_arch_pkg_oci.build.side_effect = RiftError("fake oci build failure")
 
-        with self.assertLogs(level='ERROR') as log:
+        with self.assertLogs(level="ERROR") as log:
             # Check main returns non-zero exit code
-            self.assertEqual(main(['validate', 'pkg']), 2)
+            self.assertEqual(main(["validate", "pkg"]), 2)
 
         # Check build failure error in logs.
         self.assertIn(
-            'ERROR:root:rpm build failure: fake rpm build failure',
-            log.output
+            "ERROR:root:rpm build failure: fake rpm build failure", log.output
         )
         self.assertIn(
-            'ERROR:root:oci build failure: fake oci build failure',
-            log.output
+            "ERROR:root:oci build failure: fake oci build failure", log.output
         )
 
         # Check RPM and OCI package load() and check() methods are called for
@@ -2017,11 +2074,17 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # Check actionable RPM and OCI package build() has been called for all
         # supported arch (ie. twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo),])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
         mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo),])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
 
         # Check actionable RPM and OCI package publish(), test() and clean()
         # have not been called.
@@ -2032,16 +2095,15 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_rpm.clean.assert_not_called()
         mock_act_arch_pkg_oci.clean.assert_not_called()
 
-
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_test_failure(
         self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls
     ):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -2052,9 +2114,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -2072,7 +2136,7 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # failure.
         test_results = TestResults()
         test_results.add_failure(
-            TestCase('fake', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'),
+            TestCase("fake", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"),
             0,
             None,
             None,
@@ -2081,11 +2145,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_oci.test.return_value = test_results
 
         # Run validate on package and check main returns non-zero exit code
-        self.assertEqual(main(['validate', 'pkg']), 2)
+        self.assertEqual(main(["validate", "pkg"]), 2)
 
         # Check RPM and OCI package supports_arch() method is called for all
         # supported archs.
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock_pkg_rpm_objs.supports_arch.assert_any_call(arch)
             mock_pkg_oci_objs.supports_arch.assert_any_call(arch)
 
@@ -2098,36 +2162,52 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # test() and clean() methods are called for all supported arch (ie.
         # twice).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo)])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
         mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo),
-             call(sign=False, staging=mock_staging_repo)])
+            [
+                call(sign=False, staging=mock_staging_repo),
+                call(sign=False, staging=mock_staging_repo),
+            ]
+        )
 
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_oci.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False),
-             call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+            ]
+        )
         mock_act_arch_pkg_oci.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False),
-             call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+                call(noauto=False, staging=mock_staging_repo, noquit=False),
+            ]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls(
-            [call(noquit=False), call(noquit=False)])
+            [call(noquit=False), call(noquit=False)]
+        )
         mock_act_arch_pkg_oci.clean.assert_has_calls(
-            [call(noquit=False), call(noquit=False)])
+            [call(noquit=False), call(noquit=False)]
+        )
 
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_skip_unsupported_arch(
         self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls
     ):
 
         # Declare multiple supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -2138,9 +2218,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Mock ActionableArchPackage{RPM,OCI} objects
         mock_act_arch_pkg_rpm = Mock(spec=ActionableArchPackageRPM)
@@ -2159,23 +2241,23 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # x86_64 and PackageOCI.supports_arch() that returns True only for
         # aarch64.
         with patch.object(
-            mock_pkg_rpm_objs, "supports_arch",
-            new=lambda arch: arch == 'x86_64'):
+            mock_pkg_rpm_objs, "supports_arch", new=lambda arch: arch == "x86_64"
+        ):
             with patch.object(
-                mock_pkg_oci_objs, "supports_arch",
-                new=lambda arch: arch == 'aarch64'):
-                with self.assertLogs(level='INFO') as log:
-                    self.assertEqual(main(['validate', 'pkg']), 0)
+                mock_pkg_oci_objs, "supports_arch", new=lambda arch: arch == "aarch64"
+            ):
+                with self.assertLogs(level="INFO") as log:
+                    self.assertEqual(main(["validate", "pkg"]), 0)
         # Check skipping arch info in logs.
         self.assertIn(
-            'INFO:root:Skipping validation on architecture aarch64 not '
-            'supported by rpm package pkg',
-            log.output
+            "INFO:root:Skipping validation on architecture aarch64 not "
+            "supported by rpm package pkg",
+            log.output,
         )
         self.assertIn(
-            'INFO:root:Skipping validation on architecture x86_64 not '
-            'supported by oci package pkg',
-            log.output
+            "INFO:root:Skipping validation on architecture x86_64 not "
+            "supported by oci package pkg",
+            log.output,
         )
 
         # Check RPM and OCI package check() method has been called only once
@@ -2186,35 +2268,41 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # Check actionable RPM and OCI ackage build(), publish(staging),
         # test() and clean() methods have been called only once (for x86_64).
         mock_act_arch_pkg_rpm.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo)])
+            [call(sign=False, staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_oci.build.assert_has_calls(
-            [call(sign=False, staging=mock_staging_repo)])
+            [call(sign=False, staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_oci.publish.assert_has_calls(
-            [call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_rpm.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [call(noauto=False, staging=mock_staging_repo, noquit=False)]
+        )
         mock_act_arch_pkg_oci.test.assert_has_calls(
-            [call(noauto=False, staging=mock_staging_repo, noquit=False)])
+            [call(noauto=False, staging=mock_staging_repo, noquit=False)]
+        )
         mock_act_arch_pkg_rpm.clean.assert_has_calls([call(noquit=False)])
         mock_act_arch_pkg_oci.clean.assert_has_calls([call(noquit=False)])
 
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_publish(
         self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls
     ):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
 
         # Create temporary working repo and register its deletion at exit
         working_repo = make_temp_dir()
         atexit.register(shutil.rmtree, working_repo)
 
-        self.config.set('working_repo', working_repo)
+        self.config.set("working_repo", working_repo)
         self.update_project_conf()
 
         # Create fake package without build requirement
@@ -2225,9 +2313,11 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -2247,54 +2337,61 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         mock_act_arch_pkg_oci.test.return_value = TestResults()
 
         # Run validate on pkg
-        self.assertEqual(main(['validate', 'pkg', '--publish']), 0)
+        self.assertEqual(main(["validate", "pkg", "--publish"]), 0)
 
         # Check actionable RPM and OCI package publish(staging) and
         # publish() are called for all supported arch (ie. twice).
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo),
-             call(sign=False),
-             call(staging=mock_staging_repo),
-             call(sign=False)])
+            [
+                call(staging=mock_staging_repo),
+                call(sign=False),
+                call(staging=mock_staging_repo),
+                call(sign=False),
+            ]
+        )
         mock_act_arch_pkg_oci.publish.assert_has_calls(
-            [call(staging=mock_staging_repo),
-             call(sign=False),
-             call(staging=mock_staging_repo),
-             call(sign=False)])
+            [
+                call(staging=mock_staging_repo),
+                call(sign=False),
+                call(staging=mock_staging_repo),
+                call(sign=False),
+            ]
+        )
 
         # Remove temporary working repo and unregister its deletion at exit
         shutil.rmtree(working_repo)
         atexit.unregister(shutil.rmtree)
 
-    @patch('rift.Controller.StagingRepository')
-    @patch('rift.package._project.PackageOCI', autospec=PackageOCI)
-    @patch('rift.package._project.PackageRPM', autospec=PackageRPM)
+    @patch("rift.Controller.StagingRepository")
+    @patch("rift.package._project.PackageOCI", autospec=PackageOCI)
+    @patch("rift.package._project.PackageRPM", autospec=PackageRPM)
     def test_action_validate_publish_test_failure(
         self, mock_pkg_rpm, mock_pkg_oci, mock_staging_repo_cls
     ):
 
         # Declare supported archs.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
 
         # Create temporary working repo and register its deletion at exit
         working_repo = make_temp_dir()
         atexit.register(shutil.rmtree, working_repo)
 
-        self.config.set('working_repo', working_repo)
+        self.config.set("working_repo", working_repo)
         self.update_project_conf()
 
         # Create fake package without build requirement
         self.make_pkg(build_requires=[])
-
 
         # Get Package{RPM,OCI} mock instances
         mock_pkg_rpm_objs = mock_pkg_rpm.return_value
         mock_pkg_oci_objs = mock_pkg_oci.return_value
         # Initialize Package{RPM,OCI} object attributes
         PackageRPM.__init__(
-            mock_pkg_rpm_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_rpm_objs, "pkg", self.config, self.staff, self.modules
+        )
         PackageOCI.__init__(
-            mock_pkg_oci_objs, 'pkg', self.config, self.staff, self.modules)
+            mock_pkg_oci_objs, "pkg", self.config, self.staff, self.modules
+        )
 
         # Make Package{RPM,OCI}.supports_arch() return True for all archs
         mock_pkg_rpm_objs.supports_arch.return_value = True
@@ -2312,21 +2409,23 @@ class ControllerProjectActionBuildTest(RiftProjectTestCase):
         # failure.
         test_results = TestResults()
         test_results.add_failure(
-            TestCase('fake', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 0, None, None
+            TestCase("fake", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 0, None, None
         )
         mock_act_arch_pkg_rpm.test.return_value = test_results
         mock_act_arch_pkg_oci.test.return_value = test_results
 
         # Run validate on package and check main returns non-zero exit code
-        self.assertEqual(main(['validate', 'pkg', '--publish']), 2)
+        self.assertEqual(main(["validate", "pkg", "--publish"]), 2)
 
         # Check actionable RPM and OCI package publish is called for staging
         # repository only (before running tests) but not for working directory
         # despite --publish.
         mock_act_arch_pkg_rpm.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
         mock_act_arch_pkg_oci.publish.assert_has_calls(
-            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)])
+            [call(staging=mock_staging_repo), call(staging=mock_staging_repo)]
+        )
 
         # Remove temporary working repo and unregister its deletion at exit
         shutil.rmtree(working_repo)
@@ -2337,88 +2436,95 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
     """
     Tests class for Controller action vm
     """
-    @patch('rift.Controller.VM')
+
+    @patch("rift.Controller.VM")
     def test_vm_arch_option(self, mock_vm_class):
         """Test vm --arch option required with multiple supported archs."""
         # With only one supported architecture in project, --arch argument must
         # not be required.
-        main(['vm', 'connect'])
+        main(["vm", "connect"])
 
         # Define multiple supported architectures.
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         self.update_project_conf()
 
         # With multiple supported architectures, --arch argument must be
         # required.
         with self.assertRaisesRegex(
-            RiftError,
-            "^VM architecture must be defined with --arch argument.*$"
+            RiftError, "^VM architecture must be defined with --arch argument.*$"
         ):
-            main(['vm', 'connect'])
+            main(["vm", "connect"])
 
         # It should run without error with --arch.
-        main(['vm', '--arch', 'x86_64', 'connect'])
+        main(["vm", "--arch", "x86_64", "connect"])
 
         # Test invalid value of --arch argument is reported.
         with self.assertRaisesRegex(
-            RiftError,
-            "^Project does not support architecture 'fail'$"
+            RiftError, "^Project does not support architecture 'fail'$"
         ):
-            main(['vm', '--arch', 'fail', 'connect'])
+            main(["vm", "--arch", "fail", "connect"])
 
         # Remove mock build environment
         self.clean_mock_environments()
 
-    @patch('rift.Controller.VM')
+    @patch("rift.Controller.VM")
     def test_action_vm_build(self, mock_vm_class):
-        """simple 'rift vm build' is ok """
+        """simple 'rift vm build' is ok"""
 
         mock_vm_objects = mock_vm_class.return_value
         mock_vm_objects.image_is_remote.return_value = False
-        mock_vm_objects.image_local = 'test.qcow2'
+        mock_vm_objects.image_local = "test.qcow2"
 
-        main(['vm', 'build', '--url', 'http://image', '--deploy'])
+        main(["vm", "build", "--url", "http://image", "--deploy"])
         # check VM class has been instanciated
         mock_vm_class.assert_called()
 
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', False, False, 'test.qcow2'
+            "http://image", False, False, "test.qcow2"
         )
         mock_vm_objects.build.reset_mock()
-        main(['vm', 'build', '--url', 'http://image', '--deploy', '--force'])
+        main(["vm", "build", "--url", "http://image", "--deploy", "--force"])
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', True, False, 'test.qcow2'
+            "http://image", True, False, "test.qcow2"
         )
         mock_vm_objects.build.reset_mock()
-        main(['vm', 'build', '--url', 'http://image', '--deploy', '--keep'])
+        main(["vm", "build", "--url", "http://image", "--deploy", "--keep"])
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', False, True, 'test.qcow2'
+            "http://image", False, True, "test.qcow2"
         )
         mock_vm_objects.build.reset_mock()
         main(
-            ['vm', 'build', '--url', 'http://image', '--output', 'OUTPUT.img', '--force']
+            [
+                "vm",
+                "build",
+                "--url",
+                "http://image",
+                "--output",
+                "OUTPUT.img",
+                "--force",
+            ]
         )
         mock_vm_objects.build.assert_called_once_with(
-            'http://image', True, False, 'OUTPUT.img'
+            "http://image", True, False, "OUTPUT.img"
         )
         mock_vm_objects.build.reset_mock()
         with self.assertRaisesRegex(
             RiftError, "^Either --deploy or -o,--output option must be used$"
         ):
-            main(['vm', 'build', '--url', 'http://image'])
+            main(["vm", "build", "--url", "http://image"])
         with self.assertRaisesRegex(
             RiftError,
             "^Both --deploy and -o,--output options cannot be used together$",
         ):
             main(
                 [
-                    'vm',
-                    'build',
-                    '--url',
-                    'http://image',
-                    '--deploy',
-                    '--output',
-                    'OUTPUT.img',
+                    "vm",
+                    "build",
+                    "--url",
+                    "http://image",
+                    "--deploy",
+                    "--output",
+                    "OUTPUT.img",
                 ]
             )
         # Test --deploy with remote image
@@ -2426,48 +2532,39 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError,
             "^Cannot build VM image with remote image URL and --deploy option, -o, "
-            "--output option must be used$"
+            "--output option must be used$",
         ):
-            main(['vm', 'build', '--url', 'http://image', '--deploy'])
-
+            main(["vm", "build", "--url", "http://image", "--deploy"])
 
     def test_vm_build_and_validate(self):
         """Test VM build and validate package"""
         self.skipTest("Too much instability")
         if not os.path.exists("/usr/bin/qemu-img"):
             self.skipTest("qemu-img is not available")
-        self.config.options['vm']['images_cache'] = GLOBAL_CACHE
+        self.config.options["vm"]["images_cache"] = GLOBAL_CACHE
         # Reduce memory size from default 8GB to 2GB because it is sufficient to
         # run this VM and it largely reduces storage required by virtiofs memory
         # backend file which is the same size as the VM memory, thus reducing
         # the risk to fill up small partitions when running the tests.
-        self.config.options['vm']['memory'] = 2048
-        self.config.options['proxy'] = PROXY
-        self.config.options['repos'] = {
-            'os': {
-                'url': (
-                    'https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/'
-                ),
-                'priority': 90
+        self.config.options["vm"]["memory"] = 2048
+        self.config.options["proxy"] = PROXY
+        self.config.options["repos"] = {
+            "os": {
+                "url": ("https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/"),
+                "priority": 90,
             },
-            'updates': {
-                'url': (
-                    'https://repo.almalinux.org/almalinux/8/AppStream/x86_64/'
-                    'os/'
-                ),
-                'priority': 90
+            "updates": {
+                "url": ("https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/"),
+                "priority": 90,
             },
-            'extras':  {
-                'url': (
-                    'https://repo.almalinux.org/almalinux/8/PowerTools/x86_64/'
-                    'os/'
-                ),
-                'priority': 90
-            }
+            "extras": {
+                "url": ("https://repo.almalinux.org/almalinux/8/PowerTools/x86_64/os/"),
+                "priority": 90,
+            },
         }
         # Enable virtiofs that is natively supported by Alma without requirement
         # of additional RPM.
-        self.config.options['shared_fs_type'] = 'virtiofs'
+        self.config.options["shared_fs_type"] = "virtiofs"
         # Update project YAML configuration with new options defined above
         self.update_project_conf()
         # Copy example cloud-init template
@@ -2477,11 +2574,11 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
         # Ensure cache directory exists
         self.ensure_vm_images_cache_dir()
         # Build virtual machine image
-        main(['vm', 'build', VALID_IMAGE_URL['x86_64'], '--deploy'])
+        main(["vm", "build", VALID_IMAGE_URL["x86_64"], "--deploy"])
         # Create source package and launch validation on fresh VM image
-        pkg = 'pkg'
+        pkg = "pkg"
         self.make_pkg(name=pkg, build_requires=[], requires=[])
-        main(['validate', pkg])
+        main(["validate", pkg])
         # Remove mock build environments
         self.clean_mock_environments()
 
@@ -2493,27 +2590,27 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
 
     def setUp(self):
         super().setUp()
-        self.gpg_home = os.path.join(self.projdir, '.gnupg')
+        self.gpg_home = os.path.join(self.projdir, ".gnupg")
 
         # Launch GPG agent for this test
         cmd = [
-          'gpg-agent',
-          '--homedir',
-          self.gpg_home,
-          '--daemon',
+            "gpg-agent",
+            "--homedir",
+            self.gpg_home,
+            "--daemon",
         ]
         subprocess.run(cmd)
 
         # Generate keyring
-        gpg_key = 'rift'
+        gpg_key = "rift"
         cmd = [
-            'gpg',
-            '--homedir',
+            "gpg",
+            "--homedir",
             self.gpg_home,
-            '--batch',
-            '--passphrase',
-            '',
-            '--quick-generate-key',
+            "--batch",
+            "--passphrase",
+            "",
+            "--quick-generate-key",
             gpg_key,
         ]
         subprocess.run(cmd)
@@ -2521,9 +2618,9 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         # Update project configuration with generated key
         self.config.options.update(
             {
-                'gpg': {
-                    'keyring': self.gpg_home,
-                    'key': gpg_key,
+                "gpg": {
+                    "keyring": self.gpg_home,
+                    "key": gpg_key,
                 }
             }
         )
@@ -2531,7 +2628,7 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
 
     def tearDown(self):
         # Kill GPG agent launched for the test
-        cmd = ['gpgconf', '--homedir', self.gpg_home, '--kill', 'gpg-agent']
+        cmd = ["gpgconf", "--homedir", self.gpg_home, "--kill", "gpg-agent"]
         subprocess.run(cmd)
 
         # Remove temporary GPG home with generated key
@@ -2540,16 +2637,12 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         super().tearDown()
 
     def test_action_sign_rpm(self):
-        """ Test sign RPM package """
+        """Test sign RPM package"""
 
         # Path of RPM packages assets
         tests_dir = os.path.dirname(os.path.abspath(__file__))
-        original_bin_rpm = os.path.join(
-            tests_dir, 'materials', 'pkg-1.0-1.noarch.rpm'
-        )
-        original_src_rpm = os.path.join(
-            tests_dir, 'materials', 'pkg-1.0-1.src.rpm'
-        )
+        original_bin_rpm = os.path.join(tests_dir, "materials", "pkg-1.0-1.noarch.rpm")
+        original_src_rpm = os.path.join(tests_dir, "materials", "pkg-1.0-1.src.rpm")
 
         # Copy RPM packages assets in temporary project directory
         copy_bin_rpm = os.path.join(self.projdir, os.path.basename(original_bin_rpm))
@@ -2564,9 +2657,9 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         self.assertFalse(src_rpm.is_signed)
 
         # Launch rift sign
-        os.environ['GNUPGHOME'] = self.gpg_home
-        self.assertEqual(main(['sign', copy_bin_rpm, copy_src_rpm]), 0)
-        del os.environ['GNUPGHOME']
+        os.environ["GNUPGHOME"] = self.gpg_home
+        self.assertEqual(main(["sign", copy_bin_rpm, copy_src_rpm]), 0)
+        del os.environ["GNUPGHOME"]
 
         # Reload packages and check they are signed now
         bin_rpm._load()
@@ -2579,12 +2672,12 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         os.unlink(copy_src_rpm)
 
     def test_action_sign_oci_archive(self):
-        """ Test sign OCI archive """
+        """Test sign OCI archive"""
         # Create temporary tarball to emulate OCI archive
         tmp_tar = make_temp_tar()
 
         # Check rift sign runs succesfully
-        self.assertEqual(main(['sign', tmp_tar]), 0)
+        self.assertEqual(main(["sign", tmp_tar]), 0)
 
         # Check detached signature has been successfully created
         sig = f"{tmp_tar}.gpg"
@@ -2601,87 +2694,88 @@ class ControllerProjectActionSyncTest(RiftProjectTestCase):
     """
     Tests class for Controller action sync
     """
-    @patch('rift.sync.RepoSyncBase.run')
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_action_sync_skip_repo_wo_params(self, mock_stdout, mock_reposyncbase_run):
-        """ Test rift runs sync action skips repo without synchronization parameters. """
-        sync_parent = make_temp_dir()
-        sync_output = os.path.join(sync_parent, 'output')
-        self.config.set('arch', ['x86_64'])
 
-        self.config.options['sync_output'] = sync_output
-        self.config.options['repos'] = {
-            'repo1': {
-                'sync': {
-                    'source': 'https://server1/repo1',
-                    'subdir': '$arch',
+    @patch("rift.sync.RepoSyncBase.run")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_action_sync_skip_repo_wo_params(self, mock_stdout, mock_reposyncbase_run):
+        """Test rift runs sync action skips repo without synchronization parameters."""
+        sync_parent = make_temp_dir()
+        sync_output = os.path.join(sync_parent, "output")
+        self.config.set("arch", ["x86_64"])
+
+        self.config.options["sync_output"] = sync_output
+        self.config.options["repos"] = {
+            "repo1": {
+                "sync": {
+                    "source": "https://server1/repo1",
+                    "subdir": "$arch",
                 },
-                'url': 'https://server1/repo1',
+                "url": "https://server1/repo1",
             },
-            'repo2': {
-                'url': 'https://server2/repo2',
+            "repo2": {
+                "url": "https://server2/repo2",
             },
         }
         # Update project YAML configuration with new options defined above
         self.update_project_conf()
         # Run sync and check debug log is emited to indicate repo2 is skipped.
-        with self.assertLogs(level='DEBUG') as log:
-            main(['sync'])
+        with self.assertLogs(level="DEBUG") as log:
+            main(["sync"])
             self.assertIn(
-                'WARNING:root:x86_64: Skipping repository repo2: no '
-                'synchronization parameters found',
-                log.output
+                "WARNING:root:x86_64: Skipping repository repo2: no "
+                "synchronization parameters found",
+                log.output,
             )
         # RepoSyncBase.run() must have been called once for repo1.
         self.assertEqual(mock_reposyncbase_run.call_count, 1)
         self.assertIn(
-            '** x86_64: Synchronizing repository repo1: '
-            'https://server1/repo1/x86_64 **',
-            mock_stdout.getvalue()
+            "** x86_64: Synchronizing repository repo1: "
+            "https://server1/repo1/x86_64 **",
+            mock_stdout.getvalue(),
         )
         # Clean synchronization output parent
         shutil.rmtree(sync_parent)
 
-    @patch('rift.Controller.RepoSyncFactory')
+    @patch("rift.Controller.RepoSyncFactory")
     def test_action_sync(self, mock_reposync):
-        """ Test rift runs sync action with or without sync conf. """
+        """Test rift runs sync action with or without sync conf."""
         # First run sync without sync conf nor -o, --output argument.
         # Check warning message log is emitted
-        with self.assertLogs(level='INFO') as log:
-            main(['sync'])
+        with self.assertLogs(level="INFO") as log:
+            main(["sync"])
             self.assertIn(
-                'ERROR:root:Synchronization output directory must be defined '
-                'with sync_output parameter in Rift configuration or -o, '
-                '--output command line option to synchronize repositories',
-                log.output
+                "ERROR:root:Synchronization output directory must be defined "
+                "with sync_output parameter in Rift configuration or -o, "
+                "--output command line option to synchronize repositories",
+                log.output,
             )
         # Check factory is not called
         self.assertEqual(mock_reposync.get.call_count, 0)
 
         # Create temporary synchronization output parent directory
         sync_parent = make_temp_dir()
-        sync_output = os.path.join(sync_parent, 'output')
+        sync_output = os.path.join(sync_parent, "output")
 
         # Add repositories with synchronization parameters in conf.
-        self.config.options['repos'] = {
-            'repo1': {
-                'sync': {
-                    'source': 'https://server1/repo1',
+        self.config.options["repos"] = {
+            "repo1": {
+                "sync": {
+                    "source": "https://server1/repo1",
                 },
-                'url': 'https://server1/repo1',
+                "url": "https://server1/repo1",
             },
-            'repo2': {
-                'sync': {
-                    'source': 'https://server2/repo2',
+            "repo2": {
+                "sync": {
+                    "source": "https://server2/repo2",
                 },
-                'url': 'https://server2/repo2',
+                "url": "https://server2/repo2",
             },
         }
         # Update project YAML configuration with new options defined above
         self.update_project_conf()
 
         # Run with --output parameter (without sync_output in conf)
-        main(['sync', '--output', sync_output])
+        main(["sync", "--output", sync_output])
 
         # Check factory has been called twice, for repo1 and repo2
         self.assertEqual(mock_reposync.get.call_count, 2)
@@ -2694,11 +2788,11 @@ class ControllerProjectActionSyncTest(RiftProjectTestCase):
         mock_reposync.get.reset_mock()
 
         # Add sync_output parameter in conf.
-        self.config.options['sync_output'] = sync_output
+        self.config.options["sync_output"] = sync_output
         self.update_project_conf()
 
         # Run sync without -o, --output parameter.
-        main(['sync'])
+        main(["sync"])
         # Check factory has been called twice, for repo1 and repo2
         self.assertEqual(mock_reposync.get.call_count, 2)
         # Check output directory has been created
@@ -2706,34 +2800,34 @@ class ControllerProjectActionSyncTest(RiftProjectTestCase):
         # Clean synchronization output parent
         shutil.rmtree(sync_parent)
 
-    @patch('rift.sync.RepoSyncBase.run')
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("rift.sync.RepoSyncBase.run")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_action_sync_multiarch(self, mock_stdout, mock_reposyncbase_run):
-        """ Test rift runs sync action with multiple architectures. """
+        """Test rift runs sync action with multiple architectures."""
         sync_parent = make_temp_dir()
-        sync_output = os.path.join(sync_parent, 'output')
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        sync_output = os.path.join(sync_parent, "output")
+        self.config.set("arch", ["x86_64", "aarch64"])
 
-        self.config.options['sync_output'] = sync_output
-        self.config.options['repos'] = {
-            'repo1': {
-                'sync': {
-                    'source': 'https://server1/repo1',
-                    'subdir': '$arch',
+        self.config.options["sync_output"] = sync_output
+        self.config.options["repos"] = {
+            "repo1": {
+                "sync": {
+                    "source": "https://server1/repo1",
+                    "subdir": "$arch",
                 },
-                'url': 'https://server1/repo1',
+                "url": "https://server1/repo1",
             },
-            'repo2': {
-                'sync': {
-                    'source': 'https://server2/$arch',
+            "repo2": {
+                "sync": {
+                    "source": "https://server2/$arch",
                 },
-                'url': 'https://server2/$arch',
+                "url": "https://server2/$arch",
             },
-            'repo3': {
-                'sync': {
-                    'source': 'https://server3/repo3',
+            "repo3": {
+                "sync": {
+                    "source": "https://server3/repo3",
                 },
-                'url': 'https://server3/repo3',
+                "url": "https://server3/repo3",
             },
         }
         # Update project YAML configuration with new options defined above
@@ -2741,12 +2835,12 @@ class ControllerProjectActionSyncTest(RiftProjectTestCase):
         # Run sync and check debug log is emited to indicate repo3 is skipped
         # with the 2nd architecture (as the URL is the same as for the 1st
         # arch).
-        with self.assertLogs(level='DEBUG') as log:
-            main(['sync'])
+        with self.assertLogs(level="DEBUG") as log:
+            main(["sync"])
             self.assertIn(
-                'DEBUG:root:Skipping already synchronized source '
-                'https://server3/repo3/',
-                log.output
+                "DEBUG:root:Skipping already synchronized source "
+                "https://server3/repo3/",
+                log.output,
             )
         # RepoSyncBase.run() must have been called 5 times:
         # - 2 calls for repo1
@@ -2754,49 +2848,46 @@ class ControllerProjectActionSyncTest(RiftProjectTestCase):
         # - 1 call for repo3
         self.assertEqual(mock_reposyncbase_run.call_count, 5)
         self.assertIn(
-            '** x86_64: Synchronizing repository repo1: '
-            'https://server1/repo1/x86_64 **',
-            mock_stdout.getvalue()
+            "** x86_64: Synchronizing repository repo1: "
+            "https://server1/repo1/x86_64 **",
+            mock_stdout.getvalue(),
         )
         self.assertIn(
-            '** aarch64: Synchronizing repository repo1: '
-            'https://server1/repo1/aarch64 **',
-            mock_stdout.getvalue()
+            "** aarch64: Synchronizing repository repo1: "
+            "https://server1/repo1/aarch64 **",
+            mock_stdout.getvalue(),
         )
         self.assertIn(
-            '** x86_64: Synchronizing repository repo2: '
-            'https://server2/x86_64/ **',
-            mock_stdout.getvalue()
+            "** x86_64: Synchronizing repository repo2: https://server2/x86_64/ **",
+            mock_stdout.getvalue(),
         )
         self.assertIn(
-            '** aarch64: Synchronizing repository repo2: '
-            'https://server2/aarch64/ **',
-            mock_stdout.getvalue()
+            "** aarch64: Synchronizing repository repo2: https://server2/aarch64/ **",
+            mock_stdout.getvalue(),
         )
         self.assertIn(
-            '** x86_64: Synchronizing repository repo3: '
-            'https://server3/repo3/ **',
-            mock_stdout.getvalue()
+            "** x86_64: Synchronizing repository repo3: https://server3/repo3/ **",
+            mock_stdout.getvalue(),
         )
         # Clean synchronization output parent
         shutil.rmtree(sync_parent)
 
     def test_action_sync_missing_output_parent(self):
-        """ Test rift raises RiftError when sync output parent is not found. """
+        """Test rift raises RiftError when sync output parent is not found."""
         sync_output = "/tmp/rift/output"
-        self.config.options['sync_output'] = sync_output
-        self.config.options['repos'] = {
-            'repo1': {
-                'sync': {
-                    'source': 'https://server1/repo1',
+        self.config.options["sync_output"] = sync_output
+        self.config.options["repos"] = {
+            "repo1": {
+                "sync": {
+                    "source": "https://server1/repo1",
                 },
-                'url': 'https://server1/repo1',
+                "url": "https://server1/repo1",
             },
-            'repo2': {
-                'sync': {
-                    'source': 'https://server2/repo2',
+            "repo2": {
+                "sync": {
+                    "source": "https://server2/repo2",
                 },
-                'url': 'https://server2/repo2',
+                "url": "https://server2/repo2",
             },
         }
         # Update project YAML configuration with new options defined above
@@ -2804,9 +2895,9 @@ class ControllerProjectActionSyncTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError,
             "Unable to create repositories synchronization directory "
-            "/tmp/rift/output, parent directory /tmp/rift does not exist."
+            "/tmp/rift/output, parent directory /tmp/rift does not exist.",
         ):
-            main(['sync'])
+            main(["sync"])
 
 
 class ControllerProjectActionGraphTest(RiftProjectTestCase):
@@ -2814,42 +2905,42 @@ class ControllerProjectActionGraphTest(RiftProjectTestCase):
     Tests class for Controller action graph
     """
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_get_packages_in_graph(self, mock_mock):
-        """ Test get_packages_in_graph(). """
+        """Test get_packages_in_graph()."""
         self.make_pkg(
-            name='libone',
-            metadata={'module': 'Great module'},
+            name="libone",
+            metadata={"module": "Great module"},
         )
         self.make_pkg(
-            name='libtwo',
-            metadata={'module': 'Great module'},
+            name="libtwo",
+            metadata={"module": "Great module"},
         )
         self.make_pkg(
-            name='my-software',
-            metadata={'module': 'Other module'},
+            name="my-software",
+            metadata={"module": "Other module"},
         )
         args = Mock()
-        args.module = 'Great module'
+        args.module = "Great module"
         args.formats = None
         args.packages = []
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         self.assertCountEqual(
             get_packages_in_graph(args, self.config, self.staff, self.modules),
-            ['libone', 'libtwo']
+            ["libone", "libtwo"],
         )
         # Check adding format does not change result in this case.
-        args.formats = ['rpm']
+        args.formats = ["rpm"]
         self.assertCountEqual(
             get_packages_in_graph(args, self.config, self.staff, self.modules),
-            ['libone', 'libtwo']
+            ["libone", "libtwo"],
         )
         args.module = None
-        args.packages = ['libone', 'my-software']
+        args.packages = ["libone", "my-software"]
         self.assertCountEqual(
             get_packages_in_graph(args, self.config, self.staff, self.modules),
-            ['libone', 'my-software']
+            ["libone", "my-software"],
         )
         # When module arg is not set and packages args is empty,
         # get_packages_in_graph() must return an empty list. This empty list
@@ -2858,10 +2949,9 @@ class ControllerProjectActionGraphTest(RiftProjectTestCase):
         args.module = None
         args.packages = []
         self.assertCountEqual(
-            get_packages_in_graph(args, self.config, self.staff, self.modules),
-            []
+            get_packages_in_graph(args, self.config, self.staff, self.modules), []
         )
-        args.module = 'fail'
+        args.module = "fail"
         args.packages = []
         with self.assertRaisesRegex(RiftError, r"^Invalid module name fail$"):
             get_packages_in_graph(args, self.config, self.staff, self.modules)
@@ -2874,11 +2964,11 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
 
     def test_gitlab_missing_patch(self):
         """gerrit without patch"""
-        cmd = ['gitlab']
+        cmd = ["gitlab"]
         with self.assertRaisesRegex(SystemExit, "2"):
             main(cmd)
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_gitlab(self, mock_mock):
         """simple gitlab"""
         self.make_pkg()
@@ -2896,27 +2986,28 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
                  Summary:        A package
                  Group:          System Environment/Base
                  License:        GPL
-                """))
+                """)
+        )
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         # Test no error is raised
-        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
-            main(['gitlab', patch_file.name])
+        with patch.object(mock_mock.return_value, "rpmlint", host_rpmlint):
+            main(["gitlab", patch_file.name])
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_gitlab_check_failed(self, mock_mock):
         """gitlab check error"""
         # Make package and inject rpmlint error ($RPM_BUILD_ROOT and
         # RPM_SOURCE_DIR in buildsteps) in RPM spec file, with both rpmlint v1
         # and v2.
         self.make_pkg()
-        with open(self.buildfiles['pkg:rpm'], "w") as spec:
+        with open(self.buildfiles["pkg:rpm"], "w") as spec:
             spec.write(
                 gen_rpm_spec(
-                    name='pkg',
-                    version='1.0',
-                    release='2',
-                    arch='noarch',
+                    name="pkg",
+                    version="1.0",
+                    release="2",
+                    arch="noarch",
                     buildsteps="$RPM_SOURCE_DIR\n$RPM_BUILD_ROOT",
                 )
             )
@@ -2934,13 +3025,14 @@ class ControllerProjectActionGitlabTest(RiftProjectTestCase):
                  Summary:        A package
                  Group:          System Environment/Base
                  License:        GPL
-                """))
+                """)
+        )
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         # Test error is raised
-        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
+        with patch.object(mock_mock.return_value, "rpmlint", host_rpmlint):
             with self.assertRaisesRegex(RiftError, "rpmlint reported errors"):
-                main(['gitlab', patch_file.name])
+                main(["gitlab", patch_file.name])
 
 
 class ControllerProjectActionGerritTest(RiftProjectTestCase):
@@ -2948,11 +3040,12 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
     Tests class for Controller action gerrit
     """
 
-    @patch('rift.container.ContainerFile.analyze')
-    @patch('rift.package.rpm.Mock')
-    @patch('rift.Controller.Review')
-    def test_gerrit_multiformats(self, mock_review, mock_mock,
-                                 mock_containerfile_analyze):
+    @patch("rift.container.ContainerFile.analyze")
+    @patch("rift.package.rpm.Mock")
+    @patch("rift.Controller.Review")
+    def test_gerrit_multiformats(
+        self, mock_review, mock_mock, mock_containerfile_analyze
+    ):
         """simple gerrit with multiformats package"""
         self.make_pkg()
         patch_file = make_temp_file(
@@ -2979,13 +3072,14 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                 -COPY --from=builder /usr/local/cargo/bin/hello /usr/local/bin/hello
                 +COPY --from=builder /usr/local/cargo/bin/hello /usr/local/sbin/hello
                  CMD ["hello"]
-                """))
+                """)
+        )
 
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         # Emulate rpmlint to return returncode 0
         mock_mock.return_value.rpmlint.return_value.returncode = 0
-        main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        main(["gerrit", "--change", "1", "--patchset", "2", patch_file.name])
         # Check rpmlint is run to analyze the RPM buildfile.
         mock_mock.return_value.rpmlint.assert_called_once()
         # Check Containerfile static analysis is run for OCI buildfile.
@@ -2994,12 +3088,12 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
-    @patch('rift.container.ContainerFile.analyze')
-    @patch('rift.package.rpm.Mock')
-    @patch('rift.Controller.Review')
+    @patch("rift.container.ContainerFile.analyze")
+    @patch("rift.package.rpm.Mock")
+    @patch("rift.Controller.Review")
     def test_gerrit_rpm(self, mock_review, mock_mock, mock_containerfile_analyze):
         """simple gerrit on rpm package"""
-        self.make_pkg(formats=['rpm'])
+        self.make_pkg(formats=["rpm"])
         patch_file = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkg/pkg.spec
@@ -3014,12 +3108,13 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                  Summary:        A package
                  Group:          System Environment/Base
                  License:        GPL
-                """))
+                """)
+        )
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         # Emulate rpmlint to return returncode 0
         mock_mock.return_value.rpmlint.return_value.returncode = 0
-        main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        main(["gerrit", "--change", "1", "--patchset", "2", patch_file.name])
         # Check rpmlint is run to analyze the RPM buildfile.
         mock_mock.return_value.rpmlint.assert_called_once()
         # Check Containerfile static analysis is skipped for RPM-only package.
@@ -3029,12 +3124,12 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
-    @patch('rift.container.ContainerFile.analyze')
-    @patch('rift.package.rpm.Mock')
-    @patch('rift.Controller.Review')
+    @patch("rift.container.ContainerFile.analyze")
+    @patch("rift.package.rpm.Mock")
+    @patch("rift.Controller.Review")
     def test_gerrit_oci(self, mock_review, mock_mock, mock_containerfile_analyze):
         """simple gerrit on oci package"""
-        self.make_pkg(formats=['oci'])
+        self.make_pkg(formats=["oci"])
         patch_file = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/Containerfile b/packages/pkg/Containerfile
@@ -3047,10 +3142,11 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                 -COPY --from=builder /usr/local/cargo/bin/hello /usr/local/bin/hello
                 +COPY --from=builder /usr/local/cargo/bin/hello /usr/local/sbin/hello
                  CMD ["hello"]
-                """))
+                """)
+        )
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        main(["gerrit", "--change", "1", "--patchset", "2", patch_file.name])
         # Check RPM static analysis is skipped for OCI-only package.
         mock_mock.return_value.rpmlint.assert_not_called()
         # Check Containerfile static analysis is run for OCI buildfile.
@@ -3060,23 +3156,24 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
         mock_review.return_value.invalidate.assert_not_called()
         mock_review.return_value.push.assert_called_once()
 
-    @patch('rift.container.ContainerFile.analyze')
-    @patch('rift.package.rpm.Mock')
-    @patch('rift.Controller.Review')
-    def test_gerrit_review_invalidated(self, mock_review, mock_mock,
-                                       mock_containerfile_analyze):
+    @patch("rift.container.ContainerFile.analyze")
+    @patch("rift.package.rpm.Mock")
+    @patch("rift.Controller.Review")
+    def test_gerrit_review_invalidated(
+        self, mock_review, mock_mock, mock_containerfile_analyze
+    ):
         """gerrit review invalidated"""
         # Make package and inject rpmlint error ($RPM_BUILD_ROOT and
         # RPM_SOURCE_DIR in buildsteps) in RPM spec file, with both rpmlint v1
         # and v2.
         self.make_pkg()
-        with open(self.buildfiles['pkg:rpm'], "w") as spec:
+        with open(self.buildfiles["pkg:rpm"], "w") as spec:
             spec.write(
                 gen_rpm_spec(
-                    name='pkg',
-                    version='1.0',
-                    release='2',
-                    arch='noarch',
+                    name="pkg",
+                    version="1.0",
+                    release="2",
+                    arch="noarch",
                     buildsteps="$RPM_SOURCE_DIR\n$RPM_BUILD_ROOT",
                 )
             )
@@ -3094,11 +3191,12 @@ class ControllerProjectActionGerritTest(RiftProjectTestCase):
                  Summary:        A package
                  Group:          System Environment/Base
                  License:        GPL
-                """))
+                """)
+        )
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with patch.object(mock_mock.return_value, 'rpmlint', host_rpmlint):
-            main(['gerrit', '--change', '1', '--patchset', '2', patch_file.name])
+        with patch.object(mock_mock.return_value, "rpmlint", host_rpmlint):
+            main(["gerrit", "--change", "1", "--patchset", "2", patch_file.name])
         # Check Containerfile static analysis is skipped for RPM-only package.
         mock_containerfile_analyze.assert_not_called()
         # Check review has been invalidated and pushed
@@ -3112,121 +3210,137 @@ class ControllerProjectActionChangelogTest(RiftProjectTestCase):
     """
 
     def test_action_changelog_without_maintainer(self):
-        """changelog without maintainer """
+        """changelog without maintainer"""
         with self.assertRaisesRegex(RiftError, "You must specify a maintainer"):
-            main(['changelog', 'pkg', '-c', 'basic change'])
+            main(["changelog", "pkg", "-c", "basic change"])
 
     def test_action_changelog_pkg_not_found(self):
         """changelog package not found"""
         with self.assertRaisesRegex(
-            RiftError,
-            "Package 'pkg' directory does not exist"):
-            main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself'])
+            RiftError, "Package 'pkg' directory does not exist"
+        ):
+            main(["changelog", "pkg", "-c", "basic change", "-t", "Myself"])
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_action_changelog_multiformats(self, mock_mock):
         """simple changelog on multiformats package"""
         self.make_pkg()
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with self.assertLogs(level='INFO') as log:
+        with self.assertLogs(level="INFO") as log:
             self.assertEqual(
-                main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself']), 0)
+                main(["changelog", "pkg", "-c", "basic change", "-t", "Myself"]), 0
+            )
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping package format oci which does not support '
-            'changelog',
-            log.output
+            "INFO:root:Skipping package format oci which does not support changelog",
+            log.output,
         )
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         pkg.load()
-        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(pkg.spec.version, '1.0')
-        self.assertEqual(pkg.spec.release, '1')
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1"
+        )
+        self.assertEqual(pkg.spec.version, "1.0")
+        self.assertEqual(pkg.spec.release, "1")
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_action_changelog_rpm(self, mock_mock):
         """simple changelog on rpm package"""
-        self.make_pkg(formats=['rpm'])
+        self.make_pkg(formats=["rpm"])
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with self.assertLogs(level='INFO') as log:
+        with self.assertLogs(level="INFO") as log:
             self.assertEqual(
-                main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself']), 0)
+                main(["changelog", "pkg", "-c", "basic change", "-t", "Myself"]), 0
+            )
         # Check absence of log message to indicate other formats are skipped.
         self.assertNotIn(
-            'INFO:root:Skipping package format oci which does not support '
-            'changelog',
-            log.output
+            "INFO:root:Skipping package format oci which does not support changelog",
+            log.output,
         )
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         pkg.load()
-        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(pkg.spec.version, '1.0')
-        self.assertEqual(pkg.spec.release, '1')
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1"
+        )
+        self.assertEqual(pkg.spec.version, "1.0")
+        self.assertEqual(pkg.spec.release, "1")
 
     def test_action_changelog_oci(self):
         """simple changelog on oci package"""
-        self.make_pkg(formats=['oci'])
-        with self.assertLogs(level='INFO') as log:
+        self.make_pkg(formats=["oci"])
+        with self.assertLogs(level="INFO") as log:
             self.assertEqual(
-                main(
-                    ['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself']
-                ), 1)
+                main(["changelog", "pkg", "-c", "basic change", "-t", "Myself"]), 1
+            )
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping package format oci which does not support '
-            'changelog',
-            log.output
+            "INFO:root:Skipping package format oci which does not support changelog",
+            log.output,
         )
         # Check presence of error in logs for unability to update any changelog.
         self.assertIn(
-            'ERROR:root:Unable to find package pkg with changelog to update',
-            log.output
+            "ERROR:root:Unable to find package pkg with changelog to update", log.output
         )
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_action_changelog_formats(self, mock_mock):
         """simple changelog with format restriction"""
         self.make_pkg()
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
-        with self.assertLogs(level='INFO') as log:
+        with self.assertLogs(level="INFO") as log:
             self.assertEqual(
                 main(
-                    ['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself',
-                    '--formats', 'rpm']
-                ), 0)
+                    [
+                        "changelog",
+                        "pkg",
+                        "-c",
+                        "basic change",
+                        "-t",
+                        "Myself",
+                        "--formats",
+                        "rpm",
+                    ]
+                ),
+                0,
+            )
 
         # Check presence of log message to indicate other formats are skipped.
         self.assertIn(
-            'INFO:root:Skipping changelog update on oci package pkg due to '
-            'restriction on package formats',
-            log.output
+            "INFO:root:Skipping changelog update on oci package pkg due to "
+            "restriction on package formats",
+            log.output,
         )
 
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         pkg.load()
-        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-1')
-        self.assertEqual(pkg.spec.version, '1.0')
-        self.assertEqual(pkg.spec.release, '1')
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1"
+        )
+        self.assertEqual(pkg.spec.version, "1.0")
+        self.assertEqual(pkg.spec.release, "1")
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_action_changelog_bump(self, mock_mock):
         """simple changelog with bump"""
         self.make_pkg()
         # mock Mock.read_spec to return spec file content directly read on host
         mock_mock.return_value.read_spec = read_file
         self.assertEqual(
-            main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Myself', '--bump']),
-            0)
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+            main(["changelog", "pkg", "-c", "basic change", "-t", "Myself", "--bump"]),
+            0,
+        )
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         pkg.load()
-        self.assertEqual(pkg.spec.changelog_name, 'Myself <buddy@somewhere.org> - 1.0-2')
-        self.assertEqual(pkg.spec.version, '1.0')
-        self.assertEqual(pkg.spec.release, '2')
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-2"
+        )
+        self.assertEqual(pkg.spec.version, "1.0")
+        self.assertEqual(pkg.spec.release, "2")
 
-    @patch('rift.package.rpm.Mock')
+    @patch("rift.package.rpm.Mock")
     def test_action_changelog_unknown_maintainer(self, mock_mock):
         """changelog with unknown maintainer"""
         self.make_pkg()
@@ -3234,275 +3348,310 @@ class ControllerProjectActionChangelogTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError, "Unknown maintainer Fail, cannot be found in staff"
         ):
-            main(['changelog', 'pkg', '-c', 'basic change', '-t', 'Fail'])
+            main(["changelog", "pkg", "-c", "basic change", "-t", "Fail"])
 
 
 class ControllerArgumentsTest(RiftTestCase):
-    """ Arguments parsing tests for Controller module"""
+    """Arguments parsing tests for Controller module"""
 
     def test_make_parser_updaterepo(self):
-        """ Test option parsing """
+        """Test option parsing"""
         args = ["build", "a_package", "--dont-update-repo"]
         parser = make_parser()
         opts = parser.parse_args(args)
         self.assertFalse(opts.updaterepo)
 
     def test_parse_args_build(self):
-        """ Test build command options parsing """
+        """Test build command options parsing"""
         parser = make_parser()
 
-        args = ['build']
+        args = ["build"]
         opts = parser.parse_args(args)
         self.assertIsNone(opts.formats)
         self.assertFalse(opts.quiet)
         self.assertFalse(opts.seq)
 
-        opts = parser.parse_args(['build', '--seq'])
+        opts = parser.parse_args(["build", "--seq"])
         self.assertTrue(opts.seq)
 
-        opts = parser.parse_args(['build', '--quiet'])
+        opts = parser.parse_args(["build", "--quiet"])
         self.assertTrue(opts.quiet)
-        opts = parser.parse_args(['build', '-q'])
+        opts = parser.parse_args(["build", "-q"])
         self.assertTrue(opts.quiet)
 
-        args = ['build', '--formats', 'rpm']
+        args = ["build", "--formats", "rpm"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['build', '--formats', 'rpm', 'oci']
+        args = ["build", "--formats", "rpm", "oci"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm', 'oci'])
+        self.assertCountEqual(opts.formats, ["rpm", "oci"])
 
-        args = ['build', '--formats', 'fail']
+        args = ["build", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
     def test_parse_args_test(self):
-        """ Test test command options parsing """
+        """Test test command options parsing"""
         parser = make_parser()
 
-        args = ['test']
+        args = ["test"]
         opts = parser.parse_args(args)
         self.assertIsNone(opts.formats)
 
-        args = ['test', '--formats', 'rpm']
+        args = ["test", "--formats", "rpm"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['test', '--formats', 'rpm', 'oci']
+        args = ["test", "--formats", "rpm", "oci"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm', 'oci'])
+        self.assertCountEqual(opts.formats, ["rpm", "oci"])
 
-        args = ['test', '--formats', 'fail']
+        args = ["test", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
     def test_parse_args_validate(self):
-        """ Test validate command options parsing """
+        """Test validate command options parsing"""
         parser = make_parser()
 
-        args = ['validate']
+        args = ["validate"]
         opts = parser.parse_args(args)
         self.assertIsNone(opts.formats)
         self.assertFalse(opts.quiet)
         self.assertFalse(opts.seq)
 
-        opts = parser.parse_args(['validate', '--seq'])
+        opts = parser.parse_args(["validate", "--seq"])
         self.assertTrue(opts.seq)
 
-        opts = parser.parse_args(['validate', '--quiet'])
+        opts = parser.parse_args(["validate", "--quiet"])
         self.assertTrue(opts.quiet)
-        opts = parser.parse_args(['validate', '-q', 'pkg'])
+        opts = parser.parse_args(["validate", "-q", "pkg"])
         self.assertTrue(opts.quiet)
 
-        args = ['validate', '--formats', 'rpm']
+        args = ["validate", "--formats", "rpm"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['validate', '--formats', 'rpm', 'oci']
+        args = ["validate", "--formats", "rpm", "oci"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm', 'oci'])
+        self.assertCountEqual(opts.formats, ["rpm", "oci"])
 
-        args = ['validate', '--formats', 'fail']
+        args = ["validate", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             parser.parse_args(args)
 
     def test_parse_args_validdiff(self):
-        """ Test validdiff command options parsing """
+        """Test validdiff command options parsing"""
         parser = make_parser()
 
-        opts = parser.parse_args(['validdiff', '/dev/null'])
+        opts = parser.parse_args(["validdiff", "/dev/null"])
         self.assertFalse(opts.quiet)
         self.assertIsNone(opts.formats)
         self.assertFalse(opts.seq)
 
-        opts = parser.parse_args(['validdiff', '/dev/null', '--seq'])
+        opts = parser.parse_args(["validdiff", "/dev/null", "--seq"])
         self.assertTrue(opts.seq)
 
-        opts = parser.parse_args(['validdiff', '/dev/null', '-q'])
+        opts = parser.parse_args(["validdiff", "/dev/null", "-q"])
         self.assertTrue(opts.quiet)
-        opts = parser.parse_args(['validdiff', '/dev/null', '--quiet'])
+        opts = parser.parse_args(["validdiff", "/dev/null", "--quiet"])
         self.assertTrue(opts.quiet)
 
-        args = ['validdiff', '/dev/null', '--formats', 'rpm']
+        args = ["validdiff", "/dev/null", "--formats", "rpm"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['validdiff', '/dev/null', '--formats', 'fail']
+        args = ["validdiff", "/dev/null", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             parser.parse_args(args)
 
     def test_parse_args_query(self):
-        """ Test query command options parsing """
+        """Test query command options parsing"""
         parser = make_parser()
 
-        args = ['query']
+        args = ["query"]
         opts = parser.parse_args(args)
         self.assertIsNone(opts.formats)
 
-        args = ['query', '--formats', 'rpm']
+        args = ["query", "--formats", "rpm"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['query', '--formats', 'rpm', 'oci']
+        args = ["query", "--formats", "rpm", "oci"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm', 'oci'])
+        self.assertCountEqual(opts.formats, ["rpm", "oci"])
 
-        args = ['query', '--formats', 'fail']
+        args = ["query", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             parser.parse_args(args)
 
     def test_parse_args_changelog(self):
-        """ Test changelog command options parsing """
+        """Test changelog command options parsing"""
         parser = make_parser()
 
-        args = ['changelog']
+        args = ["changelog"]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
-        args = ['changelog', 'pkg']
+        args = ["changelog", "pkg"]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
-        args = ['changelog', 'pkg', '-c', 'comment']
+        args = ["changelog", "pkg", "-c", "comment"]
         opts = parser.parse_args(args)
         self.assertIsNone(opts.formats)
 
-        args = ['changelog', 'pkg', '-c', 'comment', '--formats', 'rpm']
+        args = ["changelog", "pkg", "-c", "comment", "--formats", "rpm"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['changelog', 'pkg', '-c', 'comment', '--formats', 'rpm', 'oci']
+        args = ["changelog", "pkg", "-c", "comment", "--formats", "rpm", "oci"]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm', 'oci'])
+        self.assertCountEqual(opts.formats, ["rpm", "oci"])
 
-        args = ['changelog', 'pkg', '-c', 'comment', '--formats', 'fail']
+        args = ["changelog", "pkg", "-c", "comment", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
     def test_parse_args_gerrit(self):
-        """ Test gerrit command options parsing """
+        """Test gerrit command options parsing"""
         parser = make_parser()
 
-        for args in (['gerrit', '--change', '1', '--patchset', '2'],
-                    ['gerrit', '--patchset', '2', '/dev/null'],
-                    ['gerrit', '--change', '1', '/dev/null']):
+        for args in (
+            ["gerrit", "--change", "1", "--patchset", "2"],
+            ["gerrit", "--patchset", "2", "/dev/null"],
+            ["gerrit", "--change", "1", "/dev/null"],
+        ):
             with self.assertRaisesRegex(SystemExit, "2"):
                 opts = parser.parse_args(args)
 
-        args = ['gerrit', '--change', '1', '--patchset', '2', '/dev/null']
+        args = ["gerrit", "--change", "1", "--patchset", "2", "/dev/null"]
         opts = parser.parse_args(args)
         self.assertIsNone(opts.formats)
 
-        args = ['gerrit', '--change', '1', '--patchset', '2', '/dev/null',
-                '--formats', 'rpm']
+        args = [
+            "gerrit",
+            "--change",
+            "1",
+            "--patchset",
+            "2",
+            "/dev/null",
+            "--formats",
+            "rpm",
+        ]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm'])
+        self.assertCountEqual(opts.formats, ["rpm"])
 
-        args = ['gerrit', '--change', '1', '--patchset', '2', '/dev/null',
-                '--formats', 'rpm', 'oci']
+        args = [
+            "gerrit",
+            "--change",
+            "1",
+            "--patchset",
+            "2",
+            "/dev/null",
+            "--formats",
+            "rpm",
+            "oci",
+        ]
         opts = parser.parse_args(args)
-        self.assertCountEqual(opts.formats, ['rpm', 'oci'])
+        self.assertCountEqual(opts.formats, ["rpm", "oci"])
 
-        args = ['gerrit', '--change', '1', '--patchset', '2', '/dev/null',
-                '--formats', 'fail']
+        args = [
+            "gerrit",
+            "--change",
+            "1",
+            "--patchset",
+            "2",
+            "/dev/null",
+            "--formats",
+            "fail",
+        ]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
     def test_parse_args_graph(self):
-        """ Test graph command options parsing """
+        """Test graph command options parsing"""
         parser = make_parser()
 
-        args = ['graph']
+        args = ["graph"]
         opts = parser.parse_args(args)
         self.assertFalse(opts.with_external)
         self.assertIsNone(opts.formats)
         self.assertIsNone(opts.module)
         self.assertCountEqual(opts.packages, [])
 
-        args = ['graph', '--with-external', '--formats', 'rpm',
-                '--module', 'storage', 'package1', 'package2']
+        args = [
+            "graph",
+            "--with-external",
+            "--formats",
+            "rpm",
+            "--module",
+            "storage",
+            "package1",
+            "package2",
+        ]
         opts = parser.parse_args(args)
         self.assertTrue(opts.with_external)
-        self.assertCountEqual(opts.formats, ['rpm'])
-        self.assertEqual(opts.module, 'storage')
-        self.assertCountEqual(opts.packages, ['package1', 'package2'])
+        self.assertCountEqual(opts.formats, ["rpm"])
+        self.assertEqual(opts.module, "storage")
+        self.assertCountEqual(opts.packages, ["package1", "package2"])
 
-        args = ['graph', '--formats', 'fail']
+        args = ["graph", "--formats", "fail"]
         with self.assertRaises(SystemExit):
             opts = parser.parse_args(args)
 
     def test_make_parser_vm(self):
-        """ Test vm command options parsing """
+        """Test vm command options parsing"""
         parser = make_parser()
 
-        args = ['vm', '--arch', 'x86_64']
+        args = ["vm", "--arch", "x86_64"]
         opts = parser.parse_args(args)
-        self.assertEqual(opts.command, 'vm')
+        self.assertEqual(opts.command, "vm")
 
-        args = ['vm', 'start']
+        args = ["vm", "start"]
         opts = parser.parse_args(args)
-        self.assertEqual(opts.vm_cmd, 'start')
+        self.assertEqual(opts.vm_cmd, "start")
         self.assertFalse(opts.force)
 
-        args = ['vm', 'start', '--force']
+        args = ["vm", "start", "--force"]
         opts = parser.parse_args(args)
-        self.assertEqual(opts.vm_cmd, 'start')
+        self.assertEqual(opts.vm_cmd, "start")
         self.assertTrue(opts.force)
 
-        args = ['vm', 'connect']
+        args = ["vm", "connect"]
         opts = parser.parse_args(args)
-        self.assertEqual(opts.vm_cmd, 'connect')
+        self.assertEqual(opts.vm_cmd, "connect")
 
-        args = ['vm', '--arch', 'x86_64', 'connect']
+        args = ["vm", "--arch", "x86_64", "connect"]
         opts = parser.parse_args(args)
-        self.assertEqual(opts.vm_cmd, 'connect')
+        self.assertEqual(opts.vm_cmd, "connect")
 
-        args = ['vm', 'build', '--url', 'http://image']
+        args = ["vm", "build", "--url", "http://image"]
         opts = parser.parse_args(args)
-        self.assertEqual(opts.vm_cmd, 'build')
-        self.assertEqual(opts.url, 'http://image')
+        self.assertEqual(opts.vm_cmd, "build")
+        self.assertEqual(opts.url, "http://image")
         self.assertFalse(opts.force)
 
-        args = ['vm', 'build', '--url', 'http://image', '--force']
+        args = ["vm", "build", "--url", "http://image", "--force"]
         opts = parser.parse_args(args)
         self.assertTrue(opts.force)
 
-        args = ['vm', 'build', '--url', 'http://image', '--deploy']
+        args = ["vm", "build", "--url", "http://image", "--deploy"]
         opts = parser.parse_args(args)
         self.assertTrue(opts.deploy)
 
-        OUTPUT_IMG = 'OUTPUT'
+        OUTPUT_IMG = "OUTPUT"
 
-        args = ['vm', 'build', '--url', 'http://image', '-o', OUTPUT_IMG]
+        args = ["vm", "build", "--url", "http://image", "-o", OUTPUT_IMG]
         opts = parser.parse_args(args)
         self.assertEqual(opts.output, OUTPUT_IMG)
 
-        args = ['vm', 'build', '--url', 'http://image', '--output', OUTPUT_IMG]
+        args = ["vm", "build", "--url", "http://image", "--output", OUTPUT_IMG]
         opts = parser.parse_args(args)
         self.assertEqual(opts.output, OUTPUT_IMG)
 
         # This must fail due to missing output filename
-        args = ['vm', 'build', '--url', 'http://image', '--output']
+        args = ["vm", "build", "--url", "http://image", "--output"]
         with self.assertRaises(SystemExit):
             parser.parse_args(args)

--- a/tests/Gerrit.py
+++ b/tests/Gerrit.py
@@ -3,35 +3,37 @@
 #
 from unittest import mock
 
-from .TestUtils import RiftTestCase
+from rift import RiftError
 from rift.Config import Config
 from rift.Gerrit import Review
-from rift import RiftError
+
+from .TestUtils import RiftTestCase
+
 
 class GerritTest(RiftTestCase):
     def setUp(self):
         self.config = Config()
         self.config.set(
-            'gerrit',
+            "gerrit",
             {
-                'realm': 'Rift',
-                'server': 'localhost',
-                'username': 'rift',
-                'password': 'SECR3T',
-            }
+                "realm": "Rift",
+                "server": "localhost",
+                "username": "rift",
+                "password": "SECR3T",
+            },
         )
         self.review = Review()
-        self.review.add_comment('/path/to/file', 42, 'E', 'test error message')
+        self.review.add_comment("/path/to/file", 42, "E", "test error message")
 
     def test_invalidate(self):
-        """ Test Review.invalidate() method"""
+        """Test Review.invalidate() method"""
         self.assertEqual(self.review.validated, True)
         self.review.invalidate()
         self.assertEqual(self.review.validated, False)
 
     @mock.patch("rift.Gerrit.urllib.urlopen")
     def test_push(self, mock_urlopen):
-        """ Test Review push """
+        """Test Review push"""
         self.review.push(self.config, 4242, 42)
         # Check push successfully send HTTP request with urllib.urlopen() and
         # reads its result.
@@ -39,14 +41,14 @@ class GerritTest(RiftTestCase):
         mock_urlopen.return_value.read.assert_called_once()
 
     def test_push_no_config(self):
-        """ Test Review push w/o gerrit config error """
-        del self.config.options['gerrit']
+        """Test Review push w/o gerrit config error"""
+        del self.config.options["gerrit"]
         with self.assertRaisesRegex(RiftError, "Gerrit configuration is not defined"):
             self.review.push(self.config, 4242, 42)
 
     def test_push_missing_conf_param(self):
-        """ Test Review push with missing parameter error """
-        gerrit_conf = self.config.get('gerrit')
+        """Test Review push with missing parameter error"""
+        gerrit_conf = self.config.get("gerrit")
         for parameter, value in gerrit_conf.copy().items():
             # temporary remove parameter
             del gerrit_conf[parameter]

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -2,21 +2,22 @@
 # Copyright (C) 2023 CEA
 #
 
-import os
 import getpass
+import os
 import tempfile
 from textwrap import dedent
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import ANY, MagicMock, patch
 
-from .TestUtils import RiftProjectTestCase
+from rift import RiftError
+from rift.Config import _DEFAULT_VARIANT
 from rift.Mock import Mock, rpmlint_chroot_script, rpmlint_env
 from rift.repository import ProjectArchRepositories
 from rift.repository.rpm import ConsumableRepository
 from rift.RPM import RPM
-from rift.TempDir import TempDir
 from rift.run import RunResult
-from rift.Config import _DEFAULT_VARIANT
-from rift import RiftError
+from rift.TempDir import TempDir
+
+from .TestUtils import RiftProjectTestCase
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -27,207 +28,212 @@ class MockTest(RiftProjectTestCase):
     """
 
     def test_mock_object(self):
-        """ Test Mock instanciation """
-        mock = Mock(config=[], arch='x86_64', proj_vers=1.0)
+        """Test Mock instanciation"""
+        mock = Mock(config=[], arch="x86_64", proj_vers=1.0)
         self.assertEqual(mock._mockname, "rift-x86_64-{}-1.0".format(getpass.getuser()))
         self.assertEqual(mock._config, [])
 
     def test_build_context(self):
-        """ Test mock context generation """
-        arch = 'aarch64'
+        """Test mock context generation"""
+        arch = "aarch64"
         _repo_config = {
-                        'module_hotfixes': True,
-                        'excludepkgs': 'somepkg',
-                        'proxy': 'myproxy',
-                    }
+            "module_hotfixes": True,
+            "excludepkgs": "somepkg",
+            "proxy": "myproxy",
+        }
         mock = Mock({}, arch)
         repolist = [
             ConsumableRepository(
-                f"file:///tmp/{arch}", name='tmp', options=_repo_config
+                f"file:///tmp/{arch}", name="tmp", options=_repo_config
             )
         ]
         context = mock._build_template_ctx(repolist)
-        self.assertEqual(context['name'], 'rift-{}-{}'.format(arch, getpass.getuser()))
-        self.assertEqual(context['arch'], arch)
-        repos_ctx = context['repos'][0]
-        self.assertEqual(repos_ctx['name'], 'tmp')
-        self.assertEqual(repos_ctx['priority'], 999)
-        self.assertEqual(repos_ctx['url'], 'file:///tmp/$basearch')
-        self.assertEqual(repos_ctx['module_hotfixes'], True)
-        self.assertEqual(repos_ctx['excludepkgs'], 'somepkg')
-        self.assertEqual(repos_ctx['proxy'], 'myproxy')
+        self.assertEqual(context["name"], "rift-{}-{}".format(arch, getpass.getuser()))
+        self.assertEqual(context["arch"], arch)
+        repos_ctx = context["repos"][0]
+        self.assertEqual(repos_ctx["name"], "tmp")
+        self.assertEqual(repos_ctx["priority"], 999)
+        self.assertEqual(repos_ctx["url"], "file:///tmp/$basearch")
+        self.assertEqual(repos_ctx["module_hotfixes"], True)
+        self.assertEqual(repos_ctx["excludepkgs"], "somepkg")
+        self.assertEqual(repos_ctx["proxy"], "myproxy")
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_init(self, mock_run_command):
-        """ Test Mock init creates all files required by mock """
+        """Test Mock init creates all files required by mock"""
         # Emulate successful mock execution
         mock_run_command.return_value = RunResult(0, None, None)
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         mock.init([])
         self.assertTrue(
             os.path.exists(os.path.join(mock._tmpdir.path, mock.MOCK_DEFAULT))
         )
         for filename in mock.MOCK_FILES:
-            self.assertTrue(
-                os.path.exists(os.path.join(mock._tmpdir.path, filename))
-            )
+            self.assertTrue(os.path.exists(os.path.join(mock._tmpdir.path, filename)))
         mock.clean()
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_init_mock_failure(self, mock_run_command):
-        """ Test Mock init raise error on mock command failure """
+        """Test Mock init raise error on mock command failure"""
         # Emulate mock execution failure
         mock_run_command.return_value = RunResult(1, "output", None)
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         with self.assertRaisesRegex(RiftError, "^output$"):
             mock.init([])
         mock.clean()
 
     def test_init_unexisting_repo(self):
-        """ Test Mock init raise error on unexisting local file repository """
+        """Test Mock init raise error on unexisting local file repository"""
         # Emulate mock execution failure
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         with self.assertRaisesRegex(
             RiftError,
-            "^Repository /fail does not exist, unable to initialize Mock "
-            "environment$"
+            "^Repository /fail does not exist, unable to initialize Mock environment$",
         ):
             mock.init([ConsumableRepository("file:///fail")])
         mock.clean()
 
     def test_args(self):
-        """ Test mock standard arguments """
-        mock = Mock(config={}, arch='x86_64', proj_vers=1.0)
+        """Test mock standard arguments"""
+        mock = Mock(config={}, arch="x86_64", proj_vers=1.0)
         # Init tmp directory
-        mock._tmpdir = TempDir('test_mock')
+        mock._tmpdir = TempDir("test_mock")
         mock._tmpdir.create()
-        self.assertEqual(mock._mock_base(),
-                         ['mock',
-                          '--config-opts',
-                          'print_main_output=yes',
-                          f'--configdir={mock._tmpdir.path}'])
+        self.assertEqual(
+            mock._mock_base(),
+            [
+                "mock",
+                "--config-opts",
+                "print_main_output=yes",
+                f"--configdir={mock._tmpdir.path}",
+            ],
+        )
 
     def test_args_with_macros(self):
-        """ Test Mock macro arguments """
-        mock = Mock(config={"rpm_macros": {"my_version" : 1}}, arch='x86_64', proj_vers=1.0)
+        """Test Mock macro arguments"""
+        mock = Mock(
+            config={"rpm_macros": {"my_version": 1}}, arch="x86_64", proj_vers=1.0
+        )
         # Init tmp directory
-        mock._tmpdir = TempDir('test_mock')
+        mock._tmpdir = TempDir("test_mock")
         mock._tmpdir.create()
 
-        macro_file = os.path.join(mock._tmpdir.path, 'rpm.macro')
-        self.assertEqual(mock._mock_base(),
-                         ['mock',
-                          '--config-opts',
-                          'print_main_output=yes',
-                          f'--configdir={mock._tmpdir.path}',
-                          f'--macro-file={macro_file}'])
+        macro_file = os.path.join(mock._tmpdir.path, "rpm.macro")
+        self.assertEqual(
+            mock._mock_base(),
+            [
+                "mock",
+                "--config-opts",
+                "print_main_output=yes",
+                f"--configdir={mock._tmpdir.path}",
+                f"--macro-file={macro_file}",
+            ],
+        )
         self.assertEqual(open(macro_file).readlines(), ["%my_version 1\n"])
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_build_rpms(self, mock_run_command):
-        """ Test Mock build_rpms() mock build command line """
+        """Test Mock build_rpms() mock build command line"""
         # Emulate successful mock execution
         mock_run_command.return_value = RunResult(0, None, None)
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         # Init tmp directory
-        mock._tmpdir = TempDir('test_mock')
+        mock._tmpdir = TempDir("test_mock")
         mock._tmpdir.create()
 
-        src_rpm_path = os.path.join(
-            TESTS_DIR, 'materials', 'pkg-1.0-1.src.rpm'
-        )
-        repos = ProjectArchRepositories(self.config, 'x86_64').for_format('rpm')
+        src_rpm_path = os.path.join(TESTS_DIR, "materials", "pkg-1.0-1.src.rpm")
+        repos = ProjectArchRepositories(self.config, "x86_64").for_format("rpm")
         srpm = RPM(src_rpm_path)
         mock.build_rpms(srpm, _DEFAULT_VARIANT, repos, False)
         mock_run_command.assert_called_once_with(
             [
-                'mock',
-                '--config-opts',
-                'print_main_output=yes',
+                "mock",
+                "--config-opts",
+                "print_main_output=yes",
                 f"--configdir={mock._tmpdir.path}",
-                '--no-clean',
-                '--no-cleanup-after',
-                src_rpm_path
+                "--no-clean",
+                "--no-cleanup-after",
+                src_rpm_path,
             ],
             live_output=True,
             capture_output=True,
             merge_out_err=True,
-            cwd='/'
+            cwd="/",
         )
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_build_rpms_variant(self, mock_run_command):
-        """ Test Mock build_rpms() mock build command line with variant """
+        """Test Mock build_rpms() mock build command line with variant"""
         # Emulate successful mock execution
         mock_run_command.return_value = RunResult(0, None, None)
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         # Init tmp directory
-        mock._tmpdir = TempDir('test_mock')
+        mock._tmpdir = TempDir("test_mock")
         mock._tmpdir.create()
-        src_rpm_path = os.path.join(
-            TESTS_DIR, 'materials', 'pkg-1.0-1.src.rpm'
-        )
-        repos = ProjectArchRepositories(self.config, 'x86_64').for_format('rpm')
+        src_rpm_path = os.path.join(TESTS_DIR, "materials", "pkg-1.0-1.src.rpm")
+        repos = ProjectArchRepositories(self.config, "x86_64").for_format("rpm")
         repos.for_variant = MagicMock(
             return_value=[
-                ConsumableRepository('http://repo1', name='variant1-repo1'),
-                ConsumableRepository('http://repo2', name='variant1-repo2'),
+                ConsumableRepository("http://repo1", name="variant1-repo1"),
+                ConsumableRepository("http://repo2", name="variant1-repo2"),
             ]
         )
         srpm = RPM(src_rpm_path)
-        mock.build_rpms(srpm, 'variant1', repos, False)
+        mock.build_rpms(srpm, "variant1", repos, False)
         mock_run_command.assert_called_once_with(
             [
-                'mock',
-                '--config-opts',
-                'print_main_output=yes',
+                "mock",
+                "--config-opts",
+                "print_main_output=yes",
                 f"--configdir={mock._tmpdir.path}",
-                '--no-clean',
-                '--no-cleanup-after',
+                "--no-clean",
+                "--no-cleanup-after",
                 src_rpm_path,
-                '--with',
-                'variant1',
-                '--enablerepo',
-                'variant1-repo1',
-                '--enablerepo',
-                'variant1-repo2',
+                "--with",
+                "variant1",
+                "--enablerepo",
+                "variant1-repo1",
+                "--enablerepo",
+                "variant1-repo2",
             ],
             live_output=True,
             capture_output=True,
             merge_out_err=True,
-            cwd='/'
+            cwd="/",
         )
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_read_spec(self, mock_run_command):
         mock_run_command.return_value = RunResult(
             0, "standard output", "standard error"
         )
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         mock.init([])
-        result = mock.read_spec('/dev/package.spec')
+        result = mock.read_spec("/dev/package.spec")
         mock_run_command.assert_called_with(
             [
-                'mock', '--config-opts', 'print_main_output=yes',
+                "mock",
+                "--config-opts",
+                "print_main_output=yes",
                 f"--configdir={mock._tmpdir.path}",
                 "--plugin-option=bind_mount:dirs="
                 "[('/dev/package.spec', '/dev/package.spec')]",
-                'chroot',
-                'rpmspec',
-                '--parse',
-                '/dev/package.spec'
+                "chroot",
+                "rpmspec",
+                "--parse",
+                "/dev/package.spec",
             ],
             live_output=True,
             capture_output=True,
             merge_out_err=False,
-            cwd='/'
+            cwd="/",
         )
         mock.clean()
         self.assertEqual(result, "standard output")
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_read_spec_exec_error(self, mock_run_command):
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         # First run_command call for init OK
         mock_run_command.return_value = RunResult(
             0, "standard output", "standard error"
@@ -238,16 +244,16 @@ class MockTest(RiftProjectTestCase):
             1, "standard output", "standard error"
         )
         with self.assertRaisesRegex(RiftError, "standard error"):
-            mock.read_spec('/dev/package.spec')
+            mock.read_spec("/dev/package.spec")
         mock.clean()
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_read_spec_filter_output(self, mock_run_command):
         output = "error: foo\nwarning: bar\nstandard output\nsh: baz\nrpm: qux\n"
         mock_run_command.return_value = RunResult(0, output, "standard error")
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         mock.init([])
-        result = mock.read_spec('/dev/package.spec')
+        result = mock.read_spec("/dev/package.spec")
         mock.clean()
         self.assertEqual(result, "standard output")
 
@@ -255,32 +261,32 @@ class MockTest(RiftProjectTestCase):
         """Test rpmlint_env() returns None without configdir."""
         self.assertIsNone(rpmlint_env())
         self.assertIsNone(rpmlint_env(None))
-        self.assertIsNone(rpmlint_env(''))
+        self.assertIsNone(rpmlint_env(""))
 
     def test_rpmlint_env_sets_xdg_config_home_realpath(self):
         """Test rpmlint_env() sets XDG_CONFIG_HOME to realpath of configdir."""
         with tempfile.TemporaryDirectory() as tmp:
-            cfg = os.path.join(tmp, 'nested')
+            cfg = os.path.join(tmp, "nested")
             os.mkdir(cfg)
             env = rpmlint_env(cfg)
             self.assertIsNotNone(env)
-            self.assertEqual(env['XDG_CONFIG_HOME'], os.path.realpath(cfg))
+            self.assertEqual(env["XDG_CONFIG_HOME"], os.path.realpath(cfg))
             self.assertIsNot(env, os.environ)
 
     def test_rpmlint_env_is_copy_of_environ(self):
         """Test rpmlint_env() is a copy of os.environ."""
-        with patch.dict(os.environ, {'RIFT_RPMLINT_ENV_TEST': 'orig'}, clear=False):
-            env = rpmlint_env('/tmp')
-            self.assertEqual(env['RIFT_RPMLINT_ENV_TEST'], 'orig')
-            env['RIFT_RPMLINT_ENV_TEST'] = 'changed'
-            self.assertEqual(os.environ['RIFT_RPMLINT_ENV_TEST'], 'orig')
+        with patch.dict(os.environ, {"RIFT_RPMLINT_ENV_TEST": "orig"}, clear=False):
+            env = rpmlint_env("/tmp")
+            self.assertEqual(env["RIFT_RPMLINT_ENV_TEST"], "orig")
+            env["RIFT_RPMLINT_ENV_TEST"] = "changed"
+            self.assertEqual(os.environ["RIFT_RPMLINT_ENV_TEST"], "orig")
 
     def test_rpmlint_chroot_script(self):
         """Test rpmlint_chroot_script() returns shell script for rpmlint."""
         # Generate spec file in temporary directory and generate script.
         with tempfile.TemporaryDirectory() as tmp:
-            spec = os.path.join(tmp, 'pkg.spec')
-            with open(spec, 'w', encoding='utf-8'):
+            spec = os.path.join(tmp, "pkg.spec")
+            with open(spec, "w", encoding="utf-8"):
                 pass
             script = rpmlint_chroot_script(spec)
         self.assertEqual(
@@ -301,10 +307,10 @@ class MockTest(RiftProjectTestCase):
         """Test rpmlint_chroot_script() v2 branch inserts config when toml exists."""
         # Generate spec and toml files in temporary directory and generate script.
         with tempfile.TemporaryDirectory() as tmp:
-            spec = os.path.join(tmp, 'pkg.spec')
-            with open(spec, 'w', encoding='utf-8'):
+            spec = os.path.join(tmp, "pkg.spec")
+            with open(spec, "w", encoding="utf-8"):
                 pass
-            with open(os.path.join(tmp, 'rpmlint.toml'), 'w', encoding='utf-8'):
+            with open(os.path.join(tmp, "rpmlint.toml"), "w", encoding="utf-8"):
                 pass
             script = rpmlint_chroot_script(spec)
         # Check script contains rpmlint -c <toml> <spec>.
@@ -313,72 +319,87 @@ class MockTest(RiftProjectTestCase):
             script,
         )
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_rpmlint(self, mock_run_command):
         """Test Mock.rpmlint() installs rpmlint, runs it in chroot, cleans, returns result."""
-        spec_path = '/dev/package.spec'
+        spec_path = "/dev/package.spec"
         expected_script = rpmlint_chroot_script(spec_path)
 
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
 
         mock_run_command.side_effect = [
             RunResult(0, None, None),  # init
             RunResult(0, None, None),  # install rpmlint
-            RunResult(4, 'rpmlint stdout', 'rpmlint stderr'),  # chroot rpmlint
+            RunResult(4, "rpmlint stdout", "rpmlint stderr"),  # chroot rpmlint
             RunResult(0, None, None),  # clean
         ]
         mock.init([])
         result = mock.rpmlint(spec_path)
 
         # Check return value
-        self.assertEqual(result, RunResult(4, 'rpmlint stdout', 'rpmlint stderr'))
+        self.assertEqual(result, RunResult(4, "rpmlint stdout", "rpmlint stderr"))
         self.assertEqual(mock_run_command.call_count, 4)
 
         # Check mock command calls
         base = [
-            'mock', '--config-opts', 'print_main_output=yes',
-            f'--configdir={mock._tmpdir.path}',
+            "mock",
+            "--config-opts",
+            "print_main_output=yes",
+            f"--configdir={mock._tmpdir.path}",
         ]
         mock_run_command.assert_any_call(
-            base + [
-                '--no-clean', '--no-cleanup-after', '--quiet',
-                '--pm-cmd', 'install', '-y', 'rpmlint', 'kernel-devel',
+            base
+            + [
+                "--no-clean",
+                "--no-cleanup-after",
+                "--quiet",
+                "--pm-cmd",
+                "install",
+                "-y",
+                "rpmlint",
+                "kernel-devel",
             ],
             live_output=ANY,
             capture_output=True,
             merge_out_err=True,
-            cwd='/',
+            cwd="/",
         )
         mock_run_command.assert_any_call(
-            base + [
+            base
+            + [
                 "--plugin-option=bind_mount:dirs=[('/dev', '/dev')]",
-                '--quiet', 'chroot', '--', 'bash', '-c', expected_script,
+                "--quiet",
+                "chroot",
+                "--",
+                "bash",
+                "-c",
+                expected_script,
             ],
             capture_output=True,
             merge_out_err=False,
-            cwd='/',
+            cwd="/",
             env=None,
         )
         mock_run_command.assert_any_call(
-            base + ['--quiet', '--clean'],
+            base + ["--quiet", "--clean"],
             live_output=ANY,
             capture_output=True,
             merge_out_err=True,
-            cwd='/',
+            cwd="/",
         )
         mock.clean()
 
-    @patch('rift.Mock.run_command')
+    @patch("rift.Mock.run_command")
     def test_rpmlint_install_failure_no_chroot_or_clean(self, mock_run_command):
         """Test Mock.rpmlint() install failure no chroot or clean."""
-        mock = Mock(config=self.config, arch='x86_64', proj_vers=1.0)
+        mock = Mock(config=self.config, arch="x86_64", proj_vers=1.0)
         mock_run_command.side_effect = [
             RunResult(0, None, None),  # init
-            RunResult(1, 'install failed', None),  # install rpmlint/kernel-devel
+            RunResult(1, "install failed", None),  # install rpmlint/kernel-devel
         ]
         mock.init([])
-        with self.assertRaisesRegex(RiftError, 'install failed'):
-            mock.rpmlint('/dev/package.spec')
+        with self.assertRaisesRegex(RiftError, "install failed"):
+            mock.rpmlint("/dev/package.spec")
         mock.clean()
         # Check mock called 2 commands: init and install rpmlint/kernel-devel.
         self.assertEqual(mock_run_command.call_count, 2)

--- a/tests/Mock.py
+++ b/tests/Mock.py
@@ -321,7 +321,7 @@ class MockTest(RiftProjectTestCase):
 
     @patch("rift.Mock.run_command")
     def test_rpmlint(self, mock_run_command):
-        """Test Mock.rpmlint() installs rpmlint, runs it in chroot, cleans, returns result."""
+        """Test Mock.rpmlint() installs, runs, cleans, and returns result."""
         spec_path = "/dev/package.spec"
         expected_script = rpmlint_chroot_script(spec_path)
 

--- a/tests/RPM.py
+++ b/tests/RPM.py
@@ -2,37 +2,37 @@
 # Copyright (C) 2020 CEA
 #
 import os
-import time
-import rpm
 import shutil
 import subprocess
+import time
 from unittest.mock import MagicMock, patch
 
-from .TestUtils import (
-    make_temp_dir,
-    gen_rpm_spec,
-    read_file,
-    host_rpmlint,
-    RiftTestCase,
-    RiftProjectTestCase,
-)
+import rpm
+
 from rift import RiftError
-from rift.RPM import Spec, Variable, RPM
-from rift.Mock import Mock, RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2
+from rift.Mock import RPMLINT_CONFIG_V1, RPMLINT_CONFIG_V2, Mock
+from rift.RPM import RPM, Spec, Variable
+
+from .TestUtils import (
+    RiftProjectTestCase,
+    RiftTestCase,
+    gen_rpm_spec,
+    host_rpmlint,
+    make_temp_dir,
+    read_file,
+)
 
 
 def rpmlint_v2():
     """Return True if host rpmlint major version is 2."""
     try:
         proc = subprocess.run(
-            ['rpmlint', '--version'],
+            ["rpmlint", "--version"],
             stdout=subprocess.PIPE,
             check=True,
         )
     except subprocess.CalledProcessError as err:
-        raise RiftError(
-            f"Unable to get rpmlint version: {str(err)}"
-        ) from err
+        raise RiftError(f"Unable to get rpmlint version: {str(err)}") from err
     return proc.stdout.decode().startswith("2")
 
 
@@ -42,10 +42,10 @@ class SpecTest(RiftTestCase):
     """
 
     def setUp(self):
-        self.name='pkg'
-        self.version='1.0'
-        self.release='1'
-        self.arch='noarch'
+        self.name = "pkg"
+        self.version = "1.0"
+        self.release = "1"
+        self.arch = "noarch"
         # /tmp/rift-*/pkg.spec
         self.directory = make_temp_dir()
         self.spec = os.path.join(self.directory, "{0}.spec".format(self.name))
@@ -82,7 +82,7 @@ class SpecTest(RiftTestCase):
         os.rmdir(self.directory)
 
     def test_init(self):
-        """ Test Spec instanciation """
+        """Test Spec instanciation"""
         spec = Spec(self.spec, self.mock, None)
         self.assertIn(self.name, spec.pkgnames)
         self.assertEqual(len(spec.pkgnames), 1)
@@ -97,39 +97,39 @@ class SpecTest(RiftTestCase):
         self.mock.read_spec.assert_called_once_with(self.spec)
 
     def test_init_variant(self):
-        """ Test Spec instanciation """
-        self.variants = ['variant1', 'variant2']
+        """Test Spec instanciation"""
+        self.variants = ["variant1", "variant2"]
         self.update_spec()
-        spec = Spec(self.spec, self.mock, None, variant='variant1')
+        spec = Spec(self.spec, self.mock, None, variant="variant1")
         self.assertIn(self.name, spec.pkgnames)
         self.assertEqual(len(spec.pkgnames), 2)
-        self.assertCountEqual(spec.pkgnames, ['pkg', 'pkg-variant1'])
-        spec = Spec(self.spec, self.mock, None, variant='variant2')
+        self.assertCountEqual(spec.pkgnames, ["pkg", "pkg-variant1"])
+        spec = Spec(self.spec, self.mock, None, variant="variant2")
         self.assertIn(self.name, spec.pkgnames)
         self.assertEqual(len(spec.pkgnames), 2)
-        self.assertCountEqual(spec.pkgnames, ['pkg', 'pkg-variant2'])
+        self.assertCountEqual(spec.pkgnames, ["pkg", "pkg-variant2"])
 
     def test_init_fails(self):
-        """ Test Spec instanciation with error """
-        path = '/nowhere.spec'
-        self.assert_except(RiftError, "{0} does not exist".format(path), Spec, path, self.mock, None)
-
+        """Test Spec instanciation with error"""
+        path = "/nowhere.spec"
+        self.assert_except(
+            RiftError, "{0} does not exist".format(path), Spec, path, self.mock, None
+        )
 
     def test_specfile_check(self):
-        """ Test specfile check function """
-        with patch.object(self.mock, 'rpmlint', host_rpmlint):
+        """Test specfile check function"""
+        with patch.object(self.mock, "rpmlint", host_rpmlint):
             self.assertIsNone(Spec(self.spec, self.mock, None).check())
 
-
     def test_specfile_check_with_rpmlint_v1(self):
-        """ Test specfile check function with a custom rpmlint v1 file"""
+        """Test specfile check function with a custom rpmlint v1 file"""
         # Make an errorneous specfile with hardcoded /lib
         if rpmlint_v2():
             self.skipTest("This test requires rpmlint v1")
         self.files = "/lib/test"
         self.update_spec()
-        with patch.object(self.mock, 'rpmlint', host_rpmlint):
-            with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
+        with patch.object(self.mock, "rpmlint", host_rpmlint):
+            with self.assertRaisesRegex(RiftError, "rpmlint reported errors"):
                 Spec(self.spec, self.mock, None).check()
 
             # Create rpmlint config to ignore hardcoded library path
@@ -140,14 +140,14 @@ class SpecTest(RiftTestCase):
         os.unlink(rpmlintfile)
 
     def test_specfile_check_with_rpmlint_v2(self):
-        """ Test specfile check function with a custom rpmlint v2 file"""
+        """Test specfile check function with a custom rpmlint v2 file"""
         if not rpmlint_v2():
             self.skipTest("This test requires rpmlint v2")
         self.buildsteps = "$RPM_BUILD_ROOT"
         self.update_spec()
 
-        with patch.object(self.mock, 'rpmlint', host_rpmlint):
-            with self.assertRaisesRegex(RiftError, 'rpmlint reported errors'):
+        with patch.object(self.mock, "rpmlint", host_rpmlint):
+            with self.assertRaisesRegex(RiftError, "rpmlint reported errors"):
                 Spec(self.spec, self.mock, None).check()
 
             # Create rpmlint config file to ignore rpm-buildroot-usage
@@ -158,28 +158,30 @@ class SpecTest(RiftTestCase):
         os.unlink(rpmlintfile)
 
     def test_bump_release(self):
-        """ Test bump_release """
+        """Test bump_release"""
         spec = Spec(self.spec, self.mock, None)
-        spec.release = '1'
+        spec.release = "1"
         spec.bump_release()
-        self.assertEqual(spec.release, '2')
+        self.assertEqual(spec.release, "2")
         # Check with %dist macro
-        dist = rpm.expandMacro('%dist')
+        dist = rpm.expandMacro("%dist")
         spec.release = "1{}".format(dist)
         spec.bump_release()
-        self.assertEqual(spec.release, '2{}'.format(dist))
+        self.assertEqual(spec.release, "2{}".format(dist))
         # Check with prefix in release
         spec.release = "1.keyword1{}".format(dist)
         spec.bump_release()
-        self.assertEqual(spec.release, '1.keyword2{}'.format(dist))
+        self.assertEqual(spec.release, "1.keyword2{}".format(dist))
         # Check with invalid release
-        spec.release = 'a'
-        self.assert_except(RiftError,
-                           'Cannot parse package release: {}'.format(spec.release),
-                           spec.bump_release)
+        spec.release = "a"
+        self.assert_except(
+            RiftError,
+            "Cannot parse package release: {}".format(spec.release),
+            spec.bump_release,
+        )
 
     def test_add_changelog_entry(self):
-        """ Test add_changelog_entry """
+        """Test add_changelog_entry"""
         spec = Spec(self.spec, self.mock, None)
         comment = "- New feature"
         userstr = "John Doe"
@@ -187,108 +189,106 @@ class SpecTest(RiftTestCase):
 
         # Check adding changelog entry
         spec.add_changelog_entry(userstr, comment)
-        with open(spec.filepath, 'r') as fspec:
+        with open(spec.filepath, "r") as fspec:
             lines = fspec.readlines()
         self.assertTrue("* {} {} - {}\n".format(date, userstr, spec.evr) in lines)
         self.assertTrue("{}\n".format(comment) in lines)
 
     def test_add_changelog_entry_bump(self):
-        """ Test add_changelog_entry with bump release"""
+        """Test add_changelog_entry with bump release"""
         spec = Spec(self.spec, self.mock, None)
         comment = "- New feature (Bumped)"
         userstr = "John Doe"
         date = time.strftime("%a %b %d %Y", time.gmtime())
 
         spec.add_changelog_entry(userstr, comment, bump=True)
-        with open(spec.filepath, 'r') as fspec:
+        with open(spec.filepath, "r") as fspec:
             lines = fspec.readlines()
         self.assertTrue("Release:        {}\n".format(spec.release) in lines)
         self.assertTrue("* {} {} - {}\n".format(date, userstr, spec.evr) in lines)
         self.assertTrue("{}\n".format(comment) in lines)
 
-
     def test_parse_vars(self):
-        """ Test spec variables parsing """
+        """Test spec variables parsing"""
         spec = Spec(self.spec, self.mock, None)
-        self.assertTrue(str(spec.variables['foo']) == '1.%{bar}')
-        self.assertTrue(spec.variables['foo'].value == '1.%{bar}')
-        self.assertTrue(spec.variables['foo'].name == 'foo')
-        self.assertTrue(spec.variables['foo'].index == 0)
-        self.assertTrue(spec.variables['foo'].keyword == 'global')
-        self.assertTrue(str(spec.variables['bar']) == '1')
-        self.assertTrue(spec.variables['bar'].keyword == 'define')
-        self.assertTrue(spec.variables['bar'].index == 1)
+        self.assertTrue(str(spec.variables["foo"]) == "1.%{bar}")
+        self.assertTrue(spec.variables["foo"].value == "1.%{bar}")
+        self.assertTrue(spec.variables["foo"].name == "foo")
+        self.assertTrue(spec.variables["foo"].index == 0)
+        self.assertTrue(spec.variables["foo"].keyword == "global")
+        self.assertTrue(str(spec.variables["bar"]) == "1")
+        self.assertTrue(spec.variables["bar"].keyword == "define")
+        self.assertTrue(spec.variables["bar"].index == 1)
 
     def test_match_var(self):
-        """ Tests variable detection in pattern """
+        """Tests variable detection in pattern"""
         spec = Spec(self.spec, self.mock, None)
-        foo = spec.variables['foo']
-        bar = spec.variables['bar']
-        self.assertTrue(spec._match_var('%{foo}', r'^1') == foo)
-        self.assertTrue(spec._match_var('%{foo}') == bar)
-        self.assertTrue(spec._match_var('%{?foo}') == bar)
-        self.assertTrue(spec._match_var('%{foo}%{bar}') == bar)
-        self.assertTrue(spec._match_var('%{bar}') == bar)
-        self.assertTrue(spec._match_var('%{notthere}') is None)
-        self.assertTrue(spec._match_var('%{notthere}%{foo}') == bar)
-        self.assertTrue(spec._match_var('%{foo}%{?dist}') == bar)
-        self.assertTrue(spec._match_var('%{foo}%{bar}%{?dist}') == bar)
-        self.assertTrue(spec._match_var('no vars inside') is None)
+        foo = spec.variables["foo"]
+        bar = spec.variables["bar"]
+        self.assertTrue(spec._match_var("%{foo}", r"^1") == foo)
+        self.assertTrue(spec._match_var("%{foo}") == bar)
+        self.assertTrue(spec._match_var("%{?foo}") == bar)
+        self.assertTrue(spec._match_var("%{foo}%{bar}") == bar)
+        self.assertTrue(spec._match_var("%{bar}") == bar)
+        self.assertTrue(spec._match_var("%{notthere}") is None)
+        self.assertTrue(spec._match_var("%{notthere}%{foo}") == bar)
+        self.assertTrue(spec._match_var("%{foo}%{?dist}") == bar)
+        self.assertTrue(spec._match_var("%{foo}%{bar}%{?dist}") == bar)
+        self.assertTrue(spec._match_var("no vars inside") is None)
 
     def test_supports_arch_w_exclusive_arch(self):
-        """ Test supports_arch() with ExclusiveArch"""
+        """Test supports_arch() with ExclusiveArch"""
         self.exclusive_arch = "x86_64"
         self.update_spec()
         spec = Spec(self.spec, self.mock, None)
-        self.assertTrue(spec.supports_arch('x86_64'))
-        self.assertFalse(spec.supports_arch('aarch64'))
+        self.assertTrue(spec.supports_arch("x86_64"))
+        self.assertFalse(spec.supports_arch("aarch64"))
 
     def test_supports_arch_wo_exclusive_arch(self):
-        """ Test supports_arch() without ExclusiveArch"""
+        """Test supports_arch() without ExclusiveArch"""
         spec = Spec(self.spec, self.mock, None)
-        self.assertTrue(spec.supports_arch('x86_64'))
-        self.assertTrue(spec.supports_arch('aarch64'))
+        self.assertTrue(spec.supports_arch("x86_64"))
+        self.assertTrue(spec.supports_arch("aarch64"))
+
 
 class VariableTest(RiftTestCase):
-    """ Test Variable class """
+    """Test Variable class"""
+
     def test_str(self):
-        """ Test string representation """
-        var = Variable(index=3, name='foo', value='bar', keyword='define')
-        self.assertTrue(str(var) == 'bar' )
+        """Test string representation"""
+        var = Variable(index=3, name="foo", value="bar", keyword="define")
+        self.assertTrue(str(var) == "bar")
 
     def test_spec_output(self):
-        """ Test variable format output """
-        var = Variable(index=0, name='foo', value='bar', keyword='define')
-        self.assertTrue(var.spec_output() == '%define foo bar' )
-        buff = ['']
+        """Test variable format output"""
+        var = Variable(index=0, name="foo", value="bar", keyword="define")
+        self.assertTrue(var.spec_output() == "%define foo bar")
+        buff = [""]
         var.spec_output(buff)
-        self.assertTrue(buff[0] == '%define foo bar\n')
+        self.assertTrue(buff[0] == "%define foo bar\n")
 
 
 class RPMTest(RiftProjectTestCase):
-    """ Test RPM class """
+    """Test RPM class"""
+
     def setUp(self):
         super().setUp()
         tests_dir = os.path.dirname(os.path.abspath(__file__))
-        self.bin_rpm = os.path.join(
-            tests_dir, 'materials', 'pkg-1.0-1.noarch.rpm'
-        )
-        self.src_rpm = os.path.join(
-            tests_dir, 'materials', 'pkg-1.0-1.src.rpm'
-        )
+        self.bin_rpm = os.path.join(tests_dir, "materials", "pkg-1.0-1.noarch.rpm")
+        self.src_rpm = os.path.join(tests_dir, "materials", "pkg-1.0-1.src.rpm")
 
     def test_load(self):
         """RPM initializer works with bin/src RPM with/without conf."""
         # test load bin RPM without config
         rpm = RPM(self.bin_rpm)
-        self.assertEqual(rpm.name, 'pkg')
-        self.assertEqual(rpm.arch, 'noarch')
+        self.assertEqual(rpm.name, "pkg")
+        self.assertEqual(rpm.arch, "noarch")
         self.assertEqual(rpm.is_source, False)
 
         # test load src RPM with config
         rpm = RPM(self.src_rpm, self.config)
-        self.assertEqual(rpm.name, 'pkg')
-        self.assertEqual(rpm.arch, 'noarch')
+        self.assertEqual(rpm.name, "pkg")
+        self.assertEqual(rpm.arch, "noarch")
         self.assertEqual(rpm.is_source, True)
 
     def test_extract_srpm(self):
@@ -301,9 +301,9 @@ class RPMTest(RiftProjectTestCase):
         rpm.extract_srpm(specdir, srcdir)
 
         # Verify files have been properly extracted
-        for spec in ['pkg.spec', 'pkg.spec.orig']:
+        for spec in ["pkg.spec", "pkg.spec.orig"]:
             self.assertTrue(os.path.exists(os.path.join(specdir, spec)))
-        self.assertTrue(os.path.exists(os.path.join(srcdir, 'pkg-1.0.tar.gz')))
+        self.assertTrue(os.path.exists(os.path.join(srcdir, "pkg-1.0.tar.gz")))
 
         # Clean up everything
         shutil.rmtree(specdir)
@@ -320,8 +320,7 @@ class RPMTest(RiftProjectTestCase):
         rpm = RPM(self.src_rpm, self.config)
         with self.assertRaisesRegex(
             RiftError,
-            "^Unable to retrieve GPG configuration, unable to sign package "
-            ".*\.rpm$"
+            "^Unable to retrieve GPG configuration, unable to sign package .*\.rpm$",
         ):
             rpm.sign()
 
@@ -329,9 +328,9 @@ class RPMTest(RiftProjectTestCase):
         """RPM.sign() fail with nonexistent keyring."""
         self.config.options.update(
             {
-                'gpg': {
-                  'keyring': '/path/to/nonexistent/keyring',
-                  'key': 'rift',
+                "gpg": {
+                    "keyring": "/path/to/nonexistent/keyring",
+                    "key": "rift",
                 }
             }
         )
@@ -340,39 +339,41 @@ class RPMTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError,
             "^GPG keyring path /path/to/nonexistent/keyring does not exist, "
-            "unable to sign package .*\.rpm$"
+            "unable to sign package .*\.rpm$",
         ):
             rpm.sign()
 
-    def sign_copy(self, gpg_passphrase, rpm_pkg, conf_passphrase=None, preset_passphrase=None):
+    def sign_copy(
+        self, gpg_passphrase, rpm_pkg, conf_passphrase=None, preset_passphrase=None
+    ):
         """
         Generate keyring with provided gpg passphrase, update configuration with
         generated keyring, copy unsigned rpm_pkg, sign it, verify signature and
         cleanup everything.
         """
-        gpg_home = os.path.join(self.projdir, '.gnupg')
+        gpg_home = os.path.join(self.projdir, ".gnupg")
 
         # Launch the agent with --allow-preset-passphrase to accept passphrase
         # provided non-interactively by gpg-preset-passphrase.
         cmd = [
-          'gpg-agent',
-          '--homedir',
-          gpg_home,
-          '--allow-preset-passphrase',
-          '--daemon',
+            "gpg-agent",
+            "--homedir",
+            gpg_home,
+            "--allow-preset-passphrase",
+            "--daemon",
         ]
         subprocess.run(cmd)
 
         # Generate keyring
-        gpg_key = 'rift'
+        gpg_key = "rift"
         cmd = [
-            'gpg',
-            '--homedir',
+            "gpg",
+            "--homedir",
             gpg_home,
-            '--batch',
-            '--passphrase',
-            gpg_passphrase or '',
-            '--quick-generate-key',
+            "--batch",
+            "--passphrase",
+            gpg_passphrase or "",
+            "--quick-generate-key",
             gpg_key,
         ]
         subprocess.run(cmd)
@@ -383,39 +384,37 @@ class RPMTest(RiftProjectTestCase):
             # First find keygrip
             keygrip = None
             cmd = [
-                'gpg',
-                '--homedir',
+                "gpg",
+                "--homedir",
                 gpg_home,
-                '--fingerprint',
-                '--with-keygrip',
-                '--with-colons',
-                gpg_key
+                "--fingerprint",
+                "--with-keygrip",
+                "--with-colons",
+                gpg_key,
             ]
             proc = subprocess.run(cmd, stdout=subprocess.PIPE)
-            for line in proc.stdout.decode().split('\n'):
-                if line.startswith('grp'):
-                    keygrip = line.split(':')[9]
+            for line in proc.stdout.decode().split("\n"):
+                if line.startswith("grp"):
+                    keygrip = line.split(":")[9]
                     break
             # Run gpg-preset-passphrase to add passphrase in agent
-            cmd = ['/usr/libexec/gpg-preset-passphrase', '--preset', keygrip]
+            cmd = ["/usr/libexec/gpg-preset-passphrase", "--preset", keygrip]
             subprocess.run(
-                cmd,
-                env={'GNUPGHOME': gpg_home},
-                input=preset_passphrase.encode()
+                cmd, env={"GNUPGHOME": gpg_home}, input=preset_passphrase.encode()
             )
 
         # Update project configuration with generated key
         self.config.options.update(
             {
-                'gpg': {
-                    'keyring': gpg_home,
-                    'key': gpg_key,
+                "gpg": {
+                    "keyring": gpg_home,
+                    "key": gpg_key,
                 }
             }
         )
 
         if conf_passphrase is not None:
-            self.config.options['gpg']['passphrase'] = conf_passphrase
+            self.config.options["gpg"]["passphrase"] = conf_passphrase
         self.config._check()
 
         # Copy provided rpm_pkg in temporary project directory
@@ -426,9 +425,9 @@ class RPMTest(RiftProjectTestCase):
         rpm = RPM(rpm_copy, self.config)
         self.assertFalse(rpm.is_signed)
         try:
-            os.environ['GNUPGHOME'] = gpg_home
+            os.environ["GNUPGHOME"] = gpg_home
             rpm.sign()
-            del os.environ['GNUPGHOME']
+            del os.environ["GNUPGHOME"]
             # Reload RPM package and check signature
             rpm._load()
             self.assertTrue(rpm.is_signed)
@@ -437,7 +436,7 @@ class RPMTest(RiftProjectTestCase):
             os.remove(rpm_copy)
 
             # Kill GPG agent launched for the test
-            cmd = ['gpgconf', '--homedir', gpg_home, '--kill', 'gpg-agent']
+            cmd = ["gpgconf", "--homedir", gpg_home, "--kill", "gpg-agent"]
             subprocess.run(cmd)
 
             # Remove temporary GPG home with generated key
@@ -445,19 +444,16 @@ class RPMTest(RiftProjectTestCase):
 
     def test_sign_src_rpm(self):
         """Source RPM package signature."""
-        self.sign_copy('TOPSECRET', self.src_rpm, 'TOPSECRET')
+        self.sign_copy("TOPSECRET", self.src_rpm, "TOPSECRET")
 
     def test_sign_bin_rpm(self):
         """Binary RPM package signature."""
-        self.sign_copy('TOPSECRET', self.bin_rpm, 'TOPSECRET')
+        self.sign_copy("TOPSECRET", self.bin_rpm, "TOPSECRET")
 
     def test_sign_wrong_passphrase(self):
         """Package signature raises RiftError with wrong passphrase."""
-        with self.assertRaisesRegex(
-            RiftError,
-            "^Error with signing package.*"
-        ):
-            self.sign_copy('TOPSECRET', self.src_rpm, 'WRONG_PASSPHRASE')
+        with self.assertRaisesRegex(RiftError, "^Error with signing package.*"):
+            self.sign_copy("TOPSECRET", self.src_rpm, "WRONG_PASSPHRASE")
 
     def test_sign_passphrase_agent_not_interactive(self):
         """Package signature with passphrase in agent not interactive."""
@@ -465,7 +461,7 @@ class RPMTest(RiftProjectTestCase):
         # in Rift configuration but loaded in GPG agent, Rift must sign the
         # package without making the agent launch pinentry to ask for the
         # passphrase interactively.
-        self.sign_copy('TOPSECRET', self.src_rpm, preset_passphrase='TOPSECRET')
+        self.sign_copy("TOPSECRET", self.src_rpm, preset_passphrase="TOPSECRET")
 
     def test_sign_empty_passphrase_not_interactive(self):
         """Package signature with empty passphrase no interactive passphrase."""

--- a/tests/TempDir.py
+++ b/tests/TempDir.py
@@ -3,8 +3,11 @@
 #
 
 import os
-from .TestUtils import RiftTestCase
+
 from rift.TempDir import TempDir
+
+from .TestUtils import RiftTestCase
+
 
 class TempDirTest(RiftTestCase):
     """
@@ -12,23 +15,23 @@ class TempDirTest(RiftTestCase):
     """
 
     def test_init(self):
-        """ Test TempDir instance """
-        tmpdir = TempDir('somewhere')
+        """Test TempDir instance"""
+        tmpdir = TempDir("somewhere")
         self.assertIsNone(tmpdir.path)
-        self.assertEqual(tmpdir.name, 'somewhere')
+        self.assertEqual(tmpdir.name, "somewhere")
 
     def test_create(self):
-        """ Test TempDir creation"""
-        tmpdir = TempDir('somewhere')
+        """Test TempDir creation"""
+        tmpdir = TempDir("somewhere")
         tmpdir.create()
         self.assertTrue(tmpdir.name in tmpdir.path)
         self.assertTrue(os.path.isdir(tmpdir.path))
 
     def test_delete(self):
-        """ Test TempDir deletion"""
-        tmpdir = TempDir('somewhere')
+        """Test TempDir deletion"""
+        tmpdir = TempDir("somewhere")
         tmpdir.create()
-        oldpath=tmpdir.path
+        oldpath = tmpdir.path
         tmpdir.delete()
         self.assertIsNone(tmpdir.path)
         self.assertFalse(os.path.isdir(oldpath))

--- a/tests/TestResults.py
+++ b/tests/TestResults.py
@@ -5,9 +5,11 @@ import textwrap
 import xml.etree.ElementTree as ET
 from io import BytesIO
 
-from .TestUtils import RiftTestCase
-from rift.TestResults import TestResults, TestCase
 from rift.Config import _DEFAULT_VARIANT
+from rift.TestResults import TestCase, TestResults
+
+from .TestUtils import RiftTestCase
+
 
 class TestResultsTest(RiftTestCase):
     """
@@ -15,7 +17,7 @@ class TestResultsTest(RiftTestCase):
     """
 
     def test_init(self):
-        """ TestResults instance """
+        """TestResults instance"""
         results = TestResults()
 
         self.assertCountEqual(results.results, [])
@@ -25,10 +27,10 @@ class TestResultsTest(RiftTestCase):
     def test_add_success(self):
         results = TestResults()
         results.add_success(
-            TestCase('test1', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         results.add_success(
-            TestCase('test2', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test2", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         self.assertTrue(results.global_result)
         self.assertEqual(len(results), 2)
@@ -36,10 +38,10 @@ class TestResultsTest(RiftTestCase):
     def test_add_failure(self):
         results = TestResults()
         results.add_failure(
-            TestCase('test1', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         results.add_failure(
-            TestCase('test2', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test2", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         self.assertFalse(results.global_result)
         self.assertEqual(len(results), 2)
@@ -47,10 +49,10 @@ class TestResultsTest(RiftTestCase):
     def test_add_success_failure(self):
         results = TestResults()
         results.add_success(
-            TestCase('test1', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         results.add_failure(
-            TestCase('test2', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test2", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         self.assertFalse(results.global_result)
         self.assertEqual(len(results), 2)
@@ -58,17 +60,17 @@ class TestResultsTest(RiftTestCase):
     def test_extend(self):
         results = TestResults()
         results.add_success(
-            TestCase('test1', 'pkg1', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg1", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         results.add_failure(
-            TestCase('test2', 'pkg1', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test2", "pkg1", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         others = TestResults()
         others.add_success(
-            TestCase('test1', 'pkg2', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg2", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         others.add_failure(
-            TestCase('test2', 'pkg2', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test2", "pkg2", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         results.extend(others)
         self.assertFalse(results.global_result)
@@ -77,40 +79,40 @@ class TestResultsTest(RiftTestCase):
     def test_junit(self):
         results = TestResults()
         results.add_success(
-            TestCase('test1', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'),
+            TestCase("test1", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"),
             1,
-            out="output test1"
+            out="output test1",
         )
         results.add_failure(
-            TestCase('test2', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'),
+            TestCase("test2", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"),
             1,
-            out="output test2"
+            out="output test2",
         )
         output = BytesIO()
         results.junit(output)
         root = ET.fromstring(output.getvalue().decode())
-        self.assertEqual(root.tag, 'testsuite')
-        self.assertEqual(root.attrib, { 'tests': '2'})
-        self.assertEqual(len(root.findall('*')), 2)
+        self.assertEqual(root.tag, "testsuite")
+        self.assertEqual(root.attrib, {"tests": "2"})
+        self.assertEqual(len(root.findall("*")), 2)
         for element in root:
-            self.assertEqual(element.tag, 'testcase')
-            self.assertIn(element.attrib['name'], ['test1', 'test2'])
-            self.assertEqual(element.attrib['classname'], 'rift.pkg')
-            self.assertEqual(element.attrib['time'], '1.00')
-            if element.attrib['name'] == 'test1':
-                self.assertIsNone(element.find('failure'))
-                self.assertEqual(element.find('system-out').text, 'output test1')
+            self.assertEqual(element.tag, "testcase")
+            self.assertIn(element.attrib["name"], ["test1", "test2"])
+            self.assertEqual(element.attrib["classname"], "rift.pkg")
+            self.assertEqual(element.attrib["time"], "1.00")
+            if element.attrib["name"] == "test1":
+                self.assertIsNone(element.find("failure"))
+                self.assertEqual(element.find("system-out").text, "output test1")
             else:
-                self.assertIsNotNone(element.find('failure'))
-                self.assertEqual(element.find('system-out').text, 'output test2')
+                self.assertIsNotNone(element.find("failure"))
+                self.assertEqual(element.find("system-out").text, "output test2")
 
     def test_summary(self):
         results = TestResults()
         results.add_success(
-            TestCase('test1', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         results.add_failure(
-            TestCase('test2', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test2", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
         self.assertEqual(
             results.summary(),
@@ -120,17 +122,15 @@ class TestResultsTest(RiftTestCase):
                 ----      ----   ------ -------- ------
                 pkg.test1 x86_64 rpm          1s Success
                 pkg.test2 x86_64 rpm          1s FAILURE"""
-            )
+            ),
         )
 
     def test_summary_real_variants(self):
         results = TestResults()
         results.add_success(
-            TestCase('test1', 'pkg', _DEFAULT_VARIANT, 'x86_64', 'rpm'), 1
+            TestCase("test1", "pkg", _DEFAULT_VARIANT, "x86_64", "rpm"), 1
         )
-        results.add_failure(
-            TestCase('test2', 'pkg', 'mofed', 'x86_64', 'rpm'), 1
-        )
+        results.add_failure(TestCase("test2", "pkg", "mofed", "x86_64", "rpm"), 1)
         self.assertEqual(
             results.summary(),
             textwrap.dedent(
@@ -139,5 +139,5 @@ class TestResultsTest(RiftTestCase):
                 ----      ------- ----   ------ -------- ------
                 pkg.test1 main    x86_64 rpm          1s Success
                 pkg.test2 mofed   x86_64 rpm          1s FAILURE"""
-            )
+            ),
         )

--- a/tests/TestUnidiff.py
+++ b/tests/TestUnidiff.py
@@ -1,5 +1,7 @@
 from unidiff import parse_unidiff
-from .TestUtils import make_temp_file, make_temp_dir, RiftTestCase
+
+from .TestUtils import RiftTestCase, make_temp_dir, make_temp_file
+
 
 class UnidiffTest(RiftTestCase):
     """
@@ -7,7 +9,7 @@ class UnidiffTest(RiftTestCase):
     """
 
     def testMultiFilePatch(self):
-        """ Test if unidiff parse correctly a patch with mutliple files """
+        """Test if unidiff parse correctly a patch with mutliple files"""
         unifiedpatch = make_temp_file("""
 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
 Author: Myself <buddy@somewhere.org>
@@ -37,7 +39,7 @@ index 0000000..257cc56
 @@ -0,0 +1 @@
 +pub
 """)
-        with open(unifiedpatch.name, 'r') as f:
+        with open(unifiedpatch.name, "r") as f:
             patchedfiles = parse_unidiff(f)
         self.assertEqual(len(patchedfiles), 3)
         filenames = []
@@ -48,7 +50,7 @@ index 0000000..257cc56
         self.assertTrue("file3" in filenames)
 
     def testRenamedPatch(self):
-        """ Test if unidiff parse correctly a patch with renamed files """
+        """Test if unidiff parse correctly a patch with renamed files"""
         unifiedpatch = make_temp_file("""
 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
 Author: Myself <buddy@somewhere.org>
@@ -61,13 +63,13 @@ similarity index 100%
 rename from foo
 rename to bar
 """)
-        with open(unifiedpatch.name, 'r') as f:
+        with open(unifiedpatch.name, "r") as f:
             patchedfiles = parse_unidiff(f)
         for patchedfile in patchedfiles:
             self.assertTrue(patchedfile.renamed)
 
     def testDeletedPatch(self):
-        """ Test if unidiff parse correctly a patch with deleted files """
+        """Test if unidiff parse correctly a patch with deleted files"""
         unifiedpatch = make_temp_file("""
 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
 Author: Myself <buddy@somewhere.org>
@@ -88,7 +90,7 @@ deleted file mode 100644
 index c2e4672..0000000
 Binary files a/packages/slurm/sources/slurm-18.08.6.tar.bz2 and /dev/null differ
 """)
-        with open(unifiedpatch.name, 'r') as f:
+        with open(unifiedpatch.name, "r") as f:
             patchedfiles = parse_unidiff(f)
         for patchedfile in patchedfiles:
             self.assertTrue(patchedfile.is_deleted_file)
@@ -114,7 +116,7 @@ diff --git /dev/null b/bar
 index fcd49dd..91ef207 100644
 Binary files a/sources/a.tar.gz and b/sources/a.tar.gz differ
 """)
-        with open(unifiedpatch.name, 'r') as f:
+        with open(unifiedpatch.name, "r") as f:
             patchedfiles = parse_unidiff(f)
         for patchedfile in patchedfiles:
             self.assertTrue(patchedfile.binary)

--- a/tests/TestUnidiff.py
+++ b/tests/TestUnidiff.py
@@ -1,6 +1,9 @@
+# Embedded git-diff fixtures contain long lines that must stay intact.
+# ruff: noqa: E501
+
 from unidiff import parse_unidiff
 
-from .TestUtils import RiftTestCase, make_temp_dir, make_temp_file
+from .TestUtils import RiftTestCase, make_temp_file
 
 
 class UnidiffTest(RiftTestCase):

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -7,11 +7,7 @@ Helper module to write unit tests for Rift project.
 It contains several helper methods or classes like temporary file management.
 """
 
-from collections import OrderedDict
-from collections import namedtuple
-from contextlib import contextmanager
 import io
-import jinja2
 import os
 import pathlib as pl
 import random
@@ -21,11 +17,14 @@ import tarfile
 import tempfile
 import time
 import unittest
+from collections import OrderedDict, namedtuple
+from contextlib import contextmanager
+
+import jinja2
 import yaml
 
-
-from rift.Config import Config, Staff, Modules
-from rift.Mock import Mock, rpmlint_env, rpmlint_chroot_script
+from rift.Config import Config, Modules, Staff
+from rift.Mock import Mock, rpmlint_chroot_script, rpmlint_env
 from rift.run import run_command
 
 MOCK_CONF = '''\
@@ -174,7 +173,7 @@ PackageTestDef = namedtuple("PackageTestDef", ["name", "local", "formats"])
 class RiftTestCase(unittest.TestCase):
     """unittest.TestCase subclass with additional features"""
 
-    def __init__(self, methodName='runTest'):
+    def __init__(self, methodName="runTest"):
         unittest.TestCase.__init__(self, methodName)
         # Allow to show the full content of a diff
         self.maxDiff = None
@@ -195,6 +194,7 @@ class RiftTestCase(unittest.TestCase):
         if not pl.Path(path).resolve().is_file():
             self.fail("File '%s' does not exist" % str(path))
 
+
 class RiftProjectTestCase(RiftTestCase):
     """
     RiftTestCase that setup a dummy project tree filled with minimal
@@ -205,10 +205,10 @@ class RiftProjectTestCase(RiftTestCase):
         self.cwd = os.getcwd()
         self.projdir = make_temp_dir()
         # ./packages/
-        self.packagesdir = os.path.join(self.projdir, 'packages')
+        self.packagesdir = os.path.join(self.projdir, "packages")
         os.mkdir(self.packagesdir)
         # ./packages/staff.yaml
-        self.staffpath = os.path.join(self.packagesdir, 'staff.yaml')
+        self.staffpath = os.path.join(self.packagesdir, "staff.yaml")
         with open(self.staffpath, "w") as staff:
             staff.write(
                 "staff:\n"
@@ -216,7 +216,7 @@ class RiftProjectTestCase(RiftTestCase):
                 "  Another: {email: another@elsewhere.org}\n"
             )
         # ./packages/modules.yaml
-        self.modulespath = os.path.join(self.packagesdir, 'modules.yaml')
+        self.modulespath = os.path.join(self.packagesdir, "modules.yaml")
         with open(self.modulespath, "w") as mod:
             mod.write(
                 "modules:\n"
@@ -226,7 +226,7 @@ class RiftProjectTestCase(RiftTestCase):
                 "    manager: Another\n"
             )
         # ./annex/
-        self.annexdir = os.path.join(self.projdir, 'annex')
+        self.annexdir = os.path.join(self.projdir, "annex")
         os.mkdir(self.annexdir)
         # ./project.conf
         self.projectconf = os.path.join(self.projdir, Config._DEFAULT_FILES[0])
@@ -268,24 +268,20 @@ class RiftProjectTestCase(RiftTestCase):
             if os.path.exists(src):
                 os.unlink(src)
         for pkgdir in self.pkgdirs.values():
-            info_path = os.path.join(pkgdir, 'info.yaml')
+            info_path = os.path.join(pkgdir, "info.yaml")
             if os.path.exists(info_path):
                 os.unlink(info_path)
-            os.rmdir(os.path.join(pkgdir, 'sources'))
-            if os.path.exists(os.path.join(pkgdir, 'tests')):
-                for test in os.listdir(os.path.join(pkgdir, 'tests')):
-                    os.unlink(os.path.join(pkgdir, 'tests', test))
-                os.rmdir(os.path.join(pkgdir, 'tests'))
+            os.rmdir(os.path.join(pkgdir, "sources"))
+            if os.path.exists(os.path.join(pkgdir, "tests")):
+                for test in os.listdir(os.path.join(pkgdir, "tests")):
+                    os.unlink(os.path.join(pkgdir, "tests", test))
+                os.rmdir(os.path.join(pkgdir, "tests"))
             os.rmdir(pkgdir)
         # Remove potentially generated files for VM related tests
         for path in [
-            self.config.project_path(
-                self.config.get('vm').get('cloud_init_tpl')
-            ),
-            self.config.project_path(
-                self.config.get('vm').get('build_post_script')
-            ),
-            self.config.project_path(self.config.get('vm').get('image')),
+            self.config.project_path(self.config.get("vm").get("cloud_init_tpl")),
+            self.config.project_path(self.config.get("vm").get("build_post_script")),
+            self.config.project_path(self.config.get("vm").get("image")),
         ]:
             if os.path.exists(path):
                 os.unlink(path)
@@ -293,26 +289,28 @@ class RiftProjectTestCase(RiftTestCase):
 
     def update_project_conf(self):
         """Update project YAML configuration file with new Config options."""
+
         class OrderedDumper(yaml.SafeDumper):
             pass
+
         def _dict_representer(dumper, data):
             return dumper.represent_mapping(
-                yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-                data.items()
+                yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items()
             )
+
         OrderedDumper.add_representer(OrderedDict, _dict_representer)
-        with open(self.projectconf, 'w') as fh:
+        with open(self.projectconf, "w") as fh:
             fh.write(yaml.dump(self.config.options, Dumper=OrderedDumper))
 
     def make_pkg(
         self,
-        name='pkg',
+        name="pkg",
         formats=None,
-        version='1.0',
-        release='1',
+        version="1.0",
+        release="1",
         metadata=None,
-        build_requires=['br-package'],
-        requires=['another-package'],
+        build_requires=["br-package"],
+        requires=["another-package"],
         subpackages=[],
         variants=None,
         src_top_dir=None,
@@ -320,10 +318,10 @@ class RiftProjectTestCase(RiftTestCase):
     ):
         # By default, make package in all supported formats
         if formats is None:
-            formats = ['rpm', 'oci']
+            formats = ["rpm", "oci"]
         # Check provide package formats are supported
         for _format in formats:
-            assert(_format in ['rpm', 'oci'])
+            assert _format in ["rpm", "oci"]
         # Set default source top dir name
         if src_top_dir is None:
             src_top_dir = f"{name}-{version}"
@@ -331,43 +329,35 @@ class RiftProjectTestCase(RiftTestCase):
         self.pkgdirs[name] = os.path.join(self.packagesdir, name)
         os.mkdir(self.pkgdirs[name])
         # ./packages/pkg/info.yaml
-        info = os.path.join(self.pkgdirs[name], 'info.yaml')
+        info = os.path.join(self.pkgdirs[name], "info.yaml")
         if metadata is None:
             metadata = {}
         with open(info, "w") as nfo:
             nfo.write("package:\n")
             nfo.write("    maintainers:\n")
             nfo.write("        - Myself\n")
+            nfo.write("    module: {}\n".format(metadata.get("module", "Great module")))
+            nfo.write("    origin: {}\n".format(metadata.get("origin", "Vendor")))
             nfo.write(
-                "    module: {}\n".format(
-                    metadata.get('module', 'Great module')
-                )
+                "    reason: {}\n".format(metadata.get("reason", "Missing feature"))
             )
-            nfo.write(
-                "    origin: {}\n".format(metadata.get('origin', 'Vendor'))
-            )
-            nfo.write(
-                "    reason: {}\n".format(
-                    metadata.get('reason', 'Missing feature')
-                )
-            )
-            if 'depends' in metadata:
-                nfo.write("    depends: {}\n".format(metadata.get('depends')))
-            if 'exclude_archs' in metadata:
+            if "depends" in metadata:
+                nfo.write("    depends: {}\n".format(metadata.get("depends")))
+            if "exclude_archs" in metadata:
                 nfo.write(
-                    "    exclude_archs: {}\n".format(metadata.get('exclude_archs'))
+                    "    exclude_archs: {}\n".format(metadata.get("exclude_archs"))
                 )
             if variants:
                 nfo.write("    variants:\n")
                 for variant in variants:
                     nfo.write(f"    - {variant}\n")
-            if 'oci' in formats:
+            if "oci" in formats:
                 nfo.write("    oci:\n")
                 nfo.write(f"        version: '{version}'\n")
                 nfo.write(f"        release: '{release}'\n")
 
         # ./packages/pkg/pkg.spec
-        if 'rpm' in formats:
+        if "rpm" in formats:
             buildfile = os.path.join(self.pkgdirs[name], "{0}.spec".format(name))
             with open(buildfile, "w") as spec:
                 spec.write(
@@ -377,27 +367,26 @@ class RiftProjectTestCase(RiftTestCase):
                         release=release,
                         build_requires=build_requires,
                         requires=requires,
-                        arch='noarch',
+                        arch="noarch",
                         subpackages=subpackages,
-                        variants=variants
+                        variants=variants,
                     )
                 )
             self.buildfiles[f"{name}:rpm"] = buildfile
 
         # ./packages/pkg/Containerfile
-        if 'oci' in formats:
-            buildfile = os.path.join(self.pkgdirs[name], 'Containerfile')
+        if "oci" in formats:
+            buildfile = os.path.join(self.pkgdirs[name], "Containerfile")
             with open(buildfile, "w") as fh:
-                fh.write('FROM debian:stable')
+                fh.write("FROM debian:stable")
             self.buildfiles[f"{name}:oci"] = buildfile
 
         # ./packages/pkg/sources
-        srcdir = os.path.join(self.pkgdirs[name], 'sources')
+        srcdir = os.path.join(self.pkgdirs[name], "sources")
         os.mkdir(srcdir)
 
         # ./packages/pkg/sources/pkg-version.tar.gz
-        self.pkgsrc[name] = os.path.join(srcdir,
-                                         "{0}-{1}.tar.gz".format(name, version))
+        self.pkgsrc[name] = os.path.join(srcdir, "{0}-{1}.tar.gz".format(name, version))
         with tarfile.open(self.pkgsrc[name], "w:gz") as tar:
             # Add folder in archive
             dir_info = tarfile.TarInfo(name=f"{src_top_dir}/")
@@ -416,12 +405,10 @@ class RiftProjectTestCase(RiftTestCase):
 
         # Add dummy test ./tests/0_test.sh by default
         if tests is None:
-            tests = [
-                PackageTestDef(name='0_test.sh', local=False, formats=[])
-            ]
+            tests = [PackageTestDef(name="0_test.sh", local=False, formats=[])]
 
         # ./tests
-        testsdir = os.path.join(self.pkgdirs[name], 'tests')
+        testsdir = os.path.join(self.pkgdirs[name], "tests")
 
         # If at least one test is present, create tests directory
         if tests:
@@ -431,16 +418,16 @@ class RiftProjectTestCase(RiftTestCase):
         for test in tests:
             test_file = os.path.join(testsdir, test.name)
             with open(test_file, "w") as fh:
-                fh.write('#!/bin/sh\n')
+                fh.write("#!/bin/sh\n")
                 if test.local:
-                    fh.write('# *** RIFT LOCAL ***\n')
+                    fh.write("# *** RIFT LOCAL ***\n")
                 for _format in test.formats:
                     fh.write(f"# *** RIFT FORMAT {_format} ***\n")
-                fh.write('true')
+                fh.write("true")
 
     def clean_mock_environments(self):
         """Remove mock build environments."""
-        for arch in self.config.get('arch'):
+        for arch in self.config.get("arch"):
             mock = Mock(self.config, arch)
             mock.scrub()
 
@@ -449,13 +436,11 @@ class RiftProjectTestCase(RiftTestCase):
         shutil.copy(
             os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
-                '..',
-                'template',
-                'cloud-init.tpl',
+                "..",
+                "template",
+                "cloud-init.tpl",
             ),
-            self.config.project_path(
-                self.config.get('vm').get('cloud_init_tpl')
-            ),
+            self.config.project_path(self.config.get("vm").get("cloud_init_tpl")),
         )
 
     def copy_build_post_script(self):
@@ -463,22 +448,19 @@ class RiftProjectTestCase(RiftTestCase):
         shutil.copy(
             os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
-                '..',
-                'template',
-                'build-post.sh',
+                "..",
+                "template",
+                "build-post.sh",
             ),
-            self.config.project_path(
-                self.config.get('vm').get('build_post_script')
-            ),
+            self.config.project_path(self.config.get("vm").get("build_post_script")),
         )
 
     def ensure_vm_images_cache_dir(self):
         """Ensure VM images cache directory exists."""
-        cache_dir =  self.config.project_path(
-            self.config.get('vm').get('images_cache')
-        )
+        cache_dir = self.config.project_path(self.config.get("vm").get("images_cache"))
         if not os.path.exists(cache_dir):
             os.mkdir(cache_dir)
+
 
 #
 # RPM spec file
@@ -486,14 +468,18 @@ class RiftProjectTestCase(RiftTestCase):
 def gen_rpm_spec(**kwargs):
     return jinja2.Template(SPEC_TPL).render(**kwargs)
 
+
 def read_file(filepath):
     """Read a text file and return its content."""
     return open(filepath).read()
+
+
 #
 # Containerfile
 #
 def gen_containerfile(**kwargs):
     return jinja2.Template(CONTAINERFILE_TPL).render(**kwargs)
+
 
 def host_rpmlint(filepath, configdir=None):
     """
@@ -503,27 +489,29 @@ def host_rpmlint(filepath, configdir=None):
     spec_fp = os.path.realpath(filepath)
     script = rpmlint_chroot_script(spec_fp)
     return run_command(
-        ['bash', '-lc', script],
+        ["bash", "-lc", script],
         capture_output=True,
         merge_out_err=False,
         env=rpmlint_env(configdir),
     )
+
 
 #
 # Temp files
 #
 def make_temp_dir():
     """Create and return the name of a temporary directory."""
-    return tempfile.mkdtemp(prefix='rift-test-')
+    return tempfile.mkdtemp(prefix="rift-test-")
+
 
 def make_temp_filename():
     """Return a temporary name for a file."""
-    return (tempfile.mkstemp(prefix='rift-test-'))[1]
+    return (tempfile.mkstemp(prefix="rift-test-"))[1]
+
 
 def make_temp_file(text, delete=True, suffix=None):
-    """ Create a temporary file with the provided text."""
-    tmp = tempfile.NamedTemporaryFile(prefix='rift-test-', delete=delete,
-                                      suffix=suffix)
+    """Create a temporary file with the provided text."""
+    tmp = tempfile.NamedTemporaryFile(prefix="rift-test-", delete=delete, suffix=suffix)
     tmp.write(text.encode())
     tmp.flush()
     return tmp
@@ -537,25 +525,20 @@ def nullcontext():
     """Context manager that does nothing."""
     yield
 
+
 def make_temp_tar():
-    """ Create temporary tarball with one random file"""
+    """Create temporary tarball with one random file"""
     # Create temporary file
     with tempfile.NamedTemporaryFile(
         delete=False, mode="w+", suffix=".txt"
     ) as tmp_inner:
         tmp_inner.write(
-            ''.join(
-                random.choices(
-                    string.ascii_letters + string.digits, k=2**10
-                )
-            )
+            "".join(random.choices(string.ascii_letters + string.digits, k=2**10))
         )
         inner_path = tmp_inner.name
 
     # Create tarball archive
-    with tempfile.NamedTemporaryFile(
-        delete=False, suffix=".tar"
-    ) as tmp_tar:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".tar") as tmp_tar:
         tar_path = tmp_tar.name
         with tarfile.open(fileobj=tmp_tar, mode="w:") as tar:
             tar.add(inner_path, arcname=os.path.basename(inner_path))
@@ -565,9 +548,11 @@ def make_temp_tar():
 
     return tar_path
 
+
 #
 # Executable commands utilities
 #
+
 
 def command_available(command):
     """
@@ -588,8 +573,12 @@ def command_available(command):
         return _is_executable_file(command)
 
     # Check if it's a relative path (contains path separators or starts with ./)
-    if (os.sep in command or (os.altsep and os.altsep in command) or
-        command.startswith('./') or command.startswith('../')):
+    if (
+        os.sep in command
+        or (os.altsep and os.altsep in command)
+        or command.startswith("./")
+        or command.startswith("../")
+    ):
         # Resolve relative path
         resolved_path = os.path.abspath(command)
         return _is_executable_file(resolved_path)

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -376,9 +376,7 @@ class VMTest(RiftTestCase):
         self.assertNotEqual(helper_args, [])
 
     def test_make_drive_cmd_unexisting_repo(self):
-        """
-        Check drive command line generation raise error when file repository does not exist
-        """
+        """Test drive cmdline errors when file repository is missing."""
         vm = VM(self.config, None)
         vm._repos = [ConsumableRepository("file:///fail")]
         # test for all supported shared FS types
@@ -427,7 +425,7 @@ class VMTest(RiftTestCase):
         args = vm._gen_qemu_args(image_path, "/path/to/seed/iso")
         self.assertEqual(
             args,
-            expected_args + ["-drive", f"driver=raw,file=/path/to/seed/iso,if=virtio"],
+            expected_args + ["-drive", "driver=raw,file=/path/to/seed/iso,if=virtio"],
         )
         # Test with another arch
         vm.arch = "aarch64"
@@ -624,7 +622,7 @@ class VMTest(RiftTestCase):
     def test_download_last_modified_bearer(
         self, mock_download_file, mock_auth_cls, mock_last_modified
     ):
-        """Test VM download last modified check uses Bearer token when vm.auth is idp_token."""
+        """Test VM download Last-Modified check uses Bearer idp_token."""
         mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
             "tok-head"
         )

--- a/tests/VM.py
+++ b/tests/VM.py
@@ -1,32 +1,28 @@
 #
 # Copyright (C) 2024 CEA
 #
-import os
-import shutil
 import atexit
-import urllib
-from unittest.mock import patch, Mock, PropertyMock
-
+import os
 import platform
-from .TestUtils import (
-    RiftTestCase,
-    RiftProjectTestCase,
-    make_temp_dir,
-    make_temp_file
-)
+import shutil
+import urllib
+from unittest.mock import Mock, PropertyMock, patch
+
+from rift import RiftError
 from rift.Config import (
-    Config,
+    _DEFAULT_VARIANT,
+    _DEFAULT_VIRTIOFSD,
     _DEFAULT_VM_ADDRESS,
     _DEFAULT_VM_MEMORY,
-    _DEFAULT_VIRTIOFSD,
-    _DEFAULT_VM_PORT_RANGE_MIN,
     _DEFAULT_VM_PORT_RANGE_MAX,
-    _DEFAULT_VARIANT,
+    _DEFAULT_VM_PORT_RANGE_MIN,
+    Config,
 )
-from rift.repository.rpm import ConsumableRepository
-from rift.VM import VM, ARCH_EFI_BIOS, gen_virtiofs_args
 from rift.package import Test
-from rift import RiftError
+from rift.repository.rpm import ConsumableRepository
+from rift.VM import ARCH_EFI_BIOS, VM, gen_virtiofs_args
+
+from .TestUtils import RiftProjectTestCase, RiftTestCase, make_temp_dir, make_temp_file
 
 # For optimization purpose, create a global cache directory that is removed
 # only when all tests are finished. If this cache directory would have been
@@ -38,38 +34,40 @@ atexit.register(shutil.rmtree, GLOBAL_CACHE)
 
 # Use https_proxy as proxy project configuration parameter if defined in
 # environment.
-PROXY = os.environ.get('https_proxy')
+PROXY = os.environ.get("https_proxy")
 VALID_IMAGE_URL = {
-    'x86_64': (
-        'https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/'
-        'AlmaLinux-8-GenericCloud-latest.x86_64.qcow2'
+    "x86_64": (
+        "https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/"
+        "AlmaLinux-8-GenericCloud-latest.x86_64.qcow2"
     ),
-    'aarch64': (
-        'https://repo.almalinux.org/almalinux/8/cloud/aarch64/images/'
-        'AlmaLinux-8-GenericCloud-latest.aarch64.qcow2'
-    )
+    "aarch64": (
+        "https://repo.almalinux.org/almalinux/8/cloud/aarch64/images/"
+        "AlmaLinux-8-GenericCloud-latest.aarch64.qcow2"
+    ),
 }
+
 
 class VMTest(RiftTestCase):
     """
     Tests class for VMs
     """
+
     def setUp(self):
         self.config = Config()
-        self.config.project_dir = '/'
+        self.config.project_dir = "/"
 
     def test_init(self):
-        """ Test VM initialisation """
+        """Test VM initialisation"""
         # default
-        vm = VM(self.config, 'x86_64')
-        self.assertEqual(vm.arch, 'x86_64')
-        self.assertEqual(vm.cpu_type, 'host')
+        vm = VM(self.config, "x86_64")
+        self.assertEqual(vm.arch, "x86_64")
+        self.assertEqual(vm.cpu_type, "host")
         self.assertEqual(vm.cpus, 4)
         self.assertEqual(vm.memory, _DEFAULT_VM_MEMORY)
         self.assertEqual(vm.arch_efi_bios, ARCH_EFI_BIOS)
         self.assertEqual(vm.address, _DEFAULT_VM_ADDRESS)
         self.assertEqual(vm._image_src, None)
-        self.assertEqual(vm.qemu, 'qemu-system-x86_64')
+        self.assertEqual(vm.qemu, "qemu-system-x86_64")
         self.assertEqual(vm._repos, [])
         self.assertTrue(vm.tmpmode)
         self.assertFalse(vm.copymode)
@@ -78,38 +76,38 @@ class VMTest(RiftTestCase):
         self.assertIsNone(vm.kernel)
 
         # arch specific
-        self.config.set('arch', ['aarch64'])
-        vm = VM(self.config, 'aarch64')
-        self.assertEqual(vm.arch, 'aarch64')
-        self.assertEqual(vm.cpu_type, 'cortex-a72')
+        self.config.set("arch", ["aarch64"])
+        vm = VM(self.config, "aarch64")
+        self.assertEqual(vm.arch, "aarch64")
+        self.assertEqual(vm.cpu_type, "cortex-a72")
 
         vm_custom_memory = 4096
 
         # custom
-        self.config.set('arch', ['aarch64'])
+        self.config.set("arch", ["aarch64"])
         self.config.set(
-            'vm',
+            "vm",
             {
-                'cpu': 'custom',
-                'cpus': 32,
-                'memory': vm_custom_memory,
-                'image_copy': 1,
-                'address': '192.168.0.5',
-                'image': '/my_image',
-            }
+                "cpu": "custom",
+                "cpus": 32,
+                "memory": vm_custom_memory,
+                "image_copy": 1,
+                "address": "192.168.0.5",
+                "image": "/my_image",
+            },
         )
-        self.config.set('arch_efi_bios', '/my_bios')
-        self.config.set('qemu', '/my_custom_qemu')
+        self.config.set("arch_efi_bios", "/my_bios")
+        self.config.set("qemu", "/my_custom_qemu")
 
-        vm = VM(self.config, 'aarch64')
-        self.assertEqual(vm.arch, 'aarch64')
-        self.assertEqual(vm.cpu_type, 'custom')
+        vm = VM(self.config, "aarch64")
+        self.assertEqual(vm.arch, "aarch64")
+        self.assertEqual(vm.cpu_type, "custom")
         self.assertEqual(vm.cpus, 32)
         self.assertEqual(vm.memory, vm_custom_memory)
-        self.assertEqual(vm.arch_efi_bios, '/my_bios')
-        self.assertEqual(vm.address, '192.168.0.5')
-        self.assertEqual(vm._image_src, urllib.parse.urlparse('/my_image'))
-        self.assertEqual(vm.qemu, '/my_custom_qemu')
+        self.assertEqual(vm.arch_efi_bios, "/my_bios")
+        self.assertEqual(vm.address, "192.168.0.5")
+        self.assertEqual(vm._image_src, urllib.parse.urlparse("/my_image"))
+        self.assertEqual(vm.qemu, "/my_custom_qemu")
         self.assertTrue(vm.port >= _DEFAULT_VM_PORT_RANGE_MIN)
         self.assertTrue(vm.port <= _DEFAULT_VM_PORT_RANGE_MAX)
         self.assertTrue(vm.copymode)
@@ -121,67 +119,67 @@ class VMTest(RiftTestCase):
     def test_vmid(self):
         """Check VM ID stability an uniqueness"""
         # Declare 2 supported architectures for this test
-        self.config.set('arch', ['x86_64', 'aarch64'])
+        self.config.set("arch", ["x86_64", "aarch64"])
         # 2 successive calls to id property with same object must return the
         # same value.
-        vm1 = VM(self.config, 'x86_64')
+        vm1 = VM(self.config, "x86_64")
         self.assertEqual(vm1.vmid, vm1.vmid)
-        vm2 = VM(self.config, 'aarch64')
+        vm2 = VM(self.config, "aarch64")
         self.assertEqual(vm2.vmid, vm2.vmid)
         # Verify vm1 and vm2 ID are different due because of their different
         # architecture.
         self.assertNotEqual(vm1.vmid, vm2.vmid)
         # Get another vm object with the same architecture (and user/version)
         # than vm1 and check it has the same ID.
-        vm3 = VM(self.config, 'x86_64')
+        vm3 = VM(self.config, "x86_64")
         self.assertEqual(vm1.vmid, vm3.vmid)
         # Change version for vm3 and check ID is now different of vm1.
-        self.config.set('version', '2.0')
-        vm3 = VM(self.config, 'x86_64')
+        self.config.set("version", "2.0")
+        vm3 = VM(self.config, "x86_64")
         self.assertNotEqual(vm1.vmid, vm3.vmid)
 
     def test_image_local(self):
         vm = VM(self.config, platform.machine())
         expected_values = {
             # absolute local path
-            ('/absolute/path/to/my_image.qcow2', '/absolute/path/to/my_image.qcow2'),
+            ("/absolute/path/to/my_image.qcow2", "/absolute/path/to/my_image.qcow2"),
             # relative local path
             (
-                '../relative/path/to/my_image.qcow2',
-                '../relative/path/to/my_image.qcow2'
+                "../relative/path/to/my_image.qcow2",
+                "../relative/path/to/my_image.qcow2",
             ),
             # file URI
             (
-                'file:///absolute/path/to/my_image.qcow2',
-                '/absolute/path/to/my_image.qcow2'
+                "file:///absolute/path/to/my_image.qcow2",
+                "/absolute/path/to/my_image.qcow2",
             ),
             # remote URI http
             (
-                'http://localhost/path/to/my_image.qcow2',
-                f"/tmp/rift-vm-local-image-{vm.vmid}_my_image.qcow2"
+                "http://localhost/path/to/my_image.qcow2",
+                f"/tmp/rift-vm-local-image-{vm.vmid}_my_image.qcow2",
             ),
             # remote URI https
             (
-                'https://localhost/path/to/my_other_image.qcow2',
-                f"/tmp/rift-vm-local-image-{vm.vmid}_my_other_image.qcow2"
+                "https://localhost/path/to/my_other_image.qcow2",
+                f"/tmp/rift-vm-local-image-{vm.vmid}_my_other_image.qcow2",
             ),
         }
         for expected_value in expected_values:
             self.config.set(
-                'vm',
+                "vm",
                 {
-                    'image': expected_value[0],
-                }
+                    "image": expected_value[0],
+                },
             )
             vm = VM(self.config, platform.machine())
             self.assertEqual(vm.image_local, expected_value[1])
 
     def test_image_local_unsupported_scheme(self):
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': 'fail://localhost/path/to/my_image.qcow2',
-            }
+                "image": "fail://localhost/path/to/my_image.qcow2",
+            },
         )
         vm = VM(self.config, platform.machine())
         with self.assertRaisesRegex(
@@ -192,59 +190,52 @@ class VMTest(RiftTestCase):
     def test_image_is_remote(self):
         expected_values = {
             # absolute local path
-            ('/absolute/path/to/my_image.qcow2', False),
+            ("/absolute/path/to/my_image.qcow2", False),
             # relative local path
-            ('../relative/path/to/my_image.qcow2', False),
+            ("../relative/path/to/my_image.qcow2", False),
             # file URI
-            ('file:///absolute/path/to/my_image.qcow2', False),
+            ("file:///absolute/path/to/my_image.qcow2", False),
             # remote URI http
-            ('http://localhost/path/to/my_image.qcow2', True),
+            ("http://localhost/path/to/my_image.qcow2", True),
             # remote URI https
-            ('https://localhost/path/to/my_image.qcow2', True),
+            ("https://localhost/path/to/my_image.qcow2", True),
         }
         for expected_value in expected_values:
             self.config.set(
-                'vm',
+                "vm",
                 {
-                    'image': expected_value[0],
-                }
+                    "image": expected_value[0],
+                },
             )
-            vm = VM(self.config, 'x86_64')
+            vm = VM(self.config, "x86_64")
             self.assertEqual(vm.image_is_remote(), expected_value[1])
 
     def test_default_port(self):
         """Check VM default port uniqueness and range conformity"""
         # Declare 2 supported architectures for this test
-        self.config.set('arch', ['x86_64', 'aarch64'])
-        vm1 = VM(self.config, 'x86_64')
-        vm2 = VM(self.config, 'aarch64')
-        vm3 = VM(self.config, 'x86_64')
-        port_range = {'min': 2000,  'max': 3000}
+        self.config.set("arch", ["x86_64", "aarch64"])
+        vm1 = VM(self.config, "x86_64")
+        vm2 = VM(self.config, "aarch64")
+        vm3 = VM(self.config, "x86_64")
+        port_range = {"min": 2000, "max": 3000}
         # Verify vm1 and vm2 default are different because of their different
         # architecture.
-        self.assertNotEqual(
-            vm1.default_port(port_range),
-            vm2.default_port(port_range)
-        )
+        self.assertNotEqual(vm1.default_port(port_range), vm2.default_port(port_range))
         # Verify vm1 and vm3 have the same default port because they share the
         # same combination of user/arch/version.
-        self.assertEqual(
-            vm1.default_port(port_range),
-            vm3.default_port(port_range)
-        )
+        self.assertEqual(vm1.default_port(port_range), vm3.default_port(port_range))
         # Verify both default ports are included in range
-        self.assertTrue(vm1.default_port(port_range) >= port_range['min'])
-        self.assertTrue(vm1.default_port(port_range) < port_range['max'])
-        self.assertTrue(vm2.default_port(port_range) >= port_range['min'])
-        self.assertTrue(vm2.default_port(port_range) < port_range['max'])
+        self.assertTrue(vm1.default_port(port_range) >= port_range["min"])
+        self.assertTrue(vm1.default_port(port_range) < port_range["max"])
+        self.assertTrue(vm2.default_port(port_range) >= port_range["min"])
+        self.assertTrue(vm2.default_port(port_range) < port_range["max"])
 
     def test_default_port_invalid_range(self):
         """Check VM default port raise error with invalid range"""
-        vm1 = VM(self.config, 'x86_64')
-        port_range = {'min': 2001,  'max': 2000}
+        vm1 = VM(self.config, "x86_64")
+        port_range = {"min": 2001, "max": 2000}
         with self.assertRaisesRegex(
-            RiftError,
-            "^VM port range maximum must be greater than the minimum$"
+            RiftError, "^VM port range maximum must be greater than the minimum$"
         ):
             vm1.default_port(port_range)
 
@@ -253,21 +244,51 @@ class VMTest(RiftTestCase):
         Check virtiofsd args generator
         """
         # test default values non qemu mode
-        args = gen_virtiofs_args('/socket', '/source', False)
-        self.assertEqual(args, [_DEFAULT_VIRTIOFSD, '--socket-path', '/socket',
-                                '--sandbox=none', '--shared-dir', '/source',
-                                '--cache', 'auto'])
+        args = gen_virtiofs_args("/socket", "/source", False)
+        self.assertEqual(
+            args,
+            [
+                _DEFAULT_VIRTIOFSD,
+                "--socket-path",
+                "/socket",
+                "--sandbox=none",
+                "--shared-dir",
+                "/source",
+                "--cache",
+                "auto",
+            ],
+        )
         # test default values qemu mode
-        args = gen_virtiofs_args('/socket', '/source', True)
-        self.assertEqual(args, ['sudo', _DEFAULT_VIRTIOFSD,
-                                '--socket-path=/socket',
-                                '-o', 'source=/source',
-                                '-o', 'cache=auto', '--syslog', '--daemonize'])
+        args = gen_virtiofs_args("/socket", "/source", True)
+        self.assertEqual(
+            args,
+            [
+                "sudo",
+                _DEFAULT_VIRTIOFSD,
+                "--socket-path=/socket",
+                "-o",
+                "source=/source",
+                "-o",
+                "cache=auto",
+                "--syslog",
+                "--daemonize",
+            ],
+        )
         # test custom values
-        args = gen_virtiofs_args('/socket', '/source', False, '/virtiofsd')
-        self.assertEqual(args, ['/virtiofsd', '--socket-path', '/socket',
-                               '--sandbox=none', '--shared-dir', '/source',
-                               '--cache', 'auto'])
+        args = gen_virtiofs_args("/socket", "/source", False, "/virtiofsd")
+        self.assertEqual(
+            args,
+            [
+                "/virtiofsd",
+                "--socket-path",
+                "/socket",
+                "--sandbox=none",
+                "--shared-dir",
+                "/source",
+                "--cache",
+                "auto",
+            ],
+        )
 
     def test_make_drive_cmd_nine_p(self):
         """
@@ -276,24 +297,26 @@ class VMTest(RiftTestCase):
         vm = VM(self.config, None)
 
         # Test 9p configuration without any repos
-        vm.shared_fs_type = '9p'
-        vm._project_dir = '/somewhere'
+        vm.shared_fs_type = "9p"
+        vm._project_dir = "/somewhere"
         args, helper_args = vm._make_drive_cmd()
-        nine_p_args = ['-virtfs',
-                       f"local,id=project,path={vm._project_dir},mount_tag=project,"
-                       'security_model=none']
+        nine_p_args = [
+            "-virtfs",
+            f"local,id=project,path={vm._project_dir},mount_tag=project,"
+            "security_model=none",
+        ]
         self.assertEqual(args, nine_p_args)
         self.assertEqual(helper_args, [])
 
         # Test 9p configuration with repos
         # Use ConsumableRepostory to avoid any createrepo stuff in tests
-        reponame = 'custom'
-        vm._repos = [
-            ConsumableRepository(url='/tmp', name=reponame)
-        ]
+        reponame = "custom"
+        vm._repos = [ConsumableRepository(url="/tmp", name=reponame)]
 
-        repo_args = ['-virtfs',
-                     f'local,id={reponame},path=/tmp,mount_tag={reponame},security_model=none']
+        repo_args = [
+            "-virtfs",
+            f"local,id={reponame},path=/tmp,mount_tag={reponame},security_model=none",
+        ]
 
         args, helper_args = vm._make_drive_cmd()
         self.assertEqual(args, nine_p_args + repo_args)
@@ -305,47 +328,48 @@ class VMTest(RiftTestCase):
         """
         vm = VM(self.config, platform.machine())
         # Test virtiofs configuration without any repos
-        vm.shared_fs_type = 'virtiofs'
-        vm._project_dir = '/somewhere/else'
+        vm.shared_fs_type = "virtiofs"
+        vm._project_dir = "/somewhere/else"
         args, helper_args = vm._make_drive_cmd()
-        virtiofs_same_arch = ['-object',
-                              f'memory-backend-file,id=mem,size={str(vm.memory)}M,'
-                              'mem-path=/tmp,share=on',
-                              '-machine', 'memory-backend=mem,accel=kvm',
-                              '-chardev',
-                              'socket,id=project,path=/tmp/.virtio_fs_project',
-                              '-device',
-                              'vhost-user-fs-pci,queue-size=1024,chardev=project,'
-                              'tag=project']
+        virtiofs_same_arch = [
+            "-object",
+            f"memory-backend-file,id=mem,size={str(vm.memory)}M,mem-path=/tmp,share=on",
+            "-machine",
+            "memory-backend=mem,accel=kvm",
+            "-chardev",
+            "socket,id=project,path=/tmp/.virtio_fs_project",
+            "-device",
+            "vhost-user-fs-pci,queue-size=1024,chardev=project,tag=project",
+        ]
         self.assertEqual(args, virtiofs_same_arch)
         self.assertNotEqual(helper_args, [])
-        vm.arch = 'not_the_same_arch'
+        vm.arch = "not_the_same_arch"
         args, helper_args = vm._make_drive_cmd()
-        virtiofs_diff_arch = ['-object',
-                              f'memory-backend-file,id=mem,size={str(vm.memory)}M,'
-                              'mem-path=/tmp,share=on',
-                              '-machine', 'memory-backend=mem',
-                              '-chardev',
-                              'socket,id=project,path=/tmp/.virtio_fs_project',
-                              '-device',
-                              'vhost-user-fs-pci,queue-size=1024,chardev=project,'
-                              'tag=project']
+        virtiofs_diff_arch = [
+            "-object",
+            f"memory-backend-file,id=mem,size={str(vm.memory)}M,mem-path=/tmp,share=on",
+            "-machine",
+            "memory-backend=mem",
+            "-chardev",
+            "socket,id=project,path=/tmp/.virtio_fs_project",
+            "-device",
+            "vhost-user-fs-pci,queue-size=1024,chardev=project,tag=project",
+        ]
         self.assertEqual(args, virtiofs_diff_arch)
         # Content of helper_args is not tested here see test_gen_virtiofs_args
         self.assertNotEqual(helper_args, [])
 
         # Test virtiofs configuration with repos
         # Use ConsumableRepostory to avoid any createrepo stuff in tests
-        reponame = 'custom'
-        vm._repos = [
-            ConsumableRepository(url='/tmp', name=reponame)
-        ]
+        reponame = "custom"
+        vm._repos = [ConsumableRepository(url="/tmp", name=reponame)]
 
-        repo_args = ['-chardev',
-                     f'socket,id={reponame},path=/tmp/.virtio_fs_{reponame}',
-                     '-device',
-                     f'vhost-user-fs-pci,queue-size=1024,chardev={reponame},'
-                     f'tag={reponame}']
+        repo_args = [
+            "-chardev",
+            f"socket,id={reponame},path=/tmp/.virtio_fs_{reponame}",
+            "-device",
+            f"vhost-user-fs-pci,queue-size=1024,chardev={reponame},tag={reponame}",
+        ]
         args, helper_args = vm._make_drive_cmd()
         self.assertEqual(args, virtiofs_diff_arch + repo_args)
         # Content of helper_args is not tested here see test_gen_virtiofs_args
@@ -358,76 +382,100 @@ class VMTest(RiftTestCase):
         vm = VM(self.config, None)
         vm._repos = [ConsumableRepository("file:///fail")]
         # test for all supported shared FS types
-        for shared_fs_type in ['9p', 'virtiofs']:
+        for shared_fs_type in ["9p", "virtiofs"]:
             vm.shared_fs_type = shared_fs_type
             with self.assertRaisesRegex(
-                RiftError,
-                '^Repository /fail does not exist, unable to start VM$'
+                RiftError, "^Repository /fail does not exist, unable to start VM$"
             ):
                 vm._make_drive_cmd()
-
 
     def test_gen_qemu_args(self):
         """
         Check qemu args generator
         """
         vm = VM(self.config, platform.machine())
-        vm.consolesock = '/console'
-        image_path = '/my_image'
+        vm.consolesock = "/console"
+        image_path = "/my_image"
         # Test without seed iso path
         args = vm._gen_qemu_args(image_path, None)
-        expected_args = [ vm.qemu, '-enable-kvm', '-cpu', vm.cpu_type,
-                          '-name', 'rift', '-display', 'none',
-                          '-m', str(vm.memory), '-smp', str(vm.cpus),
-                          '-drive',
-                          f"file={image_path},if=virtio,format=qcow2,cache=unsafe",
-                          '-chardev', f"socket,id=charserial0,path={vm.consolesock},"
-                          'server=on,wait=off',
-                          '-device', 'isa-serial,chardev=charserial0,id=serial0',
-                          '-netdev', f"user,id=hostnet0,hostname={vm.NAME},"
-                          f"hostfwd=tcp::{vm.port}-:22",
-                          '-device',
-                          'virtio-net-pci,netdev=hostnet0,bus=pci.0,addr=0x3']
+        expected_args = [
+            vm.qemu,
+            "-enable-kvm",
+            "-cpu",
+            vm.cpu_type,
+            "-name",
+            "rift",
+            "-display",
+            "none",
+            "-m",
+            str(vm.memory),
+            "-smp",
+            str(vm.cpus),
+            "-drive",
+            f"file={image_path},if=virtio,format=qcow2,cache=unsafe",
+            "-chardev",
+            f"socket,id=charserial0,path={vm.consolesock},server=on,wait=off",
+            "-device",
+            "isa-serial,chardev=charserial0,id=serial0",
+            "-netdev",
+            f"user,id=hostnet0,hostname={vm.NAME},hostfwd=tcp::{vm.port}-:22",
+            "-device",
+            "virtio-net-pci,netdev=hostnet0,bus=pci.0,addr=0x3",
+        ]
         self.assertEqual(args, expected_args)
         # Test with seed iso path
         args = vm._gen_qemu_args(image_path, "/path/to/seed/iso")
         self.assertEqual(
             args,
-            expected_args
-            + ['-drive', f"driver=raw,file=/path/to/seed/iso,if=virtio"]
+            expected_args + ["-drive", f"driver=raw,file=/path/to/seed/iso,if=virtio"],
         )
         # Test with another arch
-        vm.arch = 'aarch64'
+        vm.arch = "aarch64"
         args = vm._gen_qemu_args(image_path, None)
-        expected_args_aarch64 = [ vm.qemu, '-machine', 'virt', '-cpu', vm.cpu_type,
-                          '-name', 'rift', '-display', 'none',
-                          '-m', str(vm.memory), '-smp', str(vm.cpus),
-                          '-bios', vm.arch_efi_bios,
-                          '-drive',
-                          f"file={image_path},if=virtio,format=qcow2,cache=unsafe",
-                          '-chardev', f"socket,id=charserial0,path={vm.consolesock},"
-                          'server=on,wait=off',
-                          '-device', 'virtio-serial,id=ser0,max_ports=8',
-                          '-serial', 'chardev:charserial0',
-                          '-netdev', f"user,id=hostnet0,hostname={vm.NAME},"
-                          f"hostfwd=tcp::{vm.port}-:22",
-                          '-device',
-                          'virtio-net-device,netdev=hostnet0']
+        expected_args_aarch64 = [
+            vm.qemu,
+            "-machine",
+            "virt",
+            "-cpu",
+            vm.cpu_type,
+            "-name",
+            "rift",
+            "-display",
+            "none",
+            "-m",
+            str(vm.memory),
+            "-smp",
+            str(vm.cpus),
+            "-bios",
+            vm.arch_efi_bios,
+            "-drive",
+            f"file={image_path},if=virtio,format=qcow2,cache=unsafe",
+            "-chardev",
+            f"socket,id=charserial0,path={vm.consolesock},server=on,wait=off",
+            "-device",
+            "virtio-serial,id=ser0,max_ports=8",
+            "-serial",
+            "chardev:charserial0",
+            "-netdev",
+            f"user,id=hostnet0,hostname={vm.NAME},hostfwd=tcp::{vm.port}-:22",
+            "-device",
+            "virtio-net-device,netdev=hostnet0",
+        ]
         self.assertEqual(args, expected_args_aarch64)
 
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download(self, mock_message, mock_download_file):
         """Test VM download"""
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-            }
+                "image": url,
+            },
         )
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
@@ -437,28 +485,29 @@ class VMTest(RiftTestCase):
             vm._download(False)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
             mock_download_file.assert_called_once_with(
-                url, vm.image_local, bearer_token=None)
+                url, vm.image_local, bearer_token=None
+            )
 
-    @patch('rift.VM.Auth')
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.Auth")
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download_idp_token_bearer(
         self, mock_message, mock_download_file, mock_auth_cls
     ):
         """Remote VM image download sends Bearer token when vm.auth is idp_token."""
         mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
-            'test-idp-token'
+            "test-idp-token"
         )
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-                'auth': 'idp_token',
-            }
+                "image": url,
+                "auth": "idp_token",
+            },
         )
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
@@ -468,189 +517,188 @@ class VMTest(RiftTestCase):
             vm._download(False)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
             mock_download_file.assert_called_once_with(
-                url, vm.image_local, bearer_token='test-idp-token')
+                url, vm.image_local, bearer_token="test-idp-token"
+            )
 
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download_force(self, mock_message, mock_download_file):
         """Test VM download force remove local image when present"""
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-            }
+                "image": url,
+            },
         )
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
             mock_image_local.return_value = tmpfile.name
             self.assertTrue(os.path.exists(vm.image_local))
-            with self.assertLogs(level='DEBUG') as cm:
+            with self.assertLogs(level="DEBUG") as cm:
                 vm._download(True)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
             mock_download_file.assert_called_once_with(
-                url, vm.image_local, bearer_token=None)
+                url, vm.image_local, bearer_token=None
+            )
         self.assertIn(
-            'INFO:root:Remove VM image local copy and force re-download for remote '
-            'image',
-            cm.output
+            "INFO:root:Remove VM image local copy and force re-download for remote "
+            "image",
+            cm.output,
         )
 
-    @patch('rift.VM.last_modified')
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.last_modified")
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download_exists_last_modified_older(
         self, mock_message, mock_download_file, mock_last_modified
     ):
         """Test VM download skipped when local copy is present"""
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-            }
+                "image": url,
+            },
         )
         mock_last_modified.return_value = 0.0
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
             mock_image_local.return_value = tmpfile.name
             self.assertTrue(os.path.exists(vm.image_local))
-            with self.assertLogs(level='DEBUG') as cm:
+            with self.assertLogs(level="DEBUG") as cm:
                 vm._download(False)
             mock_message.assert_not_called()
             # Check download_file() has not been called
             mock_download_file.assert_not_called()
-            mock_last_modified.assert_called_once_with(
-                url, bearer_token=None)
+            mock_last_modified.assert_called_once_with(url, bearer_token=None)
             self.assertIn(
                 "DEBUG:root:Local copy of VM image is already updated "
                 f"({int(os.path.getmtime(tmpfile.name))} > 0), skipping download of "
                 "remote image",
-                cm.output
+                cm.output,
             )
 
-    @patch('rift.VM.last_modified')
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.last_modified")
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download_exists_last_modified_newer(
         self, mock_message, mock_download_file, mock_last_modified
     ):
         """Test VM download skipped when local copy is present"""
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-            }
+                "image": url,
+            },
         )
         mock_last_modified.return_value = float(2**32)
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
             mock_image_local.return_value = tmpfile.name
             self.assertTrue(os.path.exists(vm.image_local))
-            with self.assertLogs(level='DEBUG') as cm:
+            with self.assertLogs(level="DEBUG") as cm:
                 vm._download(False)
             mock_message.assert_called_once_with(f"Download remote VM image {url}")
             mock_download_file.assert_called_once_with(
-                url, vm.image_local, bearer_token=None)
-            mock_last_modified.assert_called_once_with(
-                url, bearer_token=None)
+                url, vm.image_local, bearer_token=None
+            )
+            mock_last_modified.assert_called_once_with(url, bearer_token=None)
         self.assertIn(
-            'INFO:root:Remote VM image has been updated, removing local copy',
-            cm.output
+            "INFO:root:Remote VM image has been updated, removing local copy", cm.output
         )
 
-    @patch('rift.VM.last_modified')
-    @patch('rift.VM.Auth')
-    @patch('rift.VM.download_file')
+    @patch("rift.VM.last_modified")
+    @patch("rift.VM.Auth")
+    @patch("rift.VM.download_file")
     def test_download_last_modified_bearer(
         self, mock_download_file, mock_auth_cls, mock_last_modified
     ):
         """Test VM download last modified check uses Bearer token when vm.auth is idp_token."""
         mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
-            'tok-head'
+            "tok-head"
         )
         mock_last_modified.return_value = 0.0
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-                'auth': 'idp_token',
-            }
+                "image": url,
+                "auth": "idp_token",
+            },
         )
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
             mock_image_local.return_value = tmpfile.name
             self.assertTrue(os.path.exists(vm.image_local))
             vm._download(False)
-            mock_last_modified.assert_called_once_with(url, bearer_token='tok-head')
+            mock_last_modified.assert_called_once_with(url, bearer_token="tok-head")
             mock_download_file.assert_not_called()
 
-    @patch('rift.VM.last_modified')
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.last_modified")
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download_exists_last_modified_error(
         self, mock_message, mock_download_file, mock_last_modified
     ):
         """Test VM download skipped when local copy is present"""
-        url = 'http://localhost/path/to/my_image.qcow2'
+        url = "http://localhost/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-            }
+                "image": url,
+            },
         )
         mock_last_modified.side_effect = RiftError("last-modified failure")
         with patch(
-            'rift.VM.VM.image_local', new_callable=PropertyMock
+            "rift.VM.VM.image_local", new_callable=PropertyMock
         ) as mock_image_local:
             vm = VM(self.config, platform.machine())
             tmpfile = make_temp_file("")
             mock_image_local.return_value = tmpfile.name
             self.assertTrue(os.path.exists(vm.image_local))
-            with self.assertLogs(level='DEBUG') as cm:
+            with self.assertLogs(level="DEBUG") as cm:
                 vm._download(False)
             mock_message.assert_not_called()
             mock_download_file.assert_not_called()
-            mock_last_modified.assert_called_once_with(
-                url, bearer_token=None)
+            mock_last_modified.assert_called_once_with(url, bearer_token=None)
         self.assertIn(
             "DEBUG:root:Local copy of VM image is present, unable to get remote image "
             "modification date because of error (last-modified failure), skipping "
             "download of remote image",
-            cm.output
+            cm.output,
         )
 
-    @patch('rift.VM.download_file')
-    @patch('rift.VM.message')
+    @patch("rift.VM.download_file")
+    @patch("rift.VM.message")
     def test_download_skip_local(self, mock_message, mock_download_file):
         """Test VM download is no-op with local images"""
-        url = '/path/to/my_image.qcow2'
+        url = "/path/to/my_image.qcow2"
         self.config.set(
-            'vm',
+            "vm",
             {
-                'image': url,
-            }
+                "image": url,
+            },
         )
         vm = VM(self.config, platform.machine())
         vm._download(False)
         mock_message.assert_not_called()
         mock_download_file.assert_not_called()
 
-    @patch('rift.VM.message')
+    @patch("rift.VM.message")
     def test_start(self, mock_message):
         """Test VM start not running"""
         vm = VM(self.config, platform.machine())
@@ -666,7 +714,7 @@ class VMTest(RiftTestCase):
         vm.ready.assert_called_once()
         vm.prepare.assert_called_once()
 
-    @patch('rift.VM.message')
+    @patch("rift.VM.message")
     def test_start_force(self, mock_message):
         """Test VM force start not running"""
         vm = VM(self.config, platform.machine())
@@ -678,7 +726,7 @@ class VMTest(RiftTestCase):
         self.assertTrue(vm.start(force=True))
         vm._download.assert_called_once_with(True)
 
-    @patch('rift.VM.message')
+    @patch("rift.VM.message")
     def test_start_running(self, mock_message):
         """Test VM start already running"""
         vm = VM(self.config, platform.machine())
@@ -696,9 +744,9 @@ class VMTest(RiftTestCase):
         vm = VM(self.config, platform.machine())
         funcs = vm.local_test_funcs()
         self.assertIsInstance(funcs, dict)
-        self.assertCountEqual(funcs.keys(), ['vm_cmd', 'vm_wait', 'vm_reboot'])
+        self.assertCountEqual(funcs.keys(), ["vm_cmd", "vm_wait", "vm_reboot"])
 
-    @patch('rift.VM.run_command')
+    @patch("rift.VM.run_command")
     def test_run_test(self, mock_run_command):
         vm = VM(self.config, platform.machine())
         test = Test("test.sh")
@@ -707,10 +755,10 @@ class VMTest(RiftTestCase):
         # Check command executed by SSH on VM
         self.assertEqual(
             mock_run_command.call_args[0][0][-1],
-            f"export RIFT_VARIANT={_DEFAULT_VARIANT}; cd /rift.project; test.sh"
+            f"export RIFT_VARIANT={_DEFAULT_VARIANT}; cd /rift.project; test.sh",
         )
 
-    @patch('rift.VM.run_command')
+    @patch("rift.VM.run_command")
     def test_run_test_variant(self, mock_run_command):
         vm = VM(self.config, platform.machine())
         test = Test("test.sh")
@@ -719,8 +767,9 @@ class VMTest(RiftTestCase):
         # Check command executed by SSH on VM
         self.assertEqual(
             mock_run_command.call_args[0][0][-1],
-            "export RIFT_VARIANT=variant1; cd /rift.project; test.sh"
+            "export RIFT_VARIANT=variant1; cd /rift.project; test.sh",
         )
+
 
 class VMBuildTest(RiftProjectTestCase):
     """
@@ -731,9 +780,9 @@ class VMBuildTest(RiftProjectTestCase):
         super().setUp()
         # Override some configuration parameters defined in dummy config from
         # RiftProjectTestCase.
-        self.config.options['vm']['images_cache'] = GLOBAL_CACHE
-        self.config.options['proxy'] = PROXY
-        self.valid_url = VALID_IMAGE_URL['x86_64']
+        self.config.options["vm"]["images_cache"] = GLOBAL_CACHE
+        self.config.options["proxy"] = PROXY
+        self.valid_url = VALID_IMAGE_URL["x86_64"]
         self.copy_cloud_init_tpl()
         self.ensure_vm_images_cache_dir()
 
@@ -744,22 +793,21 @@ class VMBuildTest(RiftProjectTestCase):
 
     def test_build_missing_cache_dir(self):
         """Test VM build with missing cache directory"""
-        vm = VM(self.config, 'x86_64')
-        vm.images_cache = 'non-existent-directory'
+        vm = VM(self.config, "x86_64")
+        vm.images_cache = "non-existent-directory"
         self.assertFalse(os.path.exists(vm.images_cache))
         with self.assertRaisesRegex(
             RiftError,
-            f"^Cloud images cache directory {vm.images_cache} does not "
-            "exist$",
+            f"^Cloud images cache directory {vm.images_cache} does not exist$",
         ):
             vm.build(self.valid_url, False, False, vm.image_local)
 
     def test_build_wrong_url(self):
         """Test VM build with URL error"""
-        vm = VM(self.config, 'x86_64')
+        vm = VM(self.config, "x86_64")
         with patch(
-            'rift.utils.urllib.request.urlopen',
-            side_effect=urllib.error.URLError('fake URL error')
+            "rift.utils.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("fake URL error"),
         ):
             with self.assertRaisesRegex(
                 RiftError,
@@ -767,51 +815,47 @@ class VMBuildTest(RiftProjectTestCase):
             ):
                 vm.build("http://test", False, False, vm.image_local)
         with patch(
-            'rift.utils.urllib.request.urlopen',
-            side_effect=urllib.error.HTTPError(404, "404", 'Not Found', None, None)
+            "rift.utils.urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(404, "404", "Not Found", None, None),
         ):
             with self.assertRaisesRegex(
                 RiftError,
-                "^Error while downloading http://test: HTTP "
-                "Error 404: Not Found$",
+                "^Error while downloading http://test: HTTP Error 404: Not Found$",
             ):
-                vm.build(
-                    'http://test', False, False, vm.image_local
-                )
+                vm.build("http://test", False, False, vm.image_local)
 
     def test_build_missing_cloudinit_tpl(self):
         """Test VM build with missing cloud-init template"""
-        vm = VM(self.config, 'x86_64')
+        vm = VM(self.config, "x86_64")
         os.unlink(vm.cloud_init_tpl)
         with self.assertRaisesRegex(
             RiftError,
-            "^Unable to find cloud-init template file "
-            f"{vm.cloud_init_tpl}$",
+            f"^Unable to find cloud-init template file {vm.cloud_init_tpl}$",
         ):
             vm.build(self.valid_url, False, False, vm.image_local)
 
     def test_build_ok(self):
         """Test VM basic build"""
         self._check_qemuimg()
-        vm = VM(self.config, 'x86_64')
+        vm = VM(self.config, "x86_64")
         vm.build(self.valid_url, False, False, vm.image_local)
         self.assertEqual(os.path.exists(vm.image_local), True)
 
     def test_build_ok_copymode(self):
         """Test VM build OK with copymode enabled"""
-        vm = VM(self.config, 'x86_64')
+        vm = VM(self.config, "x86_64")
         vm.copymode = 1
         vm.build(self.valid_url, False, False, vm.image_local)
         self.assertEqual(os.path.exists(vm.image_local), True)
 
-    @patch('rift.VM.input')
+    @patch("rift.VM.input")
     def test_build_overwrite(self, mock_input):
         """Test VM build overwrite"""
         self._check_qemuimg()
-        vm = VM(self.config, 'x86_64')
+        vm = VM(self.config, "x86_64")
         # create empty output image
-        open(vm.image_local, 'w').close()
-        mock_input.side_effect = 'yes'
+        open(vm.image_local, "w").close()
+        mock_input.side_effect = "yes"
         vm.build(self.valid_url, False, False, vm.image_local)
         self.assertEqual(os.path.exists(vm.image_local), True)
         mock_input.assert_called_once()
@@ -819,34 +863,34 @@ class VMBuildTest(RiftProjectTestCase):
     def test_build_with_build_script(self):
         """Test VM build with build script"""
         self._check_qemuimg()
-        vm = VM(self.config, 'x86_64')
-        with open(vm.build_post_script, 'w') as fh:
+        vm = VM(self.config, "x86_64")
+        with open(vm.build_post_script, "w") as fh:
             fh.write("#!/bin/bash\n/bin/true\n")
         vm.build(self.valid_url, False, False, vm.image_local)
         self.assertEqual(os.path.exists(vm.image_local), True)
 
     def test_build_build_script_kernel(self):
         """Test VM build with build script and kernel configuration"""
-        self.config.options['vm']['kernel'] = '4.18.0-513.el8'
-        vm = VM(self.config, 'x86_64')
-        with open(vm.build_post_script, 'w', encoding='utf-8') as fh:
-            fh.write('#!/bin/bash\n')
+        self.config.options["vm"]["kernel"] = "4.18.0-513.el8"
+        vm = VM(self.config, "x86_64")
+        with open(vm.build_post_script, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/bash\n")
         vm.cmd = Mock(return_value=Mock(returncode=0))
         vm._build_run_post_script([])
         vm.cmd.assert_called_once()
-        self.assertIn('RIFT_KERNEL=4.18.0-513.el8', vm.cmd.call_args[0][0])
+        self.assertIn("RIFT_KERNEL=4.18.0-513.el8", vm.cmd.call_args[0][0])
 
         vm.kernel = None
         vm.cmd.reset_mock()
         vm._build_run_post_script([])
-        self.assertIn('RIFT_KERNEL=', vm.cmd.call_args[0][0])
-        self.assertNotIn('RIFT_KERNEL=4.18.0-513.el8', vm.cmd.call_args[0][0])
+        self.assertIn("RIFT_KERNEL=", vm.cmd.call_args[0][0])
+        self.assertNotIn("RIFT_KERNEL=4.18.0-513.el8", vm.cmd.call_args[0][0])
 
     def test_build_with_build_script_error(self):
         """Test VM build with build script error"""
         self._check_qemuimg()
-        vm = VM(self.config, 'x86_64')
-        with open(vm.build_post_script, 'w') as fh:
+        vm = VM(self.config, "x86_64")
+        with open(vm.build_post_script, "w") as fh:
             fh.write("#!/bin/bash\n/bin/false\n")
         with self.assertRaisesRegex(
             RiftError, "^Error while running build post script$"
@@ -857,11 +901,13 @@ class VMBuildTest(RiftProjectTestCase):
     def test_build_aarch64(self):
         """Test VM build aarch64"""
         self._check_qemuimg()
-        self.config.set('arch', ['aarch64'])
-        vm = VM(self.config, 'aarch64')
+        self.config.set("arch", ["aarch64"])
+        vm = VM(self.config, "aarch64")
         vm.arch_efi_bios = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
-            '..', 'vendor', 'QEMU_EFI.silent.fd'
+            "..",
+            "vendor",
+            "QEMU_EFI.silent.fd",
         )
         self.valid_url = VALID_IMAGE_URL[vm.arch]
         vm.build(self.valid_url, False, False, vm.image_local)

--- a/tests/annex/base.py
+++ b/tests/annex/base.py
@@ -27,11 +27,10 @@ from ..TestUtils import (
     read_file,
 )
 
-_TEST_ANNEX_PATH = '/tmp/rift-test-annex'
+_TEST_ANNEX_PATH = "/tmp/rift-test-annex"
 
 
 class AnnexTest(RiftTestCase):
-
     """
     Test class for the Rift Annex
     """
@@ -39,62 +38,70 @@ class AnnexTest(RiftTestCase):
     def setUp(self):
         # Create a minimal project configuration
         self.config = Config()
-        self.config.project_dir = '/tmp/rift-working-repo'
+        self.config.project_dir = "/tmp/rift-working-repo"
         # Create the working repo
-        self.working_repo = '/tmp/rift-working-repo'
+        self.working_repo = "/tmp/rift-working-repo"
         os.mkdir(self.working_repo)
-        os.mkdir(self.working_repo + '/packages')
+        os.mkdir(self.working_repo + "/packages")
 
         self.staff = Staff(config=self.config)
-        self.staff_file = make_temp_file(textwrap.dedent("""
+        self.staff_file = make_temp_file(
+            textwrap.dedent("""
         staff:
             'J. Doe':
                 email: 'j.doe@rift.org'
-        """))
+        """)
+        )
 
         self.staff.load(self.staff_file.name)
-        self.config_file = make_temp_file(textwrap.dedent("""
+        self.config_file = make_temp_file(
+            textwrap.dedent("""
         modules:
             'Tools':
                 manager: 'J. Doe'
-        """))
+        """)
+        )
         self.modules = Modules(config=self.config, staff=self.staff)
         self.modules.load(self.config_file.name)
 
         # Create a Annex for the tests
         os.mkdir(_TEST_ANNEX_PATH)
         self.config.set(
-            'set_annex',
+            "set_annex",
             {
-                'address': _TEST_ANNEX_PATH,
-                'type': 'directory',
+                "address": _TEST_ANNEX_PATH,
+                "type": "directory",
             },
         )
         self.annex = Annex(self.config)
 
-        self.source = make_temp_file(textwrap.dedent("""
+        self.source = make_temp_file(
+            textwrap.dedent("""
         This file is an annex test
-        """))
+        """)
+        )
 
         self.source_digest = hashfile(self.source.name)
         self.source_pointer = make_temp_file(self.source_digest)
 
         # Create a mock package in the working repo
-        self.package_infos = make_temp_file(textwrap.dedent("""
+        self.package_infos = make_temp_file(
+            textwrap.dedent("""
         package:
            maintainers:
            - J. Doe
            module: Tools
            reason: Missing package
            origin: Company
-        """))
-        self.package = PackageRPM('foo-pkg', self.config, self.staff, self.modules)
+        """)
+        )
+        self.package = PackageRPM("foo-pkg", self.config, self.staff, self.modules)
         self.package.load_info(infopath=self.package_infos.name)
         self.package.write()
         with open(self.package.buildfile, "w") as fh:
             fh.write(
                 gen_rpm_spec(
-                    name='foo-pkg',
+                    name="foo-pkg",
                     version="1.0",
                     release="1",
                     arch="x86_64",
@@ -103,16 +110,16 @@ class AnnexTest(RiftTestCase):
 
     def tearDown(self):
         # Remove the Annex and the working repo created for the tests
-        shutil.rmtree('/tmp/rift-test-annex')
+        shutil.rmtree("/tmp/rift-test-annex")
         shutil.rmtree(self.working_repo)
 
     def test_init(self):
-        """ Test local annex initialisation """
+        """Test local annex initialisation"""
 
         self.assertEqual(self.annex.set_annex.annex_path, _TEST_ANNEX_PATH)
 
     def test_get(self):
-        """ Test get method """
+        """Test get method"""
 
         self.annex.push(self.source.name)
         dest = make_temp_filename()
@@ -122,7 +129,7 @@ class AnnexTest(RiftTestCase):
         self.assertEqual(hashfile(dest), self.source_digest)
 
     def test_get_by_path(self):
-        """ Test get_by_path method """
+        """Test get_by_path method"""
 
         self.annex.push(self.source.name)
         dest = make_temp_filename()
@@ -132,13 +139,13 @@ class AnnexTest(RiftTestCase):
         self.assertEqual(hashfile(dest), self.source_digest)
 
     def test_delete(self):
-        """ Test delete method """
+        """Test delete method"""
 
         # We can not use tempfile in this test
         # because even if we delete the file
         # tempfile will try to delete it again
         # raising an exception
-        source_file = make_temp_file('Rift Annex Test', delete=False)
+        source_file = make_temp_file("Rift Annex Test", delete=False)
 
         # Push the file into the Annex and retrieve the digest (pointer)
         self.annex.push(source_file.name)
@@ -147,7 +154,7 @@ class AnnexTest(RiftTestCase):
 
         # Check if the file is not present in the Annex
         with self.assertRaises(FileNotFoundError):
-            self.annex.get_by_path(source_file.name, '/dev/null')
+            self.annex.get_by_path(source_file.name, "/dev/null")
 
     def test_list(self):
         """Test the list method"""
@@ -159,11 +166,13 @@ class AnnexTest(RiftTestCase):
         for filename, size, insertion_time, names in self.annex.list():
             self.assertEqual(get_digest_from_path(self.source.name), filename)
             self.assertEqual(source_size, size)
-            self.assertAlmostEqual(source_insertion_time, insertion_time, delta=1) # delta for potentials delay
+            self.assertAlmostEqual(
+                source_insertion_time, insertion_time, delta=1
+            )  # delta for potentials delay
         self.assertTrue(os.path.basename(self.source.name) in names)
 
     def test_push(self):
-        """ Test push method """
+        """Test push method"""
 
         # Push the file into the annex
         self.annex.push(self.source.name)
@@ -172,45 +181,48 @@ class AnnexTest(RiftTestCase):
         # Check if the file is correctly created
         # and pushed into the annex
         self.assertTrue(os.path.exists(digest_path))
-        self.assertTrue(os.path.exists(os.path.join(
-            self.annex.set_annex.annex_path,
-            get_info_from_digest(self.source_digest))
-        ))
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    self.annex.set_annex.annex_path,
+                    get_info_from_digest(self.source_digest),
+                )
+            )
+        )
 
         self.assertEqual(hashfile(digest_path), self.source_digest)
 
     def test_annex_backup(self):
-        """ Test the Annex backup method """
+        """Test the Annex backup method"""
 
         os.mkdir(self.package.sourcesdir)
-        pkg_src_file = self.package.sourcesdir + '/src.tar'
-        with open(pkg_src_file, 'wb') as source_file:
+        pkg_src_file = self.package.sourcesdir + "/src.tar"
+        with open(pkg_src_file, "wb") as source_file:
             source_file.write(os.urandom(4096 * 8))
 
         # Push this file into the annex
         self.annex.push(pkg_src_file)
 
         # Generate another file, not related to a package
-        orphaned_file = make_temp_file('Rift Annex Test (Backup')
+        orphaned_file = make_temp_file("Rift Annex Test (Backup")
         self.annex.push(orphaned_file.name)
 
         # Backup the annex
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             annex_backup = self.annex.backup(
                 ProjectPackages.list(self.config, self.staff, self.modules)
             )
 
         # Get the files present in the annex backup
-        with tarfile.open(annex_backup, 'r') as backup:
+        with tarfile.open(annex_backup, "r") as backup:
             annexed_files = [f.name for f in backup.getmembers()]
 
         # Check if the package-1 files are present in the archive
         self.assertTrue(get_digest_from_path(pkg_src_file) in annexed_files)
         self.assertTrue(
-            get_info_from_digest(get_digest_from_path(pkg_src_file))
-            in annexed_files
+            get_info_from_digest(get_digest_from_path(pkg_src_file)) in annexed_files
         )
 
         # Check if the orphaned file is not in the archive

--- a/tests/annex/server.py
+++ b/tests/annex/server.py
@@ -13,82 +13,82 @@ from ..TestUtils import RiftTestCase, make_temp_filename
 class ServerAnnexTest(RiftTestCase):
     """Tests for ServerAnnex HTTP annex with optional IDP token auth."""
 
-    _CONFIG = {'idp_app_token': 'app-token', 's3_credential_file': '/tmp/creds'}
-    _ANNEX_URL = 'https://annex.example.com/objects'
+    _CONFIG = {"idp_app_token": "app-token", "s3_credential_file": "/tmp/creds"}
+    _ANNEX_URL = "https://annex.example.com/objects"
 
-    def _mock_response(self, content=b'data'):
+    def _mock_response(self, content=b"data"):
         res = Mock()
         res.status_code = 200
         res.raw = Mock()
-        res.raw.read = Mock(side_effect=[content, b''])
+        res.raw.read = Mock(side_effect=[content, b""])
         res.iter_content = Mock(return_value=[content])
         res.__bool__ = Mock(return_value=True)
         return res
 
-    @patch('rift.annex.server.requests.get')
+    @patch("rift.annex.server.requests.get")
     def test_get_no_auth(self, mock_get):
         """get() sends no Authorization header when auth is not configured."""
         mock_get.return_value = self._mock_response()
         annex = ServerAnnex({}, self._ANNEX_URL)
         dest = make_temp_filename()
-        self.assertTrue(annex.get('ABCDEF', dest))
+        self.assertTrue(annex.get("ABCDEF", dest))
         mock_get.assert_called_once_with(
-            f'{self._ANNEX_URL}/ABCDEF',
+            f"{self._ANNEX_URL}/ABCDEF",
             stream=True,
             timeout=15,
             headers={},
         )
         os.remove(dest)
 
-    @patch('rift.annex.server.Auth')
-    @patch('rift.annex.server.requests.get')
+    @patch("rift.annex.server.Auth")
+    @patch("rift.annex.server.requests.get")
     def test_get_idp_token_bearer(self, mock_get, mock_auth_cls):
         """get() sends Bearer token when auth is idp_token."""
         mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
-            'test-idp-token'
+            "test-idp-token"
         )
         mock_get.return_value = self._mock_response()
-        annex = ServerAnnex(self._CONFIG, self._ANNEX_URL, auth='idp_token')
+        annex = ServerAnnex(self._CONFIG, self._ANNEX_URL, auth="idp_token")
         dest = make_temp_filename()
-        self.assertTrue(annex.get('ABCDEF', dest))
+        self.assertTrue(annex.get("ABCDEF", dest))
         mock_auth_cls.return_value.get_idp_token_noninteractive.assert_called_once()
         mock_get.assert_called_once_with(
-            f'{self._ANNEX_URL}/ABCDEF',
+            f"{self._ANNEX_URL}/ABCDEF",
             stream=True,
             timeout=15,
-            headers={'Authorization': 'Bearer test-idp-token'},
+            headers={"Authorization": "Bearer test-idp-token"},
         )
         os.remove(dest)
 
-    @patch('rift.annex.server.Auth')
-    @patch('rift.annex.server.requests.get')
+    @patch("rift.annex.server.Auth")
+    @patch("rift.annex.server.requests.get")
     def test_backup_idp_token_bearer(self, mock_get, mock_auth_cls):
         """backup() sends Bearer token on annex fetches when auth is idp_token."""
         mock_auth_cls.return_value.get_idp_token_noninteractive.return_value = (
-            'test-idp-token'
+            "test-idp-token"
         )
         mock_get.return_value = self._mock_response()
 
-        digest = 'ABCDEF'
+        digest = "ABCDEF"
         pointer_file = make_temp_filename()
-        with open(pointer_file, 'w', encoding='utf-8') as fh:
+        with open(pointer_file, "w", encoding="utf-8") as fh:
             fh.write(digest)
 
-        annex = ServerAnnex(self._CONFIG, self._ANNEX_URL, auth='idp_token')
+        annex = ServerAnnex(self._CONFIG, self._ANNEX_URL, auth="idp_token")
         output = make_temp_filename()
         annex.backup([pointer_file], output)
 
-        expected_headers = {'Authorization': 'Bearer test-idp-token'}
+        expected_headers = {"Authorization": "Bearer test-idp-token"}
         mock_get.assert_has_calls(
             [
                 call(
-                    f'{self._ANNEX_URL}/{digest}',
+                    f"{self._ANNEX_URL}/{digest}",
                     stream=True,
                     timeout=15,
                     headers=expected_headers,
                 ),
                 call(
-                    f'{self._ANNEX_URL}/{digest}.info',
+                    f"{self._ANNEX_URL}/{digest}.info",
                     stream=True,
                     timeout=15,
                     headers=expected_headers,

--- a/tests/annex/utils.py
+++ b/tests/annex/utils.py
@@ -26,34 +26,34 @@ class AnnexUtilsTest(RiftTestCase):
         # Generate a random fully binary file*
         # make_temp_file from test_utils cant be used
         # here since it does not support binary content
-        with open('/tmp/binary_file', 'wb') as bin_file:
+        with open("/tmp/binary_file", "wb") as bin_file:
             bin_file.write(os.urandom(4096 * 8))
 
-        self.assertTrue(is_binary('/tmp/binary_file'))
-        os.remove('/tmp/binary_file')
+        self.assertTrue(is_binary("/tmp/binary_file"))
+        os.remove("/tmp/binary_file")
 
     def test_is_binary_with_non_binary(self):
         """
         Test if a fully non binary file is correctly detected as an non binary file
         """
 
-        non_binary_file = make_temp_file('ACTG' * 40)
+        non_binary_file = make_temp_file("ACTG" * 40)
         self.assertFalse(is_binary(non_binary_file.name))
 
     def test_is_binary_with_empty_file(self):
-         """
-         Test if an empty is correctly detected by is_binary
-         """
+        """
+        Test if an empty is correctly detected by is_binary
+        """
 
-         empty_file = make_temp_file('')
-         self.assertFalse(is_binary(empty_file.name))
+        empty_file = make_temp_file("")
+        self.assertFalse(is_binary(empty_file.name))
 
     def test_get_digest_from_path(self):
         """
         Test if a file is able to be readed by this method
         """
 
-        file_content = 'Red Hat Enterprise Linux release 8.8 (Ootpa)'
+        file_content = "Red Hat Enterprise Linux release 8.8 (Ootpa)"
         file_path = make_temp_file(file_content)
         self.assertEqual(file_content, get_digest_from_path(file_path.name))
 
@@ -62,26 +62,26 @@ class AnnexUtilsTest(RiftTestCase):
         Test the concetenation between the digest and the metadata suffix
         """
 
-        digest = '7CF2DB5EC261A0FA27A502D3196A6F60'
-        self.assertEqual(digest + '.info', get_info_from_digest(digest))
+        digest = "7CF2DB5EC261A0FA27A502D3196A6F60"
+        self.assertEqual(digest + ".info", get_info_from_digest(digest))
 
     def test_hashfile(self):
-        """ Test if the hashfile method hash the filepath correctly """
+        """Test if the hashfile method hash the filepath correctly"""
 
-        path = make_temp_file('OCEAN')
+        path = make_temp_file("OCEAN")
         self.assertNotEqual(path.name, hashfile(path.name))
 
     def test_is_pointer_valid_identifier(self):
-        """ Test if is_pointer correctly detect a valid identifier """
+        """Test if is_pointer correctly detect a valid identifier"""
 
-        correct_identifier = '7CF2DB5EC261A0FA27A502D3196A6F60'
+        correct_identifier = "7CF2DB5EC261A0FA27A502D3196A6F60"
         temp_file = make_temp_file(correct_identifier)
         self.assertTrue(is_pointer(temp_file.name))
 
     def test_is_pointer_valid_identifier_with_line_feed(self):
-        """ Test if is_pointer correctly detect a valid identifier with a line feed """
+        """Test if is_pointer correctly detect a valid identifier with a line feed"""
 
-        correct_identifier = '7CF2DB5EC261A0FA27A502D3196A6F60\n'
+        correct_identifier = "7CF2DB5EC261A0FA27A502D3196A6F60\n"
         temp_file = make_temp_file(correct_identifier)
         self.assertTrue(is_pointer(temp_file.name))
 
@@ -90,7 +90,7 @@ class AnnexUtilsTest(RiftTestCase):
         Test if is_pointer correctly detect a valid identifier with a carriage return.
         """
 
-        correct_identifier = '7CF2DB5EC261A0FA27A502D3196A6F60\r\n'
+        correct_identifier = "7CF2DB5EC261A0FA27A502D3196A6F60\r\n"
         temp_file = make_temp_file(correct_identifier)
         self.assertTrue(is_pointer(temp_file.name))
 
@@ -99,13 +99,13 @@ class AnnexUtilsTest(RiftTestCase):
         Test if is_pointer correctly detect a valid identifier with a whitespace.
         """
 
-        correct_identifier = '7CF2DB5EC261A0FA27A502D3196A6F60 '
+        correct_identifier = "7CF2DB5EC261A0FA27A502D3196A6F60 "
         temp_file = make_temp_file(correct_identifier)
         self.assertTrue(is_pointer(temp_file.name))
 
     def test_is_pointer_invalid_identifier(self):
-        """ Test if is_pointer correctly detect a invalid identifier """
+        """Test if is_pointer correctly detect a invalid identifier"""
 
-        incorrect_identifier = 'rift annex test'
+        incorrect_identifier = "rift annex test"
         temp_file = make_temp_file(incorrect_identifier)
         self.assertFalse(is_pointer(temp_file.name))

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -55,8 +55,11 @@ class AuthTest(unittest.TestCase):
         auth = Auth(self._minimal_config)
         with self.assertRaisesRegex(
             RiftError,
-            rf"Missing idp_token in authentication state file {re.escape(self._cred_path)}\. "
-            r"Run 'rift auth' first\.",
+            (
+                r"Missing idp_token in authentication state file "
+                rf"{re.escape(self._cred_path)}\. "
+                r"Run 'rift auth' first\."
+            ),
         ):
             auth.get_idp_token_noninteractive()
 
@@ -82,7 +85,10 @@ class AuthTest(unittest.TestCase):
         auth = Auth(self._minimal_config)
         with self.assertRaisesRegex(
             RiftError,
-            rf"Missing idp_token in authentication state file {re.escape(self._cred_path)}\. "
-            r"Run 'rift auth' first\.",
+            (
+                r"Missing idp_token in authentication state file "
+                rf"{re.escape(self._cred_path)}\. "
+                r"Run 'rift auth' first\."
+            ),
         ):
             auth.get_idp_token_noninteractive()

--- a/tests/container.py
+++ b/tests/container.py
@@ -1,25 +1,25 @@
 #
 # Copyright (C) 2026 CEA
 #
-from unittest.mock import patch, Mock
-import subprocess
-import shutil
 import os
+import shutil
+import subprocess
+from unittest.mock import Mock, patch
 
-from .TestUtils import (
-    RiftProjectTestCase,
-    command_available,
-    make_temp_file,
-    make_temp_tar,
-    gen_containerfile,
-    EXPECTED_HADOLINT_EXEC
-)
-
-from rift.container import ContainerRuntime, ContainerFile, ContainerArchive
+from rift import RiftError
+from rift.container import ContainerArchive, ContainerFile, ContainerRuntime
+from rift.Gerrit import Review
 from rift.package.oci import PackageOCI
 from rift.run import RunResult
-from rift.Gerrit import Review
-from rift import RiftError
+
+from .TestUtils import (
+    EXPECTED_HADOLINT_EXEC,
+    RiftProjectTestCase,
+    command_available,
+    gen_containerfile,
+    make_temp_file,
+    make_temp_tar,
+)
 
 
 class ContainerRuntimeTest(RiftProjectTestCase):
@@ -28,85 +28,116 @@ class ContainerRuntimeTest(RiftProjectTestCase):
     def test_tag(self):
         """Test ContainerRuntime tag generation."""
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         package.load()
-        actionable_package = package.for_arch('x86_64')
+        actionable_package = package.for_arch("x86_64")
         container = ContainerRuntime(self.config)
-        self.assertEqual(container.tag(actionable_package), 'pkg:1.0-1-x86_64')
+        self.assertEqual(container.tag(actionable_package), "pkg:1.0-1-x86_64")
 
-    @patch('rift.container.run_command')
+    @patch("rift.container.run_command")
     def test_build(self, mock_run_command):
         """Test ContainerRuntime build command."""
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         package.load()
-        actionable_package = package.for_arch('x86_64')
+        actionable_package = package.for_arch("x86_64")
         container = ContainerRuntime(self.config)
-        mock_run_command.return_value = RunResult(0, 'ok', None)
-        container.build(actionable_package, 'pkg_1.0')
+        mock_run_command.return_value = RunResult(0, "ok", None)
+        container.build(actionable_package, "pkg_1.0")
         mock_run_command.assert_called_once_with(
-            ['podman', '--root', container.rootdir, 'build',
-             '--arch', 'amd64',
-             '--annotation', 'org.opencontainers.image.version=1.0-1',
-             '--annotation', 'org.opencontainers.image.title=pkg',
-             '--annotation', 'org.opencontainers.image.vendir=rift',
-             '--tag', 'pkg:1.0-1-x86_64', 'pkg_1.0'])
+            [
+                "podman",
+                "--root",
+                container.rootdir,
+                "build",
+                "--arch",
+                "amd64",
+                "--annotation",
+                "org.opencontainers.image.version=1.0-1",
+                "--annotation",
+                "org.opencontainers.image.title=pkg",
+                "--annotation",
+                "org.opencontainers.image.vendir=rift",
+                "--tag",
+                "pkg:1.0-1-x86_64",
+                "pkg_1.0",
+            ]
+        )
 
-    @patch('rift.container.run_command')
+    @patch("rift.container.run_command")
     def test_build_failure(self, mock_run_command):
         """Test ContainerRuntime build failure handling."""
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         package.load()
-        actionable_package = package.for_arch('x86_64')
+        actionable_package = package.for_arch("x86_64")
         container = ContainerRuntime(self.config)
-        mock_run_command.return_value = RunResult(1, None, 'failure')
+        mock_run_command.return_value = RunResult(1, None, "failure")
         with self.assertRaisesRegex(
-            RiftError, "^Container image build error: exit code 1$"):
-            container.build(actionable_package, 'pkg_1.0')
+            RiftError, "^Container image build error: exit code 1$"
+        ):
+            container.build(actionable_package, "pkg_1.0")
 
-    @patch('rift.container.run_command')
+    @patch("rift.container.run_command")
     def test_run_test(self, mock_run_command):
         """Test ContainerRuntime run_test command."""
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         package.load()
-        actionable_package = package.for_arch('x86_64')
+        actionable_package = package.for_arch("x86_64")
         test = [test for test in package.tests()].pop()
         container = ContainerRuntime(self.config)
-        test_result = RunResult(0, 'ok', None)
+        test_result = RunResult(0, "ok", None)
         mock_run_command.return_value = test_result
         self.assertEqual(container.run_test(actionable_package, test), test_result)
         mock_run_command.assert_called_once_with(
-            ['podman', '--root', container.rootdir, 'run', '--rm',
-             '-i', '--mount',
-             f'type=bind,src={package.dir}/tests/0_test.sh,dst=/run/0_test.sh,ro=true',
-             '--arch', 'amd64', 'localhost/pkg:1.0-1-x86_64', '/run/0_test.sh'],
-             capture_output=True)
+            [
+                "podman",
+                "--root",
+                container.rootdir,
+                "run",
+                "--rm",
+                "-i",
+                "--mount",
+                f"type=bind,src={package.dir}/tests/0_test.sh,dst=/run/0_test.sh,ro=true",
+                "--arch",
+                "amd64",
+                "localhost/pkg:1.0-1-x86_64",
+                "/run/0_test.sh",
+            ],
+            capture_output=True,
+        )
 
-    @patch('rift.container.run_command')
+    @patch("rift.container.run_command")
     def test_archive(self, mock_run_command):
         """Test ContainerRuntime archive command."""
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         package.load()
-        actionable_package = package.for_arch('x86_64')
+        actionable_package = package.for_arch("x86_64")
         container = ContainerRuntime(self.config)
-        archive_result = RunResult(0, 'ok', None)
+        archive_result = RunResult(0, "ok", None)
         mock_run_command.return_value = archive_result
         self.assertEqual(
             container.archive(
                 actionable_package,
-                ContainerArchive(self.config, '/path/to/container.tar')
+                ContainerArchive(self.config, "/path/to/container.tar"),
             ),
-            archive_result)
+            archive_result,
+        )
         mock_run_command.assert_called_once_with(
-            ['podman', '--root', container.rootdir, 'push', 'pkg:1.0-1-x86_64',
-             'oci-archive:/path/to/container.tar:pkg:1.0-1-x86_64'])
+            [
+                "podman",
+                "--root",
+                container.rootdir,
+                "push",
+                "pkg:1.0-1-x86_64",
+                "oci-archive:/path/to/container.tar:pkg:1.0-1-x86_64",
+            ]
+        )
 
 
 class ContainerArchiveTest(RiftProjectTestCase):
-
     def setUp(self):
         super().setUp()
         # Initialize ContainerArchive with temporary tarball
@@ -123,7 +154,7 @@ class ContainerArchiveTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError,
             r"^Unable to retrieve GPG configuration, unable to sign OCI "
-            r"archive .*\.tar$"
+            r"archive .*\.tar$",
         ):
             self.container_archive.sign()
         self.assertFalse(os.path.exists(self.container_archive.signature))
@@ -132,9 +163,9 @@ class ContainerArchiveTest(RiftProjectTestCase):
         """ContainerArchive.sign() fail with nonexistent keyring."""
         self.config.options.update(
             {
-                'gpg': {
-                  'keyring': '/path/to/nonexistent/keyring',
-                  'key': 'rift',
+                "gpg": {
+                    "keyring": "/path/to/nonexistent/keyring",
+                    "key": "rift",
                 }
             }
         )
@@ -142,7 +173,7 @@ class ContainerArchiveTest(RiftProjectTestCase):
         with self.assertRaisesRegex(
             RiftError,
             r"^GPG keyring path /path/to/nonexistent/keyring does not exist, "
-            r"unable to sign OCI archive .*\.tar$"
+            r"unable to sign OCI archive .*\.tar$",
         ):
             self.container_archive.sign()
         self.assertFalse(os.path.exists(self.container_archive.signature))
@@ -153,29 +184,29 @@ class ContainerArchiveTest(RiftProjectTestCase):
         generated keyring, copy unsigned rpm_pkg, sign it, verify signature and
         cleanup everything.
         """
-        gpg_home = os.path.join(self.projdir, '.gnupg')
+        gpg_home = os.path.join(self.projdir, ".gnupg")
 
         # Launch the agent with --allow-preset-passphrase to accept passphrase
         # provided non-interactively by gpg-preset-passphrase.
         cmd = [
-          'gpg-agent',
-          '--homedir',
-          gpg_home,
-          '--allow-preset-passphrase',
-          '--daemon',
+            "gpg-agent",
+            "--homedir",
+            gpg_home,
+            "--allow-preset-passphrase",
+            "--daemon",
         ]
         subprocess.run(cmd)
 
         # Generate keyring
-        gpg_key = 'rift'
+        gpg_key = "rift"
         cmd = [
-            'gpg',
-            '--homedir',
+            "gpg",
+            "--homedir",
             gpg_home,
-            '--batch',
-            '--passphrase',
-            gpg_passphrase or '',
-            '--quick-generate-key',
+            "--batch",
+            "--passphrase",
+            gpg_passphrase or "",
+            "--quick-generate-key",
             gpg_key,
         ]
         subprocess.run(cmd)
@@ -186,39 +217,37 @@ class ContainerArchiveTest(RiftProjectTestCase):
             # First find keygrip
             keygrip = None
             cmd = [
-                'gpg',
-                '--homedir',
+                "gpg",
+                "--homedir",
                 gpg_home,
-                '--fingerprint',
-                '--with-keygrip',
-                '--with-colons',
-                gpg_key
+                "--fingerprint",
+                "--with-keygrip",
+                "--with-colons",
+                gpg_key,
             ]
             proc = subprocess.run(cmd, stdout=subprocess.PIPE)
-            for line in proc.stdout.decode().split('\n'):
-                if line.startswith('grp'):
-                    keygrip = line.split(':')[9]
+            for line in proc.stdout.decode().split("\n"):
+                if line.startswith("grp"):
+                    keygrip = line.split(":")[9]
                     break
             # Run gpg-preset-passphrase to add passphrase in agent
-            cmd = ['/usr/libexec/gpg-preset-passphrase', '--preset', keygrip]
+            cmd = ["/usr/libexec/gpg-preset-passphrase", "--preset", keygrip]
             subprocess.run(
-                cmd,
-                env={'GNUPGHOME': gpg_home},
-                input=preset_passphrase.encode()
+                cmd, env={"GNUPGHOME": gpg_home}, input=preset_passphrase.encode()
             )
 
         # Update project configuration with generated key
         self.config.options.update(
             {
-                'gpg': {
-                    'keyring': gpg_home,
-                    'key': gpg_key,
+                "gpg": {
+                    "keyring": gpg_home,
+                    "key": gpg_key,
                 }
             }
         )
 
         if conf_passphrase is not None:
-            self.config.options['gpg']['passphrase'] = conf_passphrase
+            self.config.options["gpg"]["passphrase"] = conf_passphrase
         self.config._check()
 
         try:
@@ -226,7 +255,7 @@ class ContainerArchiveTest(RiftProjectTestCase):
 
         finally:
             # Kill GPG agent launched for the test
-            cmd = ['gpgconf', '--homedir', gpg_home, '--kill', 'gpg-agent']
+            cmd = ["gpgconf", "--homedir", gpg_home, "--kill", "gpg-agent"]
             subprocess.run(cmd)
 
             # Remove temporary GPG home with generated key
@@ -234,18 +263,15 @@ class ContainerArchiveTest(RiftProjectTestCase):
 
     def test_sign(self):
         """Container archive signature."""
-        self.sign_copy('TOPSECRET', 'TOPSECRET')
+        self.sign_copy("TOPSECRET", "TOPSECRET")
         self.assertTrue(os.path.exists(self.container_archive.signature))
 
     def test_sign_wrong_passphrase(self):
         """
         Container archive signature raises RiftError with wrong passphrase.
         """
-        with self.assertRaisesRegex(
-            RiftError,
-            "^Error with signing OCI archive .*"
-        ):
-            self.sign_copy('TOPSECRET', 'WRONG_PASSPHRASE')
+        with self.assertRaisesRegex(RiftError, "^Error with signing OCI archive .*"):
+            self.sign_copy("TOPSECRET", "WRONG_PASSPHRASE")
         self.assertFalse(os.path.exists(self.container_archive.signature))
 
     def test_sign_passphrase_agent_not_interactive(self):
@@ -256,7 +282,7 @@ class ContainerArchiveTest(RiftProjectTestCase):
         # in Rift configuration but loaded in GPG agent, Rift must sign the
         # package without making the agent launch pinentry to ask for the
         # passphrase interactively.
-        self.sign_copy('TOPSECRET', preset_passphrase='TOPSECRET')
+        self.sign_copy("TOPSECRET", preset_passphrase="TOPSECRET")
         self.assertTrue(os.path.exists(self.container_archive.signature))
 
     def test_sign_empty_passphrase_not_interactive(self):
@@ -278,7 +304,7 @@ class ContainerFileTest(RiftProjectTestCase):
         """ContainerFile check"""
         if not command_available(EXPECTED_HADOLINT_EXEC):
             self.skipTest("hadolint executable not found")
-        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        self.config.update({"containers": {"linter": EXPECTED_HADOLINT_EXEC}})
         tmp_container_file = make_temp_file(gen_containerfile())
         container_file = ContainerFile(self.config, tmp_container_file.name)
         container_file.check()
@@ -287,7 +313,7 @@ class ContainerFileTest(RiftProjectTestCase):
         """ContainerFile check with error"""
         if not command_available(EXPECTED_HADOLINT_EXEC):
             self.skipTest("hadolint executable not found")
-        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        self.config.update({"containers": {"linter": EXPECTED_HADOLINT_EXEC}})
         tmp_container_file = make_temp_file(gen_containerfile(lines=["WORKDIR fail"]))
         container_file = ContainerFile(self.config, tmp_container_file.name)
         with self.assertRaisesRegex(
@@ -297,24 +323,24 @@ class ContainerFileTest(RiftProjectTestCase):
 
     def test_check_linter_not_found(self):
         """ContainerFile check error log linter not found"""
-        self.config.update({'containers': { 'linter': 'hadolint-not-found' }})
+        self.config.update({"containers": {"linter": "hadolint-not-found"}})
         tmp_container_file = make_temp_file(gen_containerfile())
         container_file = ContainerFile(self.config, tmp_container_file.name)
-        with self.assertLogs(level='ERROR') as log:
+        with self.assertLogs(level="ERROR") as log:
             container_file.check()
         self.assertIn(
             "ERROR:root:Unable to find Containerfile linter executable "
             "'hadolint-not-found'",
-            log.output
+            log.output,
         )
 
     def test_analyze(self):
         """ContainerFile analyze"""
         if not command_available(EXPECTED_HADOLINT_EXEC):
             self.skipTest("hadolint executable not found")
-        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        self.config.update({"containers": {"linter": EXPECTED_HADOLINT_EXEC}})
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         tmp_container_file = make_temp_file(gen_containerfile())
         container_file = ContainerFile(self.config, tmp_container_file.name)
         review = Mock(spec=Review)
@@ -326,28 +352,29 @@ class ContainerFileTest(RiftProjectTestCase):
         """ContainerFile analyze with error"""
         if not command_available(EXPECTED_HADOLINT_EXEC):
             self.skipTest("hadolint executable not found")
-        self.config.update({'containers': { 'linter': EXPECTED_HADOLINT_EXEC }})
+        self.config.update({"containers": {"linter": EXPECTED_HADOLINT_EXEC}})
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         tmp_container_file = make_temp_file(gen_containerfile(lines=["WORKDIR fail"]))
         container_file = ContainerFile(self.config, tmp_container_file.name)
         review = Mock(spec=Review)
         container_file.analyze(review, package.dir)
         review.add_comment.assert_called_with(
-            container_file.path, '3', 'DL3000', 'Use absolute WORKDIR')
+            container_file.path, "3", "DL3000", "Use absolute WORKDIR"
+        )
         review.invalidate.assert_called_once()
 
     def test_analyze_linter_not_found(self):
         """ContainerFile analyze error when linter not found"""
-        self.config.update({'containers': { 'linter': 'hadolint-not-found' }})
+        self.config.update({"containers": {"linter": "hadolint-not-found"}})
         self.make_pkg()
-        package = PackageOCI('pkg', self.config, self.staff, self.modules)
+        package = PackageOCI("pkg", self.config, self.staff, self.modules)
         tmp_container_file = make_temp_file(gen_containerfile())
         container_file = ContainerFile(self.config, tmp_container_file.name)
         review = Mock(spec=Review)
         with self.assertRaisesRegex(
             RiftError,
-            "Unable to find Containerfile linter executable 'hadolint-not-found'"
+            "Unable to find Containerfile linter executable 'hadolint-not-found'",
         ):
             container_file.analyze(review, package.dir)
         review.invalidate.assert_not_called()

--- a/tests/graph.py
+++ b/tests/graph.py
@@ -351,7 +351,7 @@ class GraphTest(RiftProjectTestCase):
         self.assertIsInstance(build_requirements[0].package, PackageRPM)
 
     def test_multiple_packages_with_provides(self):
-        """Test graph with multiple packages and dependencies on provides in RPM spec files"""
+        """Test graph with packages depending on RPM Provides."""
         # Define 2 packages without depends in info.yaml but with build requires
         # on other subpackages provides.
         self.make_pkg(

--- a/tests/graph.py
+++ b/tests/graph.py
@@ -1,14 +1,14 @@
 #
 # Copyright (C) 2025 CEA
 #
+import io
 import os
 import shutil
-import io
 from unittest.mock import patch
 
 from rift.graph import PackagesDependencyGraph
-from rift.package.rpm import PackageRPM
 from rift.package.oci import PackageOCI
+from rift.package.rpm import PackageRPM
 
 from .TestUtils import RiftProjectTestCase, SubPackage, read_file
 
@@ -17,19 +17,18 @@ class GraphTest(RiftProjectTestCase):
     """
     Tests class for PackageDependencyGraph
     """
+
     def test_one_package(self):
-        """ Test graph with one package """
-        pkg_name = 'fake'
+        """Test graph with one package"""
+        pkg_name = "fake"
         self.make_pkg(name=pkg_name)
         package_rpm = PackageRPM(pkg_name, self.config, self.staff, self.modules)
         package_oci = PackageOCI(pkg_name, self.config, self.staff, self.modules)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
         # 1 package in 2 formats → 2 nodes expected in the graph
         self.assertEqual(len(graph.nodes), 2)
@@ -49,16 +48,14 @@ class GraphTest(RiftProjectTestCase):
         self.assertEqual(build_requirements[0].reasons, ["User request"])
 
     def test_one_package_one_format(self):
-        """ Test graph with one package in one format"""
-        pkg_name = 'fake'
-        self.make_pkg(name=pkg_name, formats=['rpm'])
+        """Test graph with one package in one format"""
+        pkg_name = "fake"
+        self.make_pkg(name=pkg_name, formats=["rpm"])
         package_rpm = PackageRPM(pkg_name, self.config, self.staff, self.modules)
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
         # 1 package in 1 format → 1 node expected in the graph
         self.assertEqual(len(graph.nodes), 1)
@@ -71,15 +68,12 @@ class GraphTest(RiftProjectTestCase):
         self.assertEqual(build_requirements[0].reasons, ["User request"])
 
     def test_one_package_build_format_filter(self):
-        """ Test graph with one package and format filter """
-        pkg_name = 'fake'
+        """Test graph with one package and format filter"""
+        pkg_name = "fake"
         self.make_pkg(name=pkg_name)
         package_oci = PackageOCI(pkg_name, self.config, self.staff, self.modules)
         graph = PackagesDependencyGraph.from_project(
-            self.config,
-            self.staff,
-            self.modules,
-            formats=['oci']
+            self.config, self.staff, self.modules, formats=["oci"]
         )
         # 1 package in 2 formats but format filder → 1 node expected in the graph
         self.assertEqual(len(graph.nodes), 1)
@@ -92,8 +86,8 @@ class GraphTest(RiftProjectTestCase):
         self.assertEqual(build_requirements[0].reasons, ["User request"])
 
     def test_packages_unable_load(self):
-        """ Test graph build with package unable to load """
-        pkgs_names = ['success', 'failed']
+        """Test graph build with package unable to load"""
+        pkgs_names = ["success", "failed"]
         packages = {}
         for pkg_name in pkgs_names:
             self.make_pkg(name=pkg_name)
@@ -101,16 +95,14 @@ class GraphTest(RiftProjectTestCase):
                 pkg_name, self.config, self.staff, self.modules
             )
         # Remove info.yaml in packages failed to generate error
-        os.unlink(packages['failed'].metafile)
+        os.unlink(packages["failed"].metafile)
         # Build packages graph
-        with self.assertLogs(level='WARNING') as cm:
+        with self.assertLogs(level="WARNING") as cm:
             # mock Mock.read_spec to return spec file content directly read on host
-            with patch('rift.package.rpm.Mock') as mock_mock:
+            with patch("rift.package.rpm.Mock") as mock_mock:
                 mock_mock.return_value.read_spec = read_file
                 graph = PackagesDependencyGraph.from_project(
-                    self.config,
-                    self.staff,
-                    self.modules
+                    self.config, self.staff, self.modules
                 )
         # Check warning message have been emitted. Error should appear twice,
         # once for each package supported format.
@@ -123,86 +115,70 @@ class GraphTest(RiftProjectTestCase):
                 "WARNING:root:Skipping package 'failed' unable to load: [Errno 2]"
                 " No such file or directory: "
                 f"'{self.projdir}/packages/failed/info.yaml'",
-            ]
+            ],
         )
         # Check success package is successfully loaded anyway.
         # (2 formats → 2 nodes expected in the graph).
         self.assertEqual(len(graph.nodes), 2)
         for node in graph.nodes:
-            self.assertEqual(node.package.name, 'success')
+            self.assertEqual(node.package.name, "success")
 
     def test_dump(self):
-        """ Test graph dump """
-        pkg_name = 'fake'
+        """Test graph dump"""
+        pkg_name = "fake"
         self.make_pkg(name=pkg_name)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
-        with self.assertLogs(level='INFO') as cm:
+        with self.assertLogs(level="INFO") as cm:
             graph.dump()
         self.assertEqual(
             cm.output,
             [
-                'INFO:root:→ rpm:fake',
+                "INFO:root:→ rpm:fake",
                 "INFO:root:  provides: ['fake', 'fake-provide']",
                 "INFO:root:  requires: ['br-package']",
-                'INFO:root:  is required by: []',
-                'INFO:root:→ oci:fake',
+                "INFO:root:  is required by: []",
+                "INFO:root:→ oci:fake",
                 "INFO:root:  provides: ['fake']",
                 "INFO:root:  requires: []",
-                'INFO:root:  is required by: []'
-            ]
+                "INFO:root:  is required by: []",
+            ],
         )
 
     def test_empty_solve(self):
-        """ Test solve with package not in graph """
-        pkg_name = 'one'
+        """Test solve with package not in graph"""
+        pkg_name = "one"
         self.make_pkg(name=pkg_name)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
-        package = PackageRPM('another', self.config, self.staff, self.modules)
+        package = PackageRPM("another", self.config, self.staff, self.modules)
         build_requirements = graph.solve(package)
         self.assertEqual(len(build_requirements), 0)
 
     def test_multiple_packages(self):
-        """ Test graph with multiple packages and dependencies in info.yaml """
+        """Test graph with multiple packages and dependencies in info.yaml"""
         # Define 3 packages with depends in info.yaml, in both string and list
         # formats.
+        self.make_pkg(name="libone", metadata={"depends": "libtwo"})
         self.make_pkg(
-            name='libone',
-            metadata={
-                'depends': 'libtwo'
-            }
+            name="libtwo",
         )
-        self.make_pkg(
-            name='libtwo',
-        )
-        self.make_pkg(
-            name='my-software',
-            metadata={
-                'depends': ['libone']
-            }
-        )
+        self.make_pkg(name="my-software", metadata={"depends": ["libone"]})
 
         # Load graph
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
         # 3 packages x 2 formats → 6 nodes expected in the graph
         self.assertEqual(len(graph.nodes), 6)
@@ -210,25 +186,25 @@ class GraphTest(RiftProjectTestCase):
         # Rebuild of my-software does not trigger rebuild of other packages.
         for package_class in (PackageRPM, PackageOCI):
             build_requirements = graph.solve(
-                package_class('my-software', self.config, self.staff, self.modules)
+                package_class("my-software", self.config, self.staff, self.modules)
             )
             self.assertEqual(len(build_requirements), 1)
             self.assertIsInstance(build_requirements[0].package, package_class)
-            self.assertEqual(build_requirements[0].package.name, 'my-software')
+            self.assertEqual(build_requirements[0].package.name, "my-software")
             self.assertEqual(build_requirements[0].reasons, ["User request"])
 
         # Rebuild of libone triggers rebuild of my-software because it depends
         # on libone.
         for package_class in (PackageRPM, PackageOCI):
             build_requirements = graph.solve(
-                package_class('libone', self.config, self.staff, self.modules)
+                package_class("libone", self.config, self.staff, self.modules)
             )
             self.assertEqual(len(build_requirements), 2)
             for build_requirement in build_requirements:
                 self.assertIsInstance(build_requirement.package, package_class)
-            self.assertEqual(build_requirements[0].package.name, 'libone')
+            self.assertEqual(build_requirements[0].package.name, "libone")
             self.assertEqual(build_requirements[0].reasons, ["User request"])
-            self.assertEqual(build_requirements[1].package.name, 'my-software')
+            self.assertEqual(build_requirements[1].package.name, "my-software")
             self.assertEqual(
                 build_requirements[1].reasons,
                 [f"depends on {build_requirements[1].package.format}:libone"],
@@ -239,56 +215,48 @@ class GraphTest(RiftProjectTestCase):
         # - my-software because it depends on libone
         for package_class in (PackageRPM, PackageOCI):
             build_requirements = graph.solve(
-                package_class('libtwo', self.config, self.staff, self.modules)
+                package_class("libtwo", self.config, self.staff, self.modules)
             )
             self.assertEqual(len(build_requirements), 3)
             for build_requirement in build_requirements:
                 self.assertIsInstance(build_requirement.package, package_class)
-            self.assertEqual(build_requirements[0].package.name, 'libtwo')
+            self.assertEqual(build_requirements[0].package.name, "libtwo")
             self.assertEqual(build_requirements[0].reasons, ["User request"])
-            self.assertEqual(build_requirements[1].package.name, 'libone')
+            self.assertEqual(build_requirements[1].package.name, "libone")
             self.assertEqual(
                 build_requirements[1].reasons,
                 [f"depends on {build_requirement.package.format}:libtwo"],
             )
-            self.assertEqual(build_requirements[2].package.name, 'my-software')
+            self.assertEqual(build_requirements[2].package.name, "my-software")
             self.assertEqual(
                 build_requirements[2].reasons,
                 [f"depends on {build_requirement.package.format}:libone"],
             )
 
     def test_multiple_packages_spec_fallback(self):
-        """ Test graph with multiple packages and dependencies in RPM spec files """
+        """Test graph with multiple packages and dependencies in RPM spec files"""
         # Define 3 packages without depends in info.yaml but with build requires
         # on others subpackages.
         self.make_pkg(
-            name='libone',
-            build_requires=['libtwo-devel >= 3.5'],
-            subpackages=[
-                SubPackage('libone-bin'),
-                SubPackage('libone-devel')
-            ]
+            name="libone",
+            build_requires=["libtwo-devel >= 3.5"],
+            subpackages=[SubPackage("libone-bin"), SubPackage("libone-devel")],
         )
         self.make_pkg(
-            name='libtwo',
-            subpackages=[
-                SubPackage('libtwo-bin'),
-                SubPackage('libtwo-devel')
-            ]
+            name="libtwo",
+            subpackages=[SubPackage("libtwo-bin"), SubPackage("libtwo-devel")],
         )
         self.make_pkg(
-            name='my-software',
-            build_requires=['libone-devel = 3, libtwo-devel'],
+            name="my-software",
+            build_requires=["libone-devel = 3, libtwo-devel"],
         )
 
         def load_graph():
             # mock Mock.read_spec to return spec file content directly read on host
-            with patch('rift.package.rpm.Mock') as mock_mock:
+            with patch("rift.package.rpm.Mock") as mock_mock:
                 mock_mock.return_value.read_spec = read_file
                 graph = PackagesDependencyGraph.from_project(
-                    self.config,
-                    self.staff,
-                    self.modules
+                    self.config, self.staff, self.modules
                 )
             self.assertEqual(len(graph.nodes), 6)
             return graph
@@ -298,39 +266,37 @@ class GraphTest(RiftProjectTestCase):
         # Rebuild of my-software does not trigger rebuild of other packages.
         for package_class in (PackageRPM, PackageOCI):
             build_requirements = graph.solve(
-                package_class('my-software', self.config, self.staff, self.modules)
+                package_class("my-software", self.config, self.staff, self.modules)
             )
             self.assertEqual(len(build_requirements), 1)
             self.assertIsInstance(build_requirements[0].package, package_class)
-            self.assertEqual(build_requirements[0].package.name, 'my-software')
+            self.assertEqual(build_requirements[0].package.name, "my-software")
             self.assertEqual(build_requirements[0].reasons, ["User request"])
 
         # Rebuild of RPM libone triggers rebuild of my-software because
         # my-software build requires on one of libone subpackage.
         build_requirements = graph.solve(
-            PackageRPM('libone', self.config, self.staff, self.modules)
+            PackageRPM("libone", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 2)
         for build_requirement in build_requirements:
             self.assertIsInstance(build_requirement.package, PackageRPM)
-        self.assertEqual(build_requirements[0].package.name, 'libone')
+        self.assertEqual(build_requirements[0].package.name, "libone")
         self.assertEqual(build_requirements[0].reasons, ["User request"])
-        self.assertEqual(build_requirements[1].package.name, 'my-software')
+        self.assertEqual(build_requirements[1].package.name, "my-software")
         self.assertEqual(
-            build_requirements[1].reasons,
-            ["build depends on rpm:libone-devel"]
+            build_requirements[1].reasons, ["build depends on rpm:libone-devel"]
         )
 
         # However, rebuild of OCI libone does not trigger rebuild other rebuild
         # because build requirements are expressed in RPM spec file only.
         build_requirements = graph.solve(
-            PackageOCI('libone', self.config, self.staff, self.modules)
+            PackageOCI("libone", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 1)
         self.assertIsInstance(build_requirements[0].package, PackageOCI)
-        self.assertEqual(build_requirements[0].package.name, 'libone')
+        self.assertEqual(build_requirements[0].package.name, "libone")
         self.assertEqual(build_requirements[0].reasons, ["User request"])
-
 
         # Rebuild of RPM libtwo triggers rebuild of libone and my-software
         # because:
@@ -338,46 +304,40 @@ class GraphTest(RiftProjectTestCase):
         # - my-software build requires on one of libtwo subpackage and on one
         #   of libone subpackage.
         build_requirements = graph.solve(
-            PackageRPM('libtwo', self.config, self.staff, self.modules)
+            PackageRPM("libtwo", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 3)
         for build_requirement in build_requirements:
             self.assertIsInstance(build_requirement.package, PackageRPM)
-        self.assertEqual(build_requirements[0].package.name, 'libtwo')
+        self.assertEqual(build_requirements[0].package.name, "libtwo")
         self.assertEqual(build_requirements[0].reasons, ["User request"])
-        self.assertEqual(build_requirements[1].package.name, 'libone')
+        self.assertEqual(build_requirements[1].package.name, "libone")
         self.assertEqual(
-            build_requirements[1].reasons,
-            ["build depends on rpm:libtwo-devel"]
+            build_requirements[1].reasons, ["build depends on rpm:libtwo-devel"]
         )
-        self.assertEqual(build_requirements[2].package.name, 'my-software')
+        self.assertEqual(build_requirements[2].package.name, "my-software")
         self.assertCountEqual(
             build_requirements[2].reasons,
-            [
-                "build depends on rpm:libone-devel",
-                "build depends on rpm:libtwo-devel"
-            ]
+            ["build depends on rpm:libone-devel", "build depends on rpm:libtwo-devel"],
         )
 
         # However, rebuild of OCI libtwo does not trigger rebuild other rebuild
         # because build requirements are expressed in RPM spec file only.
         build_requirements = graph.solve(
-            PackageOCI('libtwo', self.config, self.staff, self.modules)
+            PackageOCI("libtwo", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 1)
         self.assertIsInstance(build_requirements[0].package, PackageOCI)
-        self.assertEqual(build_requirements[0].package.name, 'libtwo')
+        self.assertEqual(build_requirements[0].package.name, "libtwo")
         self.assertEqual(build_requirements[0].reasons, ["User request"])
 
         # Remove my-software package directory, redefine my-software package
         # with dependencies in info.yaml and reload the graph.
-        shutil.rmtree(self.pkgdirs['my-software'])
+        shutil.rmtree(self.pkgdirs["my-software"])
         self.make_pkg(
-            name='my-software',
-            build_requires=['libone-devel, libtwo-devel'],
-            metadata={
-                'depends': ['libtwo']
-            }
+            name="my-software",
+            build_requires=["libone-devel, libtwo-devel"],
+            metadata={"depends": ["libtwo"]},
         )
         graph = load_graph()
 
@@ -385,35 +345,30 @@ class GraphTest(RiftProjectTestCase):
         # because my-software dependencies defined in info.yaml now overrides
         # build requires in RPM spec file.
         build_requirements = graph.solve(
-            PackageRPM('libone', self.config, self.staff, self.modules)
+            PackageRPM("libone", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 1)
         self.assertIsInstance(build_requirements[0].package, PackageRPM)
 
     def test_multiple_packages_with_provides(self):
-        """ Test graph with multiple packages and dependencies on provides in RPM spec files """
+        """Test graph with multiple packages and dependencies on provides in RPM spec files"""
         # Define 2 packages without depends in info.yaml but with build requires
         # on other subpackages provides.
         self.make_pkg(
-            name='libone',
-            subpackages=[
-                SubPackage('libone-bin'),
-                SubPackage('libone-devel')
-            ]
+            name="libone",
+            subpackages=[SubPackage("libone-bin"), SubPackage("libone-devel")],
         )
         self.make_pkg(
-            name='my-software',
-            build_requires=['libone-provide = 3'],
+            name="my-software",
+            build_requires=["libone-provide = 3"],
         )
 
         def load_graph():
             # mock Mock.read_spec to return spec file content directly read on host
-            with patch('rift.package.rpm.Mock') as mock_mock:
+            with patch("rift.package.rpm.Mock") as mock_mock:
                 mock_mock.return_value.read_spec = read_file
                 graph = PackagesDependencyGraph.from_project(
-                    self.config,
-                    self.staff,
-                    self.modules
+                    self.config, self.staff, self.modules
                 )
             # 2 packages x 2 formats → 4 nodes expected in the graph
             self.assertEqual(len(graph.nodes), 4)
@@ -424,66 +379,48 @@ class GraphTest(RiftProjectTestCase):
         # Rebuild of libone triggers rebuild of my-software because my-software
         # build requires on one of libone subpackage provides.
         build_requirements = graph.solve(
-            PackageRPM('libone', self.config, self.staff, self.modules)
+            PackageRPM("libone", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 2)
         for build_requirement in build_requirements:
             self.assertIsInstance(build_requirement.package, PackageRPM)
-        self.assertEqual(build_requirements[0].package.name, 'libone')
+        self.assertEqual(build_requirements[0].package.name, "libone")
         self.assertEqual(build_requirements[0].reasons, ["User request"])
-        self.assertEqual(build_requirements[1].package.name, 'my-software')
+        self.assertEqual(build_requirements[1].package.name, "my-software")
         self.assertEqual(
-            build_requirements[1].reasons,
-            ["build depends on rpm:libone-provide"]
+            build_requirements[1].reasons, ["build depends on rpm:libone-provide"]
         )
 
         # However, rebuild of OCI libone does not trigger rebuild other rebuild
         # because provides are expressed in RPM spec file only.
         build_requirements = graph.solve(
-            PackageOCI('libone', self.config, self.staff, self.modules)
+            PackageOCI("libone", self.config, self.staff, self.modules)
         )
         self.assertEqual(len(build_requirements), 1)
         self.assertIsInstance(build_requirements[0].package, PackageOCI)
-        self.assertEqual(build_requirements[0].package.name, 'libone')
+        self.assertEqual(build_requirements[0].package.name, "libone")
         self.assertEqual(build_requirements[0].reasons, ["User request"])
 
     def test_loop(self):
-        """ Test graph solve with dependency loop """
+        """Test graph solve with dependency loop"""
         # Define 3 packages with a dependency loop.
-        self.make_pkg(
-            name='libone',
-            metadata={
-                'depends': 'libtwo'
-            }
-        )
-        self.make_pkg(
-            name='libtwo',
-            metadata={
-                'depends': 'libthree'
-            }
-        )
-        self.make_pkg(
-            name='libthree',
-            metadata={
-                'depends': 'libone'
-            }
-        )
+        self.make_pkg(name="libone", metadata={"depends": "libtwo"})
+        self.make_pkg(name="libtwo", metadata={"depends": "libthree"})
+        self.make_pkg(name="libthree", metadata={"depends": "libone"})
 
         # Load graph
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
         # 3 packages x 2 formats → 6 nodes expected in the graph
         self.assertEqual(len(graph.nodes), 6)
 
         # For all three package, the resolution should return all three
         # build requirements (in RPM and OCI format).
-        for package in ['libone', 'libtwo', 'libthree']:
+        for package in ["libone", "libtwo", "libthree"]:
             for package_class in (PackageRPM, PackageOCI):
                 build_requirements = graph.solve(
                     package_class(package, self.config, self.staff, self.modules)
@@ -492,47 +429,31 @@ class GraphTest(RiftProjectTestCase):
                     self.assertIsInstance(build_requirement.package, package_class)
                 self.assertEqual(len(build_requirements), 3)
 
-    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch("sys.stdout", new_callable=io.StringIO)
     def test_draw(self, mock_stdout):
-        """ Test graph draw """
+        """Test graph draw"""
         # Define 3 packages with depends in info.yaml, in both string and list
         # formats.
+        self.make_pkg(name="libone", metadata={"depends": "libtwo"})
         self.make_pkg(
-            name='libone',
-            metadata={
-                'depends': 'libtwo'
-            }
+            name="libtwo",
         )
-        self.make_pkg(
-            name='libtwo',
-        )
-        self.make_pkg(
-            name='my-software',
-            metadata={
-                'depends': ['libone']
-            }
-        )
+        self.make_pkg(name="my-software", metadata={"depends": ["libone"]})
 
         # Load graph
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
         graph.draw(False, [])  # w/o external deps
         output = mock_stdout.getvalue()
 
         # Check all packages are declared as nodes (with their labels) in graph.
-        for package in ['libone', 'libtwo', 'my-software']:
-            self.assertTrue(
-                f"\"rpm:{package}\" [ label = " in output
-            )
-            self.assertTrue(
-                f"\"oci:{package}\" [ label = " in output
-            )
+        for package in ["libone", "libtwo", "my-software"]:
+            self.assertTrue(f'"rpm:{package}" [ label = ' in output)
+            self.assertTrue(f'"oci:{package}" [ label = ' in output)
         # Check depedencies are represented in graph.
         self.assertTrue('"rpm:my-software" -> "rpm:libone"' in output)
         self.assertTrue('"rpm:libone" -> "rpm:libtwo"' in output)
@@ -541,102 +462,77 @@ class GraphTest(RiftProjectTestCase):
         self.assertTrue('"oci:libone" -> "oci:libtwo"' in output)
         self.assertFalse('"oci:libtwo" -> "oci:my-software"' in output)
 
-    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch("sys.stdout", new_callable=io.StringIO)
     def test_draw_packages_subset(self, mock_stdout):
-        """ Test graph draw a subset of packages"""
+        """Test graph draw a subset of packages"""
         # Define 3 packages with depends in info.yaml, in both string and list
         # formats.
+        self.make_pkg(name="libone", metadata={"depends": "libtwo"})
         self.make_pkg(
-            name='libone',
-            metadata={
-                'depends': 'libtwo'
-            }
+            name="libtwo",
         )
-        self.make_pkg(
-            name='libtwo',
-        )
-        self.make_pkg(
-            name='my-software',
-            metadata={
-                'depends': ['libone']
-            }
-        )
+        self.make_pkg(name="my-software", metadata={"depends": ["libone"]})
 
         # Load graph
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
-        graph.draw(False, ['libone'])  # only libone and its deps
+        graph.draw(False, ["libone"])  # only libone and its deps
         output = mock_stdout.getvalue()
 
         # Check libone and its dependency libtwo are declared as nodes in the
         # graph.
-        for package in ['libone', 'libtwo']:
-            self.assertTrue(
-                f"\"rpm:{package}\" [ label = " in output
-            )
-            self.assertTrue(
-                f"\"oci:{package}\" [ label = " in output
-            )
+        for package in ["libone", "libtwo"]:
+            self.assertTrue(f'"rpm:{package}" [ label = ' in output)
+            self.assertTrue(f'"oci:{package}" [ label = ' in output)
         # Check depedencies are represented in graph.
         self.assertTrue('"rpm:libone" -> "rpm:libtwo"' in output)
         self.assertTrue('"oci:libone" -> "oci:libtwo"' in output)
         # Check my-software is not mentionned in graph.
-        self.assertFalse('rpm:my-software' in output)
-        self.assertFalse('oci:my-software' in output)
+        self.assertFalse("rpm:my-software" in output)
+        self.assertFalse("oci:my-software" in output)
 
-    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch("sys.stdout", new_callable=io.StringIO)
     def test_draw_with_external_deps(self, mock_stdout):
-        """ Test graph draw with external dependencies """
+        """Test graph draw with external dependencies"""
         # Define 3 packages without depends in info.yaml but with build requires
         # on others subpackages and external dep.
         self.make_pkg(
-            name='libone',
-            build_requires=['libtwo-devel', 'external-devel'],
+            name="libone",
+            build_requires=["libtwo-devel", "external-devel"],
             subpackages=[
-                SubPackage('libone-bin'),
-                SubPackage('libone-devel'),
-            ]
+                SubPackage("libone-bin"),
+                SubPackage("libone-devel"),
+            ],
         )
         self.make_pkg(
-            name='libtwo',
-            subpackages=[
-                SubPackage('libtwo-bin'),
-                SubPackage('libtwo-devel')
-            ]
+            name="libtwo",
+            subpackages=[SubPackage("libtwo-bin"), SubPackage("libtwo-devel")],
         )
         self.make_pkg(
-            name='my-software',
-            build_requires=['libone-devel, libtwo-devel', 'external-devel'],
+            name="my-software",
+            build_requires=["libone-devel, libtwo-devel", "external-devel"],
         )
 
         # Load graph
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             graph = PackagesDependencyGraph.from_project(
-                self.config,
-                self.staff,
-                self.modules
+                self.config, self.staff, self.modules
             )
         graph.draw(True, [])  # w/ external deps
         output = mock_stdout.getvalue()
 
         # Check external RPM packages are declared as nodes (with their labels)
         # in graph.
-        self.assertTrue(
-                '"rpm:external-devel" [fillcolor=orange]' in output
-        )
+        self.assertTrue('"rpm:external-devel" [fillcolor=orange]' in output)
         # External package must not be present for OCI format as this is a
         # spec/RPM specific notion.
-        self.assertFalse(
-                '"oci:external-devel" [fillcolor=orange]' in output
-        )
+        self.assertFalse('"oci:external-devel" [fillcolor=orange]' in output)
 
         # Check depedencies are represented in graph.
         self.assertTrue('"rpm:my-software" -> "rpm:external-devel"' in output)

--- a/tests/package/base.py
+++ b/tests/package/base.py
@@ -6,20 +6,22 @@ import textwrap
 from unittest.mock import patch
 
 from rift import RiftError
+from rift.Gerrit import Review
 from rift.package import Package
 from rift.package._base import (
-    _SOURCES_DIR,
     _META_FILE,
+    _SOURCES_DIR,
     _TESTS_DIR,
     ActionableArchPackage,
     Test,
 )
-from ..TestUtils import RiftProjectTestCase, PackageTestDef, make_temp_file
-from rift.Gerrit import Review
+
+from ..TestUtils import PackageTestDef, RiftProjectTestCase, make_temp_file
 
 
 class PackageTestingConcrete(Package):
     """Dummy Package concrete child for testing purpose."""
+
     def __init__(self, name, config, staff, modules, _format):
         super().__init__(name, config, staff, modules, _format, f"{name}.buildfile")
 
@@ -41,6 +43,7 @@ class PackageTestingConcrete(Package):
 
 class ActionableArchPackageTestingConcrete(ActionableArchPackage):
     """Dummy ActionableArchPackage concrete child for testing purpose."""
+
     def __init__(self, package, arch):
         super().__init__(package, arch)
 
@@ -61,199 +64,195 @@ class PackageTest(RiftProjectTestCase):
 
     def test_init_abstract(self):
         with self.assertRaisesRegex(
-            TypeError,
-            "^Can't instantiate abstract class Package .*"
+            TypeError, "^Can't instantiate abstract class Package .*"
         ):
-            Package('pkg', self.config, self.staff, self.modules, 'fail', 'build.fail')
+            Package("pkg", self.config, self.staff, self.modules, "fail", "build.fail")
 
     def test_init_concrete(self):
-        """ Test Package initialisation """
-        pkgname = 'pkg'
-        self.config.project_dir = '/'
+        """Test Package initialisation"""
+        pkgname = "pkg"
+        self.config.project_dir = "/"
         pkg = PackageTestingConcrete(
-            pkgname, self.config, self.staff, self.modules, 'rpm'
+            pkgname, self.config, self.staff, self.modules, "rpm"
         )
         self.assertEqual(
-            pkg.dir, '/{0}/{1}'.format(self.config.get('packages_dir'), pkgname)
+            pkg.dir, "/{0}/{1}".format(self.config.get("packages_dir"), pkgname)
         )
         self.assertEqual(pkg.sourcesdir, os.path.join(pkg.dir, _SOURCES_DIR))
         self.assertEqual(pkg.testsdir, os.path.join(pkg.dir, _TESTS_DIR))
         self.assertEqual(pkg.metafile, os.path.join(pkg.dir, _META_FILE))
-        self.assertEqual(pkg.format, 'rpm')
+        self.assertEqual(pkg.format, "rpm")
         self.assertEqual(pkg.buildfile, f"{pkg.dir}/{pkgname}.buildfile")
 
     def test_init_invalid_format(self):
         with self.assertRaisesRegex(RiftError, "^Unsupported package format fail$"):
-            PackageTestingConcrete('pkg', self.config, self.staff, self.modules, 'fail')
+            PackageTestingConcrete("pkg", self.config, self.staff, self.modules, "fail")
 
     def test_load(self):
-        """ Test Package information loading """
+        """Test Package information loading"""
         self.make_pkg(
-            metadata={'depends': ['foo', 'bar'], 'exclude_archs': ['aarch64']}
+            metadata={"depends": ["foo", "bar"], "exclude_archs": ["aarch64"]}
         )
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         pkg.load()
-        self.assertEqual(pkg.module, 'Great module')
-        self.assertEqual(pkg.maintainers, ['Myself'])
-        self.assertEqual(pkg.reason, 'Missing feature')
-        self.assertEqual(pkg.origin, 'Vendor')
-        self.assertCountEqual(pkg.depends, ['foo', 'bar'])
-        self.assertCountEqual(pkg.exclude_archs, ['aarch64'])
+        self.assertEqual(pkg.module, "Great module")
+        self.assertEqual(pkg.maintainers, ["Myself"])
+        self.assertEqual(pkg.reason, "Missing feature")
+        self.assertEqual(pkg.origin, "Vendor")
+        self.assertCountEqual(pkg.depends, ["foo", "bar"])
+        self.assertCountEqual(pkg.exclude_archs, ["aarch64"])
 
     def test_for_arch(self):
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
-        actionable_pkg = pkg.for_arch('x86_64')
+        actionable_pkg = pkg.for_arch("x86_64")
         self.assertIsInstance(actionable_pkg, ActionableArchPackageTestingConcrete)
-        self.assertEqual(actionable_pkg.name, 'pkg')
+        self.assertEqual(actionable_pkg.name, "pkg")
         self.assertEqual(actionable_pkg.package, pkg)
         self.assertEqual(actionable_pkg.buildfile, f"{pkg.dir}/{pkg.name}.buildfile")
         self.assertEqual(actionable_pkg.config, self.config)
-        self.assertEqual(actionable_pkg.arch, 'x86_64')
+        self.assertEqual(actionable_pkg.arch, "x86_64")
 
     def test_tests(self):
-        """ Test Package tests method """
+        """Test Package tests method"""
         self.make_pkg()
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         pkg.load()
         tests = [test for test in pkg.tests()]
         self.assertEqual(len(tests), 1)
         self.assertIsInstance(tests[0], Test)
-        self.assertEqual(tests[0].name, '0_test')
+        self.assertEqual(tests[0].name, "0_test")
 
     def test_tests_format(self):
-        """ Test Package tests method with formats restriction in tests """
+        """Test Package tests method with formats restriction in tests"""
         self.make_pkg(
             tests=[
-                PackageTestDef(name='0_test.sh', local=False, formats=[]),
-                PackageTestDef(name='1_test.sh', local=False,
-                    formats=['rpm', 'other']),
-                PackageTestDef(name='2_test.sh', local=False,
-                    formats=['other']),
+                PackageTestDef(name="0_test.sh", local=False, formats=[]),
+                PackageTestDef(name="1_test.sh", local=False, formats=["rpm", "other"]),
+                PackageTestDef(name="2_test.sh", local=False, formats=["other"]),
             ]
         )
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         pkg.load()
         tests = [test for test in pkg.tests()]
         self.assertEqual(len(tests), 2)
         for test in tests:
             self.assertIsInstance(test, Test)
-        self.assertCountEqual(
-            [test.name for test in tests], ['0_test', '1_test'])
+        self.assertCountEqual([test.name for test in tests], ["0_test", "1_test"])
 
     def test_subpackages(self):
-        """ Test Package subpackages (dummy implementation) """
+        """Test Package subpackages (dummy implementation)"""
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         self.assertCountEqual(pkg.subpackages(), [])
 
     def test_build_requires(self):
-        """ Test Package build requires (dummy implementation) """
+        """Test Package build requires (dummy implementation)"""
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         self.assertCountEqual(pkg.build_requires(), [])
 
     def test_add_changelog_entry(self):
-        """ Test Package add changelog entry (not implemented) """
+        """Test Package add changelog entry (not implemented)"""
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         with self.assertRaises(NotImplementedError):
             pkg.add_changelog_entry("Myself", "Package modification", False)
 
     def test_analyze(self):
-        """ Test Package analyze (not implemented) """
+        """Test Package analyze (not implemented)"""
         pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
         with self.assertRaises(NotImplementedError):
             pkg.analyze(Review(), pkg.dir)
 
 
 class ActionableArchPackageTest(RiftProjectTestCase):
-
     def setUp(self):
         super().setUp()
         self.pkg = PackageTestingConcrete(
-            'pkg', self.config, self.staff, self.modules, 'rpm'
+            "pkg", self.config, self.staff, self.modules, "rpm"
         )
 
     def test_init_abstract(self):
         with self.assertRaisesRegex(
-            TypeError,
-            "^Can't instantiate abstract class ActionableArchPackage .*"
+            TypeError, "^Can't instantiate abstract class ActionableArchPackage .*"
         ):
-            ActionableArchPackage(self.pkg, 'x86_64')
+            ActionableArchPackage(self.pkg, "x86_64")
 
     def test_init_concrete(self):
-        ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        ActionableArchPackageTestingConcrete(self.pkg, "x86_64")
 
-    @patch('rift.package._base.run_command')
+    @patch("rift.package._base.run_command")
     def test_run_local_test(self, mock_run_command):
-        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, "x86_64")
         command = make_temp_file(
             textwrap.dedent("""\
                 #!/bin/sh
                 /bin/true
                 """),
-            suffix='.sh'
+            suffix=".sh",
         )
         test = Test(command.name)
         actionable_pkg.run_local_test(test)
         mock_run_command.assert_called_once_with(
-            command.name, capture_output=True, shell=True)
+            command.name, capture_output=True, shell=True
+        )
 
-    @patch('rift.package._base.run_command')
+    @patch("rift.package._base.run_command")
     def test_run_local_test_with_funcs(self, mock_run_command):
-        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, "x86_64")
         command = make_temp_file(
             textwrap.dedent("""\
                 #!/bin/sh
                 /bin/true
                 """),
-            suffix='.sh'
+            suffix=".sh",
         )
         test = Test(command.name)
-        actionable_pkg.run_local_test(test, { 'hey': 'echo hey!'})
+        actionable_pkg.run_local_test(test, {"hey": "echo hey!"})
         mock_run_command.assert_called_once_with(
             f"hey() {{ echo hey!; }}; export -f hey; {command.name}",
-            capture_output=True, shell=True)
+            capture_output=True,
+            shell=True,
+        )
 
     def test_clean(self):
-        """ Test clean method no-op on abstract class """
-        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, 'x86_64')
+        """Test clean method no-op on abstract class"""
+        actionable_pkg = ActionableArchPackageTestingConcrete(self.pkg, "x86_64")
         actionable_pkg.clean()
 
 
 class TestTest(RiftProjectTestCase):
     def test_init(self):
-        """ Test with command """
+        """Test with command"""
         command = make_temp_file(
             textwrap.dedent("""\
                 #!/bin/sh
                 # fake test
                 /bin/true
                 """),
-            suffix='.sh'
+            suffix=".sh",
         )
         test = Test(command.name)
         self.assertEqual(test.command, command.name)
         self.assertFalse(test.local)
         self.assertCountEqual(test.formats, [])
-        self.assertEqual(
-            test.name, os.path.splitext(os.path.basename(command.name))[0])
+        self.assertEqual(test.name, os.path.splitext(os.path.basename(command.name))[0])
 
     def test_init_local(self):
-        """ Test with command to run locally """
+        """Test with command to run locally"""
         command = make_temp_file(
             textwrap.dedent("""\
                 #!/bin/sh
@@ -262,17 +261,16 @@ class TestTest(RiftProjectTestCase):
                 #
                 /bin/true
                 """),
-            suffix='.sh'
+            suffix=".sh",
         )
-        with self.assertLogs(level='DEBUG') as logs:
+        with self.assertLogs(level="DEBUG") as logs:
             test = Test(command.name)
         self.assertTrue(test.local)
         self.assertCountEqual(test.formats, [])
-        self.assertIn(
-            f"DEBUG:root:Test '{test.name}' detected as local", logs.output)
+        self.assertIn(f"DEBUG:root:Test '{test.name}' detected as local", logs.output)
 
     def test_one_format(self):
-        """ Test with analyzed command restricted to one format """
+        """Test with analyzed command restricted to one format"""
         command = make_temp_file(
             textwrap.dedent("""\
                 #!/bin/sh
@@ -281,18 +279,18 @@ class TestTest(RiftProjectTestCase):
                 #
                 /bin/true
                 """),
-            suffix='.sh'
+            suffix=".sh",
         )
-        with self.assertLogs(level='DEBUG') as logs:
+        with self.assertLogs(level="DEBUG") as logs:
             test = Test(command.name)
-        self.assertCountEqual(test.formats, ['rpm'])
+        self.assertCountEqual(test.formats, ["rpm"])
         self.assertIn(
-            f"DEBUG:root:Test '{test.name}' restricted to specific formats: "
-            "rpm",
-            logs.output)
+            f"DEBUG:root:Test '{test.name}' restricted to specific formats: rpm",
+            logs.output,
+        )
 
     def test_multiple_formats(self):
-        """ Test with analyzed command restricted to multiple formats """
+        """Test with analyzed command restricted to multiple formats"""
         command = make_temp_file(
             textwrap.dedent("""\
                 #!/bin/sh
@@ -302,12 +300,12 @@ class TestTest(RiftProjectTestCase):
                 #
                 /bin/true
                 """),
-            suffix='.sh'
+            suffix=".sh",
         )
-        with self.assertLogs(level='DEBUG') as logs:
+        with self.assertLogs(level="DEBUG") as logs:
             test = Test(command.name)
-        self.assertCountEqual(test.formats, ['rpm', 'other'])
+        self.assertCountEqual(test.formats, ["rpm", "other"])
         self.assertIn(
-            f"DEBUG:root:Test '{test.name}' restricted to specific formats:"
-             " rpm, other",
-             logs.output)
+            f"DEBUG:root:Test '{test.name}' restricted to specific formats: rpm, other",
+            logs.output,
+        )

--- a/tests/package/oci.py
+++ b/tests/package/oci.py
@@ -6,29 +6,36 @@ import textwrap
 from unittest.mock import Mock, patch
 
 from rift import RiftError
-from rift.package.oci import PackageOCI, ActionableArchPackageOCI
-from rift.repository.oci import ArchRepositoriesOCI
 from rift.Gerrit import Review
+from rift.package.oci import ActionableArchPackageOCI, PackageOCI
+from rift.repository.oci import ArchRepositoriesOCI
 from rift.run import RunResult
 from rift.TestResults import TestResults
 
-from ..TestUtils import RiftProjectTestCase, PackageTestDef, make_temp_file, gen_containerfile
+from ..TestUtils import (
+    PackageTestDef,
+    RiftProjectTestCase,
+    gen_containerfile,
+    make_temp_file,
+)
 
 
 class PackageOCITest(RiftProjectTestCase):
     """
     Tests class for PackageOCI
     """
+
     def test_init(self):
-        """PackageOCI initialisation """
-        pkgname = 'pkg'
+        """PackageOCI initialisation"""
+        pkgname = "pkg"
         pkg = PackageOCI(pkgname, self.config, self.staff, self.modules)
-        self.assertEqual(pkg.format, 'oci')
+        self.assertEqual(pkg.format, "oci")
         self.assertEqual(pkg.buildfile, f"{pkg.dir}/Containerfile")
 
     def test_load(self):
         """PackageOCI infos loading"""
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -38,17 +45,19 @@ class PackageOCITest(RiftProjectTestCase):
                 oci:
                     version: 0.0.1
                     release: 1
-            """))
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+            """)
+        )
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         container_file = make_temp_file(gen_containerfile())
         pkg.buildfile = container_file.name
-        pkg.load(infopath = pkgfile.name)
-        self.assertEqual(pkg.version, '0.0.1')
-        self.assertEqual(pkg.release, '1')
+        pkg.load(infopath=pkgfile.name)
+        self.assertEqual(pkg.version, "0.0.1")
+        self.assertEqual(pkg.release, "1")
 
     def test_load_source_topdir(self):
         """PackageOCI infos loading with source topdir"""
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -59,16 +68,18 @@ class PackageOCITest(RiftProjectTestCase):
                     version: 0.0.1
                     release: 1
                     source_topdir: pkg-main
-            """))
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+            """)
+        )
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         container_file = make_temp_file(gen_containerfile())
         pkg.buildfile = container_file.name
-        pkg.load(infopath = pkgfile.name)
-        self.assertEqual(pkg.source_topdir, 'pkg-main')
+        pkg.load(infopath=pkgfile.name)
+        self.assertEqual(pkg.source_topdir, "pkg-main")
 
     def test_load_main_source(self):
         """PackageOCI infos loading with main source"""
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -79,16 +90,18 @@ class PackageOCITest(RiftProjectTestCase):
                     version: 0.0.1
                     release: 1
                     main_source: pkg-full.tar.bz2
-            """))
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+            """)
+        )
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         container_file = make_temp_file(gen_containerfile())
         pkg.buildfile = container_file.name
-        pkg.load(infopath = pkgfile.name)
-        self.assertEqual(pkg.main_source, 'pkg-full.tar.bz2')
+        pkg.load(infopath=pkgfile.name)
+        self.assertEqual(pkg.main_source, "pkg-full.tar.bz2")
 
     def test_load_missing_version(self):
         """PackageOCI infos missing version"""
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -97,15 +110,18 @@ class PackageOCITest(RiftProjectTestCase):
                 origin: Company
                 oci:
                     release: 1
-            """))
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+            """)
+        )
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         with self.assertRaisesRegex(
-            RiftError, "Unable to load oci version from metadata"):
-            pkg.load(infopath = pkgfile.name)
+            RiftError, "Unable to load oci version from metadata"
+        ):
+            pkg.load(infopath=pkgfile.name)
 
     def test_load_missing_release(self):
         """PackageOCI infos missing release"""
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -114,26 +130,28 @@ class PackageOCITest(RiftProjectTestCase):
                 origin: Company
                 oci:
                     version: 0.0.1
-            """))
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+            """)
+        )
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         with self.assertRaisesRegex(
-            RiftError, "Unable to load oci release from metadata"):
-            pkg.load(infopath = pkgfile.name)
+            RiftError, "Unable to load oci release from metadata"
+        ):
+            pkg.load(infopath=pkgfile.name)
 
     def test_write(self):
         """PackageOCI write"""
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
-        pkg.module = 'Great module'
-        pkg.maintainers = ['Myself']
-        pkg.reason = 'Missing package'
-        pkg.origin = 'Company'
-        pkg.version = '0.0.1'
-        pkg.release = '2'
-        pkg.main_source = 'pkg-1.0.tar.gz'
-        pkg.source_topdir = 'pkg_1.0'
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
+        pkg.module = "Great module"
+        pkg.maintainers = ["Myself"]
+        pkg.reason = "Missing package"
+        pkg.origin = "Company"
+        pkg.version = "0.0.1"
+        pkg.release = "2"
+        pkg.main_source = "pkg-1.0.tar.gz"
+        pkg.source_topdir = "pkg_1.0"
         os.makedirs(pkg.dir)
         pkg.write()
-        loaded = PackageOCI('pkg', self.config, self.staff, self.modules)
+        loaded = PackageOCI("pkg", self.config, self.staff, self.modules)
         container_file = make_temp_file(gen_containerfile())
         loaded.buildfile = container_file.name
         loaded.load()
@@ -146,11 +164,12 @@ class PackageOCITest(RiftProjectTestCase):
         self.assertEqual(pkg.main_source, loaded.main_source)
         self.assertEqual(pkg.source_topdir, loaded.source_topdir)
 
-    @patch('rift.package.oci.ContainerFile')
+    @patch("rift.package.oci.ContainerFile")
     def test_check(self, mock_container_file):
         """PackageOCI check calls ContainerFile check"""
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -160,24 +179,26 @@ class PackageOCITest(RiftProjectTestCase):
                 oci:
                     version: 0.0.1
                     release: 1
-            """))
+            """)
+        )
         container_file = make_temp_file(gen_containerfile())
         pkg.buildfile = container_file.name
-        pkg.load(infopath = pkgfile.name)
+        pkg.load(infopath=pkgfile.name)
         pkg.check()
         mock_container_file.return_value.check.assert_called_once_with()
 
     def test_add_changelog_entry(self):
         """PackageOCI add changelog entry (not implemented)"""
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         with self.assertRaises(NotImplementedError):
             pkg.add_changelog_entry("Myself", "Modify package", False)
 
-    @patch('rift.package.oci.ContainerFile')
+    @patch("rift.package.oci.ContainerFile")
     def test_analyze(self, mock_container_file):
         """PackageOCI analyze calls ContainerFile analyze"""
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -187,140 +208,154 @@ class PackageOCITest(RiftProjectTestCase):
                 oci:
                     version: 0.0.1
                     release: 1
-            """))
+            """)
+        )
         container_file = make_temp_file(gen_containerfile())
         pkg.buildfile = container_file.name
-        pkg.load(infopath = pkgfile.name)
+        pkg.load(infopath=pkgfile.name)
         review = Review()
         pkg.analyze(review, pkg.dir)
-        mock_container_file.return_value.analyze.assert_called_once_with(review, pkg.dir)
+        mock_container_file.return_value.analyze.assert_called_once_with(
+            review, pkg.dir
+        )
 
     def test_supports_arch(self):
-        """ PackageOCI supports_arch() """
-        pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
-        self.assertTrue(pkg.supports_arch('x86_64'))
-        self.assertTrue(pkg.supports_arch('aarch64'))
-        self.assertFalse(pkg.supports_arch('fail'))
+        """PackageOCI supports_arch()"""
+        pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
+        self.assertTrue(pkg.supports_arch("x86_64"))
+        self.assertTrue(pkg.supports_arch("aarch64"))
+        self.assertFalse(pkg.supports_arch("fail"))
 
     def test_for_arch(self):
-        """ PackageOCI for_arch() returns ActionableArchPackageOCI object. """
-        pkgname = 'pkg'
+        """PackageOCI for_arch() returns ActionableArchPackageOCI object."""
+        pkgname = "pkg"
         pkg = PackageOCI(pkgname, self.config, self.staff, self.modules)
-        pkg_arch = pkg.for_arch('x86_64')
+        pkg_arch = pkg.for_arch("x86_64")
         self.assertIsInstance(pkg_arch, ActionableArchPackageOCI)
         self.assertEqual(pkg_arch.name, pkg.name)
         self.assertEqual(pkg_arch.buildfile, pkg.buildfile)
         self.assertEqual(pkg_arch.config, pkg._config)
         self.assertEqual(pkg_arch.package, pkg)
-        self.assertEqual(pkg_arch.arch, 'x86_64')
+        self.assertEqual(pkg_arch.arch, "x86_64")
 
 
 class ActionableArchPackageOCITest(RiftProjectTestCase):
     """
     Tests class for ActionableArchPackageOCI
     """
+
     def setup_package(self, src_top_dir=None, tests=None):
         self.make_pkg(src_top_dir=src_top_dir, tests=tests)
-        _pkg = PackageOCI('pkg', self.config, self.staff, self.modules)
+        _pkg = PackageOCI("pkg", self.config, self.staff, self.modules)
         _pkg.load()
-        self.pkg = ActionableArchPackageOCI(_pkg, 'x86_64')
+        self.pkg = ActionableArchPackageOCI(_pkg, "x86_64")
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build(self, mock_container_runtime):
         self.setup_package()
         self.pkg.build()
         mock_container_runtime.return_value.build.assert_called_once()
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build_missing_source(self, mock_container_runtime):
         self.setup_package()
         # Delete package source archive
-        os.unlink(self.pkgsrc['pkg'])
+        os.unlink(self.pkgsrc["pkg"])
         self.pkg.package.load()
         with self.assertRaisesRegex(
-            RiftError, "^Unable to find sources for package pkg$"):
+            RiftError, "^Unable to find sources for package pkg$"
+        ):
             self.pkg.build()
         mock_container_runtime.return_value.build.assert_not_called()
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build_multiple_sources_with_main_source(self, mock_container_runtime):
         self.setup_package()
         # create another source to introduce conflict
         another_source_path = os.path.join(
-            os.path.dirname(self.pkgsrc['pkg']), 'another-source')
-        with open(another_source_path, 'w+') as fh:
-            fh.write('dummy')
+            os.path.dirname(self.pkgsrc["pkg"]), "another-source"
+        )
+        with open(another_source_path, "w+") as fh:
+            fh.write("dummy")
         self.pkg.package.load()
-        self.pkg.package.main_source = 'pkg-1.0.tar.gz'
+        self.pkg.package.main_source = "pkg-1.0.tar.gz"
         self.pkg.build()
         mock_container_runtime.return_value.build.assert_called_once()
         # remove additional source
         os.unlink(another_source_path)
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build_multiple_sources_without_main_source(self, mock_container_runtime):
         self.setup_package()
         # create another source to introduce conflict
         another_source_path = os.path.join(
-            os.path.dirname(self.pkgsrc['pkg']), 'another-source')
-        with open(another_source_path, 'w+') as fh:
-            fh.write('dummy')
+            os.path.dirname(self.pkgsrc["pkg"]), "another-source"
+        )
+        with open(another_source_path, "w+") as fh:
+            fh.write("dummy")
         self.pkg.package.load()
         self.pkg.build()
         mock_container_runtime.return_value.build.assert_called_once()
         # remove additional source
         os.unlink(another_source_path)
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build_missing_main_source(self, mock_container_runtime):
         self.setup_package()
         # create another source to introduce conflict
         another_source_path = os.path.join(
-            os.path.dirname(self.pkgsrc['pkg']), 'another-source')
-        with open(another_source_path, 'w+') as fh:
-            fh.write('dummy')
+            os.path.dirname(self.pkgsrc["pkg"]), "another-source"
+        )
+        with open(another_source_path, "w+") as fh:
+            fh.write("dummy")
         self.pkg.package.load()
         self.pkg.package.main_source = "fail"
         with self.assertRaisesRegex(
             RiftError,
-            r"^Unable to find main source fail among available package sources: .*$"):
+            r"^Unable to find main source fail among available package sources: .*$",
+        ):
             self.pkg.build()
         mock_container_runtime.return_value.build.assert_not_called()
         # remove additional source
         os.unlink(another_source_path)
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build_unable_determine_source(self, mock_container_runtime):
         self.setup_package()
         # create another source to introduce conflict
         another_source_path = os.path.join(
-            os.path.dirname(self.pkgsrc['pkg']), 'pkg-1.0.tar.bz2')
-        with open(another_source_path, 'w+') as fh:
-            fh.write('dummy')
+            os.path.dirname(self.pkgsrc["pkg"]), "pkg-1.0.tar.bz2"
+        )
+        with open(another_source_path, "w+") as fh:
+            fh.write("dummy")
         self.pkg.package.load()
         with self.assertRaisesRegex(
             RiftError,
             r"^Unable to determine main package source among available package "
-            r"sources: .*$"):
+            r"sources: .*$",
+        ):
             self.pkg.build()
         mock_container_runtime.return_value.build.assert_not_called()
         # remove additional source
         os.unlink(another_source_path)
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_build_unable_find_top_dir(self, mock_container_runtime):
-        self.setup_package(src_top_dir='fail')
+        self.setup_package(src_top_dir="fail")
         self.pkg.package.load()
         with self.assertRaisesRegex(
-            RiftError, "^Unable to find package source top directory .*/pkg-1.0$"):
+            RiftError, "^Unable to find package source top directory .*/pkg-1.0$"
+        ):
             self.pkg.build()
         mock_container_runtime.return_value.build.assert_not_called()
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_test_success(self, mock_container_runtime):
         self.setup_package()
         self.pkg.run_local_test = Mock(return_value=RunResult(0, None, None))
-        mock_container_runtime.return_value.run_test.return_value = RunResult(0, 'ok', None)
+        mock_container_runtime.return_value.run_test.return_value = RunResult(
+            0, "ok", None
+        )
         results = self.pkg.test()
         # Check run_local_test() has not been called.
         self.pkg.run_local_test.assert_not_called()
@@ -329,13 +364,16 @@ class ActionableArchPackageOCITest(RiftProjectTestCase):
         self.assertIsInstance(results, TestResults)
         self.assertEqual(results.global_result, True)
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_test_local(self, mock_container_runtime):
         # Create fake package with one local test.
         self.setup_package(
-            tests=[PackageTestDef(name='0_test.sh', local=True, formats=[])])
+            tests=[PackageTestDef(name="0_test.sh", local=True, formats=[])]
+        )
         self.pkg.run_local_test = Mock(return_value=RunResult(0, None, None))
-        mock_container_runtime.return_value.run_test.return_value = RunResult(0, 'ok', None)
+        mock_container_runtime.return_value.run_test.return_value = RunResult(
+            0, "ok", None
+        )
         results = self.pkg.test()
         # Check run_local_test() has been called once for local test
         self.pkg.run_local_test.assert_called_once()
@@ -344,28 +382,30 @@ class ActionableArchPackageOCITest(RiftProjectTestCase):
         self.assertIsInstance(results, TestResults)
         self.assertEqual(results.global_result, True)
 
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerRuntime")
     def test_test_failure(self, mock_container_runtime):
         self.setup_package()
-        mock_container_runtime.return_value.run_test.return_value = RunResult(1, 'ko', None)
+        mock_container_runtime.return_value.run_test.return_value = RunResult(
+            1, "ko", None
+        )
         results = self.pkg.test()
         mock_container_runtime.return_value.run_test.assert_called_once()
         self.assertIsInstance(results, TestResults)
         self.assertEqual(results.global_result, False)
 
-    @patch('rift.package.oci.ContainerArchive')
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerArchive")
+    @patch("rift.package.oci.ContainerRuntime")
     def test_publish(self, mock_container_runtime, mock_container_archive):
         self.setup_package()
         self.pkg.repos = Mock(spec=ArchRepositoriesOCI)
-        self.pkg.repos.path = '/oci'
+        self.pkg.repos.path = "/oci"
         self.pkg.publish()
         self.pkg.repos.ensure_created.assert_called_once()
         mock_container_runtime.return_value.archive.assert_called_once()
         mock_container_archive.return_value.sign.assert_not_called()
 
-    @patch('rift.package.oci.ContainerArchive')
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerArchive")
+    @patch("rift.package.oci.ContainerRuntime")
     def test_publish_staging(self, mock_container_runtime, mock_container_archive):
         self.setup_package()
         self.pkg.repos = Mock(spec=ArchRepositoriesOCI)
@@ -374,12 +414,12 @@ class ActionableArchPackageOCITest(RiftProjectTestCase):
         mock_container_runtime.return_value.archive.assert_not_called()
         mock_container_archive.return_value.sign.assert_not_called()
 
-    @patch('rift.package.oci.ContainerArchive')
-    @patch('rift.package.oci.ContainerRuntime')
+    @patch("rift.package.oci.ContainerArchive")
+    @patch("rift.package.oci.ContainerRuntime")
     def test_publish_sign(self, mock_container_runtime, mock_container_archive):
         self.setup_package()
         self.pkg.repos = Mock(spec=ArchRepositoriesOCI)
-        self.pkg.repos.path = '/oci'
+        self.pkg.repos.path = "/oci"
         self.pkg.publish(sign=True)
         self.pkg.repos.ensure_created.assert_called_once()
         mock_container_runtime.return_value.archive.assert_called_once()

--- a/tests/package/project.py
+++ b/tests/package/project.py
@@ -5,10 +5,11 @@
 import os
 
 from rift.Config import Config
-from rift.package._virtual import PackageVirtual
-from rift.package.rpm import PackageRPM
-from rift.package.oci import PackageOCI
 from rift.package import ProjectPackages
+from rift.package._virtual import PackageVirtual
+from rift.package.oci import PackageOCI
+from rift.package.rpm import PackageRPM
+
 from ..TestUtils import RiftProjectTestCase
 
 
@@ -16,84 +17,95 @@ class ProjectPackagesTest(RiftProjectTestCase):
     """
     Tests class for ProjectPackages
     """
+
     def fill_project_dir(self, packages):
-        open(os.path.join(self.projdir, Config._DEFAULT_FILES[0]), 'a').close()
-        packages_dir = os.path.join(self.projdir, self.config.get('packages_dir'))
+        open(os.path.join(self.projdir, Config._DEFAULT_FILES[0]), "a").close()
+        packages_dir = os.path.join(self.projdir, self.config.get("packages_dir"))
         for package, formats in packages.items():
             os.mkdir(os.path.join(packages_dir, package))
-            if 'rpm' in formats:
-                open(os.path.join(packages_dir, package, f"{package}.spec"), 'a').close()
-            if 'oci' in formats:
-                open(os.path.join(packages_dir, package, 'Containerfile'), 'a').close()
+            if "rpm" in formats:
+                open(
+                    os.path.join(packages_dir, package, f"{package}.spec"), "a"
+                ).close()
+            if "oci" in formats:
+                open(os.path.join(packages_dir, package, "Containerfile"), "a").close()
 
     def test_list(self):
-        """ Test ProjectPackages list() """
-        packages_names = {'foo': ['rpm'], 'bar': ['oci']}
+        """Test ProjectPackages list()"""
+        packages_names = {"foo": ["rpm"], "bar": ["oci"]}
         self.fill_project_dir(packages_names)
         packages = list(ProjectPackages.list(self.config, self.staff, self.modules))
         self.assertEqual(len(packages), 2)
         for package in packages:
             self.assertIn(package.name, packages_names)
-            if package.name == 'foo':
+            if package.name == "foo":
                 self.assertIsInstance(package, PackageRPM)
-            elif package.name == 'bar':
+            elif package.name == "bar":
                 self.assertIsInstance(package, PackageOCI)
 
     def test_list_empty(self):
-        """ Test ProjectPackages list() empty """
+        """Test ProjectPackages list() empty"""
         self.fill_project_dir({})
-        self.assertCountEqual(ProjectPackages.list(self.config, self.staff, self.modules), [])
+        self.assertCountEqual(
+            ProjectPackages.list(self.config, self.staff, self.modules), []
+        )
 
     def test_list_with_names(self):
-        """ Test ProjectPackages list() with names"""
-        packages_names = {'foo': ['rpm'], 'bar': ['rpm'], 'baz': ['oci']}
-        list_names = ['bar', 'baz', 'fail']
+        """Test ProjectPackages list() with names"""
+        packages_names = {"foo": ["rpm"], "bar": ["rpm"], "baz": ["oci"]}
+        list_names = ["bar", "baz", "fail"]
         self.fill_project_dir(packages_names)
-        packages = list(ProjectPackages.list(self.config, self.staff, self.modules, list_names))
+        packages = list(
+            ProjectPackages.list(self.config, self.staff, self.modules, list_names)
+        )
         self.assertEqual(len(packages), 3)
         for package in packages:
             self.assertIn(package.name, list_names)
-            if package.name == 'bar':
+            if package.name == "bar":
                 self.assertIsInstance(package, PackageRPM)
-            elif package.name == 'baz':
+            elif package.name == "baz":
                 self.assertIsInstance(package, PackageOCI)
             else:
                 self.assertIsInstance(package, PackageVirtual)
 
     def test_get_virtual(self):
-        """ Test ProjectPackages get() virtual package"""
-        packages = ProjectPackages.get('pkg', self.config, self.staff, self.modules)
+        """Test ProjectPackages get() virtual package"""
+        packages = ProjectPackages.get("pkg", self.config, self.staff, self.modules)
         self.assertIsInstance(packages, list)
         self.assertEqual(len(packages), 1)
         self.assertIsInstance(packages[0], PackageVirtual)
-        self.assertEqual(packages[0].name, 'pkg')
+        self.assertEqual(packages[0].name, "pkg")
 
     def test_get_rpm(self):
-        """ Test ProjectPackages get() RPM package"""
-        self.fill_project_dir({'pkg': ['rpm']})
-        packages = ProjectPackages.get('pkg', self.config, self.staff, self.modules)
+        """Test ProjectPackages get() RPM package"""
+        self.fill_project_dir({"pkg": ["rpm"]})
+        packages = ProjectPackages.get("pkg", self.config, self.staff, self.modules)
         self.assertIsInstance(packages, list)
         self.assertEqual(len(packages), 1)
         self.assertIsInstance(packages[0], PackageRPM)
-        self.assertEqual(packages[0].name, 'pkg')
+        self.assertEqual(packages[0].name, "pkg")
 
     def test_get_oci(self):
-        """ Test ProjectPackages get() OCI package"""
-        self.fill_project_dir({'pkg': ['oci']})
-        packages = ProjectPackages.get('pkg', self.config, self.staff, self.modules)
+        """Test ProjectPackages get() OCI package"""
+        self.fill_project_dir({"pkg": ["oci"]})
+        packages = ProjectPackages.get("pkg", self.config, self.staff, self.modules)
         self.assertIsInstance(packages, list)
         self.assertEqual(len(packages), 1)
         self.assertIsInstance(packages[0], PackageOCI)
-        self.assertEqual(packages[0].name, 'pkg')
+        self.assertEqual(packages[0].name, "pkg")
 
     def test_get_multiformats(self):
-        """ Test ProjectPackages get() multiformats package"""
-        self.fill_project_dir({'pkg': ['rpm', 'oci']})
-        packages = ProjectPackages.get('pkg', self.config, self.staff, self.modules)
+        """Test ProjectPackages get() multiformats package"""
+        self.fill_project_dir({"pkg": ["rpm", "oci"]})
+        packages = ProjectPackages.get("pkg", self.config, self.staff, self.modules)
         self.assertIsInstance(packages, list)
         self.assertEqual(len(packages), 2)
         # Check there is one RPM and one OCI in list
-        self.assertEqual([isinstance(package, PackageRPM) for package in packages].count(True), 1)
-        self.assertEqual([isinstance(package, PackageOCI) for package in packages].count(True), 1)
+        self.assertEqual(
+            [isinstance(package, PackageRPM) for package in packages].count(True), 1
+        )
+        self.assertEqual(
+            [isinstance(package, PackageOCI) for package in packages].count(True), 1
+        )
         for package in packages:
-            self.assertEqual(package.name, 'pkg')
+            self.assertEqual(package.name, "pkg")

--- a/tests/package/rpm.py
+++ b/tests/package/rpm.py
@@ -2,26 +2,26 @@
 # Copyright (C) 2025 CEA
 #
 
-from unittest.mock import Mock, patch, ANY
 import os
 import textwrap
+from unittest.mock import ANY, Mock, patch
 
 from rift import RiftError
-from rift.package.rpm import PackageRPM, ActionableArchPackageRPM
+from rift.Config import _DEFAULT_VARIANT
+from rift.Gerrit import Review
+from rift.package.rpm import ActionableArchPackageRPM, PackageRPM
 from rift.repository import StagingRepository
 from rift.run import RunResult
 from rift.TestResults import TestResults
-from rift.Config import _DEFAULT_VARIANT
-from rift.Gerrit import Review
 
 from ..TestUtils import (
-    RiftProjectTestCase,
     PackageTestDef,
-    make_temp_file,
+    RiftProjectTestCase,
     gen_rpm_spec,
-    read_file,
-    nullcontext,
     host_rpmlint,
+    make_temp_file,
+    nullcontext,
+    read_file,
 )
 
 
@@ -29,21 +29,23 @@ class PackageRPMTest(RiftProjectTestCase):
     """
     Tests class for PackageRPM
     """
+
     def test_init(self):
-        """ Test PackageRPM initialisation """
-        pkgname = 'pkg'
+        """Test PackageRPM initialisation"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        self.assertEqual(pkg.format, 'rpm')
-        self.assertEqual(pkg.buildfile, '{0}/{1}.spec'.format(pkg.dir, pkgname))
+        self.assertEqual(pkg.format, "rpm")
+        self.assertEqual(pkg.buildfile, "{0}/{1}.spec".format(pkg.dir, pkgname))
         self.assertIsNone(pkg.ignore_rpms)
         self.assertIsNone(pkg.rpmnames)
         self.assertCountEqual(pkg.variants, [])
 
     def test_load(self):
-        """ Test PackageRPM information loading """
-        pkgname = 'pkg'
+        """Test PackageRPM information loading"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
@@ -58,7 +60,8 @@ class PackageRPMTest(RiftProjectTestCase):
                 variants:
                 - variant1
                 - variant2
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -70,25 +73,27 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        self.assertEqual(pkg.rpmnames, [ 'pkg', 'pkg-devel' ])
-        self.assertEqual(pkg.ignore_rpms, [ 'pkg-debuginfos' ])
-        self.assertCountEqual(pkg.variants, ['variant1', 'variant2'])
+            pkg.load(infopath=pkgfile.name)
+        self.assertEqual(pkg.rpmnames, ["pkg", "pkg-devel"])
+        self.assertEqual(pkg.ignore_rpms, ["pkg-debuginfos"])
+        self.assertCountEqual(pkg.variants, ["variant1", "variant2"])
 
     def test_check(self):
-        """ Test PackageRPM.check() does not fail with error """
-        pkgname = 'pkg'
+        """Test PackageRPM.check() does not fail with error"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -99,29 +104,31 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         # Create sources dir and source
-        sources_dir = os.path.join(pkg.dir, 'sources')
+        sources_dir = os.path.join(pkg.dir, "sources")
         os.makedirs(sources_dir)
-        with open(os.path.join(sources_dir, "pkg-1.0.tar.gz"), 'w+') as fh:
+        with open(os.path.join(sources_dir, "pkg-1.0.tar.gz"), "w+") as fh:
             fh.write("data")
         pkg.buildfile = spec_file.name
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec.return_value = open(spec_file.name).read()
-            pkg.load(infopath = pkgfile.name)
-        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+            pkg.load(infopath=pkgfile.name)
+        with patch.object(pkg.spec.mock, "rpmlint", host_rpmlint):
             pkg.check()
 
     def test_check_missing_source(self):
-        """ Test PackageRPM.check() detect missing source """
-        pkgname = 'pkg'
+        """Test PackageRPM.check() detect missing source"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -133,26 +140,29 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
-            with self.assertRaisesRegex(RiftError,
-                r'Missing source file\(s\): pkg-1.0.tar.gz'):
+            pkg.load(infopath=pkgfile.name)
+        with patch.object(pkg.spec.mock, "rpmlint", host_rpmlint):
+            with self.assertRaisesRegex(
+                RiftError, r"Missing source file\(s\): pkg-1.0.tar.gz"
+            ):
                 pkg.check()
 
     def test_check_unused_source(self):
-        """ Test PackageRPM.check() detect unused source """
-        pkgname = 'pkg'
+        """Test PackageRPM.check() detect unused source"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -163,41 +173,42 @@ class PackageRPMTest(RiftProjectTestCase):
             )
         )
         # Create sources dir, source and unused source
-        sources_dir = os.path.join(pkg.dir, 'sources')
+        sources_dir = os.path.join(pkg.dir, "sources")
         os.makedirs(sources_dir)
-        with open(os.path.join(sources_dir, 'pkg-1.0.tar.gz'), 'w+') as fh:
+        with open(os.path.join(sources_dir, "pkg-1.0.tar.gz"), "w+") as fh:
             fh.write("data")
-        with open(os.path.join(sources_dir, 'unused-1.0.tar.gz'), 'w+') as fh:
+        with open(os.path.join(sources_dir, "unused-1.0.tar.gz"), "w+") as fh:
             fh.write("data")
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
-            with self.assertRaisesRegex(RiftError,
-                r'Unused source file\(s\): unused-1.0.tar.gz'):
+            pkg.load(infopath=pkgfile.name)
+        with patch.object(pkg.spec.mock, "rpmlint", host_rpmlint):
+            with self.assertRaisesRegex(
+                RiftError, r"Unused source file\(s\): unused-1.0.tar.gz"
+            ):
                 pkg.check()
 
     def test_subpackages(self):
-        """ Test PackageRPM.subpackages() returns list of provides """
+        """Test PackageRPM.subpackages() returns list of provides"""
         self.make_pkg()
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             pkg.load()
-        self.assertCountEqual(pkg.subpackages(), ['pkg', 'pkg-provide'])
+        self.assertCountEqual(pkg.subpackages(), ["pkg", "pkg-provide"])
 
     def test_build_requires(self):
-        """ Test PackageRPM.build_requires() returns list of build requirements """
+        """Test PackageRPM.build_requires() returns list of build requirements"""
         self.make_pkg()
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             pkg.load()
-        self.assertCountEqual(pkg.build_requires(), ['br-package'])
+        self.assertCountEqual(pkg.build_requires(), ["br-package"])
 
     def test_build_requires_explicit_versions(self):
         """
@@ -205,29 +216,31 @@ class PackageRPMTest(RiftProjectTestCase):
         explicit versioning.
         """
         self.make_pkg(
-            build_requires=['lib1-devel', 'lib2-devel >= 3.4', 'lib3-devel < 6.0.0']
+            build_requires=["lib1-devel", "lib2-devel >= 3.4", "lib3-devel < 6.0.0"]
         )
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             pkg.load()
         self.assertCountEqual(
-            pkg.build_requires(), ['lib1-devel', 'lib2-devel', 'lib3-devel']
+            pkg.build_requires(), ["lib1-devel", "lib2-devel", "lib3-devel"]
         )
 
     def test_add_changelog_entry(self):
-        """ Test PackageRPM add changelog entry"""
-        pkgname = 'pkg'
+        """Test PackageRPM add changelog entry"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -239,27 +252,31 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
+            pkg.load(infopath=pkgfile.name)
         pkg.add_changelog_entry("Myself", "Package modification", False)
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        self.assertEqual(pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1")
+            pkg.load(infopath=pkgfile.name)
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-1"
+        )
 
     def test_add_changelog_entry_bump(self):
-        """ Test PackageRPM add changelog entry with release bump"""
-        pkgname = 'pkg'
+        """Test PackageRPM add changelog entry with release bump"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -271,27 +288,31 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
+            pkg.load(infopath=pkgfile.name)
         pkg.add_changelog_entry("Myself", "Package modification", True)
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        self.assertEqual(pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-2")
+            pkg.load(infopath=pkgfile.name)
+        self.assertEqual(
+            pkg.spec.changelog_name, "Myself <buddy@somewhere.org> - 1.0-2"
+        )
 
     def test_add_changelog_entry_unknown_maintainer(self):
-        """ Test PackageRPM add changelog entry with unknown maintainer """
-        pkgname = 'pkg'
+        """Test PackageRPM add changelog entry with unknown maintainer"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -303,40 +324,42 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
+            pkg.load(infopath=pkgfile.name)
         with self.assertRaisesRegex(
             RiftError, "Unknown maintainer Unknown, cannot be found in staff"
         ):
             pkg.add_changelog_entry("Unknown", "Package modification", False)
 
     def test_has_real_variants(self):
-        """ Test PackageRPM has_real_variants() """
-        pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        """Test PackageRPM has_real_variants()"""
+        pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         with self.assertRaises(AssertionError):
             pkg.has_real_variants()
         pkg.variants = [_DEFAULT_VARIANT]
         self.assertFalse(pkg.has_real_variants())
-        pkg.variants = ['variant1']
+        pkg.variants = ["variant1"]
         self.assertTrue(pkg.has_real_variants())
-        pkg.variants = [_DEFAULT_VARIANT, 'variant2']
+        pkg.variants = [_DEFAULT_VARIANT, "variant2"]
         self.assertTrue(pkg.has_real_variants())
-        pkg.variants = ['variant1', 'variant2']
+        pkg.variants = ["variant1", "variant2"]
         self.assertTrue(pkg.has_real_variants())
 
     def test_supports_arch_w_exclusive_arch(self):
-        """ Test PackageRPM supports_arch() method with ExclusiveArch"""
-        pkgname = 'pkg'
+        """Test PackageRPM supports_arch() method with ExclusiveArch"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -348,24 +371,26 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        self.assertTrue(pkg.supports_arch('x86_64'))
-        self.assertFalse(pkg.supports_arch('aarch64'))
+            pkg.load(infopath=pkgfile.name)
+        self.assertTrue(pkg.supports_arch("x86_64"))
+        self.assertFalse(pkg.supports_arch("aarch64"))
 
     def test_supports_arch_wo_exclusive_arch(self):
-        """ Test PackageRPM supports_arch() method without ExclusiveArch"""
-        pkgname = 'pkg'
+        """Test PackageRPM supports_arch() method without ExclusiveArch"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -376,24 +401,26 @@ class PackageRPMTest(RiftProjectTestCase):
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
-        self.assertTrue(pkg.supports_arch('x86_64'))
-        self.assertTrue(pkg.supports_arch('aarch64'))
+            pkg.load(infopath=pkgfile.name)
+        self.assertTrue(pkg.supports_arch("x86_64"))
+        self.assertTrue(pkg.supports_arch("aarch64"))
 
     def test_analyze(self):
-        """ Test PackageRPM analyze success """
-        pkgname = 'pkg'
+        """Test PackageRPM analyze success"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         spec_file = make_temp_file(
             gen_rpm_spec(
                 name=pkgname,
@@ -401,30 +428,32 @@ class PackageRPMTest(RiftProjectTestCase):
                 release="1",
                 arch="x86_64",
             ),
-            suffix='.spec'
+            suffix=".spec",
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
+            pkg.load(infopath=pkgfile.name)
         review = Mock(spec=Review)
-        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+        with patch.object(pkg.spec.mock, "rpmlint", host_rpmlint):
             pkg.analyze(review, pkg.dir)
         review.invalidate.assert_not_called()
 
     def test_analyze_invalidate(self):
-        """ Test PackageRPM analyze failure """
-        pkgname = 'pkg'
+        """Test PackageRPM analyze failure"""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkgfile = make_temp_file(textwrap.dedent("""
+        pkgfile = make_temp_file(
+            textwrap.dedent("""
             package:
                 maintainers:
                 - Myself
                 module: Great module
                 reason: Missing package
                 origin: Company
-            """))
+            """)
+        )
         # Use $$RPM_SOURCE_DIR and $RPM_BUILD_ROOT in build steps in order to
         # produce error in both rpmlint v1 and v2.
         spec_file = make_temp_file(
@@ -435,57 +464,54 @@ class PackageRPMTest(RiftProjectTestCase):
                 arch="x86_64",
                 buildsteps="$RPM_SOURCE_DIR\n$RPM_BUILD_ROOT",
             ),
-            suffix='.spec'
+            suffix=".spec",
         )
         pkg.buildfile = spec_file.name
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
-            pkg.load(infopath = pkgfile.name)
+            pkg.load(infopath=pkgfile.name)
         review = Mock(spec=Review)
-        with patch.object(pkg.spec.mock, 'rpmlint', host_rpmlint):
+        with patch.object(pkg.spec.mock, "rpmlint", host_rpmlint):
             pkg.analyze(review, pkg.dir)
         review.invalidate.assert_called_once()
 
     def test_for_arch(self):
-        """ Test PackageRPM for_arch() returns ActionableArchPackageRPM object. """
-        pkgname = 'pkg'
+        """Test PackageRPM for_arch() returns ActionableArchPackageRPM object."""
+        pkgname = "pkg"
         pkg = PackageRPM(pkgname, self.config, self.staff, self.modules)
-        pkg_arch = pkg.for_arch('x86_64')
+        pkg_arch = pkg.for_arch("x86_64")
         self.assertIsInstance(pkg_arch, ActionableArchPackageRPM)
         self.assertEqual(pkg_arch.name, pkg.name)
         self.assertEqual(pkg_arch.buildfile, pkg.buildfile)
         self.assertEqual(pkg_arch.config, pkg._config)
         self.assertEqual(pkg_arch.package, pkg)
-        self.assertEqual(pkg_arch.arch, 'x86_64')
+        self.assertEqual(pkg_arch.arch, "x86_64")
 
 
 class ActionableArchPackageRPMTest(RiftProjectTestCase):
     """
     Tests class for ActionableArchPackageRPM
     """
+
     def setup_package(self, variants=None, tests=None):
         self.make_pkg(variants=variants, tests=tests)
-        _pkg = PackageRPM('pkg', self.config, self.staff, self.modules)
+        _pkg = PackageRPM("pkg", self.config, self.staff, self.modules)
         # mock Mock.read_spec to return spec file content directly read on host
-        with patch('rift.package.rpm.Mock') as mock_mock:
+        with patch("rift.package.rpm.Mock") as mock_mock:
             mock_mock.return_value.read_spec = read_file
             _pkg.load()
-        self.pkg = ActionableArchPackageRPM(_pkg, 'x86_64')
+        self.pkg = ActionableArchPackageRPM(_pkg, "x86_64")
         self.pkg.mock.read_spec = read_file
 
-    @patch('rift.package.rpm.message')
-    @patch('rift.package.rpm.Mock.build_rpms')
-    @patch('rift.package.rpm.Mock.build_srpm')
-    @patch('rift.package.rpm.Mock.init')
+    @patch("rift.package.rpm.message")
+    @patch("rift.package.rpm.Mock.build_rpms")
+    @patch("rift.package.rpm.Mock.build_srpm")
+    @patch("rift.package.rpm.Mock.init")
     def test_build(
-        self,
-        mock_mock_init,
-        mock_mock_build_srpm,
-        mock_mock_build_rpms,
-        mock_message
+        self, mock_mock_init, mock_mock_build_srpm, mock_mock_build_rpms, mock_message
     ):
-        """ Test ActionableArchPackageRPM build """
+        """Test ActionableArchPackageRPM build"""
         self.setup_package()
         self.pkg.build()
         # Check build() has called expected Mock methods.
@@ -496,11 +522,13 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         )
         mock_message.assert_any_call("Building RPMS...")
 
-    @patch('rift.package.rpm.Mock.build_rpms')
-    @patch('rift.package.rpm.Mock.build_srpm')
-    @patch('rift.package.rpm.Mock.init')
-    def test_build_sign(self, mock_mock_init, mock_mock_build_srpm, mock_mock_build_rpms):
-        """ Test ActionableArchPackageRPM build with sign enabled"""
+    @patch("rift.package.rpm.Mock.build_rpms")
+    @patch("rift.package.rpm.Mock.build_srpm")
+    @patch("rift.package.rpm.Mock.init")
+    def test_build_sign(
+        self, mock_mock_init, mock_mock_build_srpm, mock_mock_build_rpms
+    ):
+        """Test ActionableArchPackageRPM build with sign enabled"""
         self.setup_package()
         self.pkg.build(sign=True)
         # Check build() has called expected Mock methods.
@@ -510,28 +538,30 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
             mock_mock_build_srpm.return_value, _DEFAULT_VARIANT, self.pkg.repos, True
         )
 
-    @patch('rift.package.rpm.Mock.build_rpms')
-    @patch('rift.package.rpm.Mock.build_srpm')
-    @patch('rift.package.rpm.Mock.init')
-    def test_build_staging(self, mock_mock_init, mock_mock_build_srpm, mock_mock_build_rpms):
-        """ Test ActionableArchPackageRPM build with staging repository"""
+    @patch("rift.package.rpm.Mock.build_rpms")
+    @patch("rift.package.rpm.Mock.build_srpm")
+    @patch("rift.package.rpm.Mock.init")
+    def test_build_staging(
+        self, mock_mock_init, mock_mock_build_srpm, mock_mock_build_rpms
+    ):
+        """Test ActionableArchPackageRPM build with staging repository"""
         self.setup_package()
         staging = StagingRepository(self.config)
         self.pkg.build(staging=staging)
         staging.delete()
         # Check build() has called expected Mock methods.
         mock_mock_init.assert_called_once_with(
-            [staging.for_format('rpm').repo.consumables['x86_64']]
+            [staging.for_format("rpm").repo.consumables["x86_64"]]
         )
         mock_mock_build_srpm.assert_called_once()
         mock_mock_build_rpms.assert_any_call(
             mock_mock_build_srpm.return_value, _DEFAULT_VARIANT, self.pkg.repos, False
         )
 
-    @patch('rift.package.rpm.message')
-    @patch('rift.package.rpm.Mock.build_rpms')
-    @patch('rift.package.rpm.Mock.build_srpm')
-    @patch('rift.package.rpm.Mock.init')
+    @patch("rift.package.rpm.message")
+    @patch("rift.package.rpm.Mock.build_rpms")
+    @patch("rift.package.rpm.Mock.build_srpm")
+    @patch("rift.package.rpm.Mock.init")
     def test_build_multiple_variants(
         self,
         mock_mock_init,
@@ -539,8 +569,8 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         mock_mock_build_rpms,
         mock_message,
     ):
-        """ Test ActionableArchPackageRPM build with multiple variants"""
-        variants = ['variant1', 'variant2']
+        """Test ActionableArchPackageRPM build with multiple variants"""
+        variants = ["variant1", "variant2"]
         self.setup_package(variants=variants)
         self.pkg.package.variants = variants
         self.pkg.build()
@@ -553,20 +583,21 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
             )
             mock_message.assert_any_call(f"Building RPMS variant {variant}...")
 
-    @patch('rift.package.rpm.Mock.clean')
-    @patch('rift.package.rpm.Mock.init')
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.Mock.clean")
+    @patch("rift.package.rpm.Mock.init")
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_local(
         self, mock_vm, mock_time_sleep, mock_mock_init, mock_mock_clean
     ):
-        """ Test ActionableArchPackageRPM local test """
+        """Test ActionableArchPackageRPM local test"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
         mock_vm_obj.run_test.return_value = RunResult(0, None, None)
         self.setup_package(
-            tests=[PackageTestDef(name='0_test.sh', local=True, formats=[])])
+            tests=[PackageTestDef(name="0_test.sh", local=True, formats=[])]
+        )
         self.pkg.run_local_test = Mock(return_value=RunResult(0, None, None))
         results = self.pkg.test()
         self.assertIsInstance(results, TestResults)
@@ -579,15 +610,15 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # Check VM is stopped after the tests
         mock_vm_obj.stop.assert_called_once()
 
-    @patch('rift.package.rpm.Mock.clean')
-    @patch('rift.package.rpm.Mock.init')
-    @patch('rift.package.rpm.banner')
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.Mock.clean")
+    @patch("rift.package.rpm.Mock.init")
+    @patch("rift.package.rpm.banner")
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_vm(
         self, mock_vm, mock_time_sleep, mock_banner, mock_mock_init, mock_mock_clean
     ):
-        """ Test ActionableArchPackageRPM test in VM """
+        """Test ActionableArchPackageRPM test in VM"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -601,24 +632,24 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # Check run_local_test() has not been called.
         self.pkg.run_local_test.assert_not_called()
         # Check VM initialized (w/o extra repository)
-        mock_vm.assert_called_once_with(self.config, 'x86_64', extra_repos=[])
+        mock_vm.assert_called_once_with(self.config, "x86_64", extra_repos=[])
         # Check VM run_test() called once for basic test
         mock_vm_obj.run_test.assert_called_once_with(ANY, _DEFAULT_VARIANT)
         # Check VM is stopped after the tests
         mock_vm_obj.stop.assert_called_once()
         mock_banner.assert_called_once_with(
-            'Starting tests of package pkg on architecture x86_64'
+            "Starting tests of package pkg on architecture x86_64"
         )
 
-    @patch('rift.package.rpm.Mock.clean')
-    @patch('rift.package.rpm.Mock.init')
-    @patch('rift.package.rpm.banner')
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.Mock.clean")
+    @patch("rift.package.rpm.Mock.init")
+    @patch("rift.package.rpm.banner")
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_staging(
         self, mock_vm, mock_time_sleep, mock_banner, mock_mock_init, mock_mock_clean
     ):
-        """ Test ActionableArchPackageRPM test with staging repository """
+        """Test ActionableArchPackageRPM test with staging repository"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -633,20 +664,20 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # Check VM initialized with staging extra repository
         mock_vm.assert_called_once_with(
             self.config,
-            'x86_64',
-            extra_repos=[staging.for_format('rpm').repo.consumables['x86_64']]
+            "x86_64",
+            extra_repos=[staging.for_format("rpm").repo.consumables["x86_64"]],
         )
         # Check VM is stopped after the tests
         mock_vm_obj.stop.assert_called_once()
         mock_banner.assert_called_once_with(
-            'Starting tests of package pkg on architecture x86_64'
+            "Starting tests of package pkg on architecture x86_64"
         )
 
-    @patch('rift.package.rpm.Mock.clean')
-    @patch('rift.package.rpm.Mock.init')
-    @patch('rift.package.rpm.banner')
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.Mock.clean")
+    @patch("rift.package.rpm.Mock.init")
+    @patch("rift.package.rpm.banner")
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_vm_multiple_variants(
         self,
         mock_vm,
@@ -655,8 +686,8 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         mock_mock_init,
         mock_mock_clean,
     ):
-        """ Test ActionableArchPackageRPM test with multiple variants """
-        variants = ['variant1', 'variant2']
+        """Test ActionableArchPackageRPM test with multiple variants"""
+        variants = ["variant1", "variant2"]
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -681,10 +712,10 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # Check VM is stopped after the tests
         mock_vm_obj.stop.assert_called_once()
 
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_vm_running(self, mock_vm, mock_time_sleep):
-        """ Test ActionableArchPackageRPM test error VM running """
+        """Test ActionableArchPackageRPM test error VM running"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = True
@@ -692,10 +723,10 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         with self.assertRaisesRegex(RiftError, "^VM is already running$"):
             self.pkg.test()
 
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_failure(self, mock_vm, mock_time_sleep):
-        """ Test ActionableArchPackageRPM test failure """
+        """Test ActionableArchPackageRPM test failure"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -704,16 +735,16 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # mock Mock.read_spec() so BasicTest can extract rpm packages from spec file
         self.pkg.mock = Mock()
         self.pkg.mock.lock.return_value = nullcontext()
-        self.pkg.mock.read_spec.return_value = open(self.buildfiles['pkg:rpm']).read()
+        self.pkg.mock.read_spec.return_value = open(self.buildfiles["pkg:rpm"]).read()
         results = self.pkg.test()
         self.assertIsInstance(results, TestResults)
         self.assertEqual(len(results), 2)
         self.assertEqual(results.global_result, False)
 
-    @patch('rift.package.rpm.time.sleep')
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.time.sleep")
+    @patch("rift.package.rpm.VM")
     def test_test_noauto(self, mock_vm, mock_time_sleep):
-        """ Test ActionableArchPackageRPM test noauto """
+        """Test ActionableArchPackageRPM test noauto"""
         # mock time.sleep() to avoid waiting sleep timeout when VM is stopped
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
@@ -724,9 +755,9 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         self.assertEqual(len(results), 0)
         self.assertEqual(results.global_result, True)
 
-    @patch('rift.package.rpm.VM')
+    @patch("rift.package.rpm.VM")
     def test_test_noquit(self, mock_vm):
-        """ Test ActionableArchPackageRPM test noquit """
+        """Test ActionableArchPackageRPM test noquit"""
         mock_vm_obj = mock_vm.return_value
         mock_vm_obj.running.return_value = False
         mock_vm_obj.run_test.return_value = RunResult(0, None, None)
@@ -734,14 +765,14 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # mock Mock.read_spec() so BasicTest can extract rpm packages from spec file
         self.pkg.mock = Mock()
         self.pkg.mock.lock.return_value = nullcontext()
-        self.pkg.mock.read_spec.return_value = open(self.buildfiles['pkg:rpm']).read()
+        self.pkg.mock.read_spec.return_value = open(self.buildfiles["pkg:rpm"]).read()
         self.pkg.test(noquit=True)
         # Check VM is NOT stopped after the tests
         mock_vm_obj.stop.assert_not_called()
 
-    @patch('rift.package.rpm.Mock.publish')
+    @patch("rift.package.rpm.Mock.publish")
     def test_publish_working_repo(self, mock_mock_publish):
-        """ Test ActionableArchPackageRPM publish in working repository """
+        """Test ActionableArchPackageRPM publish in working repository"""
         mock_repository = Mock()
         self.setup_package()
         self.pkg.repos.working = mock_repository
@@ -749,18 +780,18 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         mock_mock_publish.assert_called_once_with(mock_repository)
         mock_repository.update.assert_called_once()
 
-    @patch('rift.package.rpm.Mock.publish')
+    @patch("rift.package.rpm.Mock.publish")
     def test_publish_staging_repo(self, mock_mock_publish):
-        """ Test ActionableArchPackageRPM publish in staging repository """
+        """Test ActionableArchPackageRPM publish in staging repository"""
         mock_staging_repo = Mock()
         self.setup_package()
         self.pkg.publish(staging=mock_staging_repo)
         mock_mock_publish.assert_called_once_with(mock_staging_repo.for_format().repo)
         mock_staging_repo.for_format().repo.update.assert_called_once()
 
-    @patch('rift.package.rpm.Mock.publish')
+    @patch("rift.package.rpm.Mock.publish")
     def test_publish_no_update(self, mock_mock_publish):
-        """ Test ActionableArchPackageRPM publish """
+        """Test ActionableArchPackageRPM publish"""
         mock_repository = Mock()
         self.setup_package()
         self.pkg.repos.working = mock_repository
@@ -769,9 +800,9 @@ class ActionableArchPackageRPMTest(RiftProjectTestCase):
         # Check repo is NOT uppdated
         mock_repository.update.assert_not_called()
 
-    @patch('rift.package.rpm.Mock.clean')
+    @patch("rift.package.rpm.Mock.clean")
     def test_clean(self, mock_mock_clean):
-        """ Test ActionableArchPackageRPM clean """
+        """Test ActionableArchPackageRPM clean"""
         self.setup_package()
         self.pkg.clean()
         # Check clean() has called expected Mock method.

--- a/tests/patches.py
+++ b/tests/patches.py
@@ -33,16 +33,16 @@
 import os
 import textwrap
 
-from .TestUtils import make_temp_file, RiftProjectTestCase
-
 from rift import RiftError
 from rift.patches import get_packages_from_patch
 
-class PatchTest(RiftProjectTestCase):
+from .TestUtils import RiftProjectTestCase, make_temp_file
 
+
+class PatchTest(RiftProjectTestCase):
     def test_package_rpm_modified(self):
-        """ Test detect modified RPM package in patch"""
-        self.make_pkg('pkg')
+        """Test detect modified RPM package in patch"""
+        self.make_pkg("pkg")
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkg/pkg.spec
@@ -65,19 +65,20 @@ class PatchTest(RiftProjectTestCase):
                  # Nothing to build
                  %install
                  # Nothing to install
-                """))
+                """)
+        )
         with open(patch.name) as p:
             (updated, removed) = get_packages_from_patch(
                 p, self.config, self.modules, self.staff
             )
             self.assertEqual(len(updated), 1)
             self.assertEqual(len(removed), 0)
-            self.assertEqual(updated[0].name, 'pkg')
-            self.assertEqual(updated[0].format, 'rpm')
+            self.assertEqual(updated[0].name, "pkg")
+            self.assertEqual(updated[0].format, "rpm")
 
     def test_package_oci_modified(self):
-        """ Test detect modified OCI package in patch"""
-        self.make_pkg('pkg')
+        """Test detect modified OCI package in patch"""
+        self.make_pkg("pkg")
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/Containerfile b/packages/pkg/Containerfile
@@ -100,19 +101,20 @@ class PatchTest(RiftProjectTestCase):
                          version: 1.0
                 -        release: 1
                 +        release: 2
-                """))
+                """)
+        )
         with open(patch.name) as p:
             (updated, removed) = get_packages_from_patch(
                 p, self.config, self.modules, self.staff
             )
             self.assertEqual(len(updated), 1)
             self.assertEqual(len(removed), 0)
-            self.assertEqual(updated[0].name, 'pkg')
-            self.assertEqual(updated[0].format, 'oci')
+            self.assertEqual(updated[0].name, "pkg")
+            self.assertEqual(updated[0].format, "oci")
 
     def test_package_multiformats_modified(self):
-        """ Test detect modified multiformats package in patch"""
-        self.make_pkg('pkg')
+        """Test detect modified multiformats package in patch"""
+        self.make_pkg("pkg")
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/Containerfile b/packages/pkg/Containerfile
@@ -155,7 +157,8 @@ class PatchTest(RiftProjectTestCase):
                  # Nothing to build
                  %install
                  # Nothing to install
-                """))
+                """)
+        )
         with open(patch.name) as p:
             (updated, removed) = get_packages_from_patch(
                 p, self.config, self.modules, self.staff
@@ -163,18 +166,21 @@ class PatchTest(RiftProjectTestCase):
             self.assertEqual(len(updated), 2)
             self.assertEqual(len(removed), 0)
             for package in updated:
-                self.assertEqual(package.name, 'pkg')
+                self.assertEqual(package.name, "pkg")
             self.assertCountEqual(
-                [package.format for package in updated], ['rpm', 'oci'])
+                [package.format for package in updated], ["rpm", "oci"]
+            )
 
     def test_package_rpm_removed(self):
-        """ Test detect removed RPM package in patch"""
-        pkgname = 'pkg'
+        """Test detect removed RPM package in patch"""
+        pkgname = "pkg"
         pkgvers = 1.0
-        pkgsrc = os.path.join('packages', pkgname, 'sources',
-                              '{0}-{1}.tar.gz'.format(pkgname, pkgvers))
+        pkgsrc = os.path.join(
+            "packages", pkgname, "sources", "{0}-{1}.tar.gz".format(pkgname, pkgvers)
+        )
         patch = make_temp_file(
-            textwrap.dedent("""
+            textwrap.dedent(
+                """
                 diff --git a/packages/pkg/info.yaml b/packages/pkg/info.yaml
                 deleted file mode 100644
                 index 32ac08e..0000000
@@ -225,7 +231,9 @@ class PatchTest(RiftProjectTestCase):
                 @@ -1 +0,0 @@
                 -ACACACACACACACAC
                 \ No newline at end of file
-                """.format(pkgsrc)))
+                """.format(pkgsrc)
+            )
+        )
 
         with open(patch.name) as p:
             (updated, removed) = get_packages_from_patch(
@@ -233,17 +241,19 @@ class PatchTest(RiftProjectTestCase):
             )
             self.assertEqual(len(updated), 0)
             self.assertEqual(len(removed), 1)
-            self.assertEqual(removed[0].name, 'pkg')
-            self.assertEqual(removed[0].format, '_virtual')
+            self.assertEqual(removed[0].name, "pkg")
+            self.assertEqual(removed[0].format, "_virtual")
 
     def test_package_oci_removed(self):
-        """ Test detect removed OCI package in patch"""
-        pkgname = 'pkg'
+        """Test detect removed OCI package in patch"""
+        pkgname = "pkg"
         pkgvers = 1.0
-        pkgsrc = os.path.join('packages', pkgname, 'sources',
-                              '{0}-{1}.tar.gz'.format(pkgname, pkgvers))
+        pkgsrc = os.path.join(
+            "packages", pkgname, "sources", "{0}-{1}.tar.gz".format(pkgname, pkgvers)
+        )
         patch = make_temp_file(
-            textwrap.dedent("""
+            textwrap.dedent(
+                """
                 diff --git a/packages/pkg/Containerfile b/packages/pkg/Containerfile
                 deleted file mode 100644
                 index b3c1dc24..00000000
@@ -279,7 +289,9 @@ class PatchTest(RiftProjectTestCase):
                 @@ -1 +0,0 @@
                 -ACACACACACACACAC
                 \ No newline at end of file
-                """.format(pkgsrc)))
+                """.format(pkgsrc)
+            )
+        )
 
         with open(patch.name) as p:
             (updated, removed) = get_packages_from_patch(
@@ -287,17 +299,19 @@ class PatchTest(RiftProjectTestCase):
             )
             self.assertEqual(len(updated), 0)
             self.assertEqual(len(removed), 1)
-            self.assertEqual(removed[0].name, 'pkg')
-            self.assertEqual(removed[0].format, '_virtual')
+            self.assertEqual(removed[0].name, "pkg")
+            self.assertEqual(removed[0].format, "_virtual")
 
     def test_package_multiformats_removed(self):
-        """ Test detect removed multiformats package in patch"""
-        pkgname = 'pkg'
+        """Test detect removed multiformats package in patch"""
+        pkgname = "pkg"
         pkgvers = 1.0
-        pkgsrc = os.path.join('packages', pkgname, 'sources',
-                              '{0}-{1}.tar.gz'.format(pkgname, pkgvers))
+        pkgsrc = os.path.join(
+            "packages", pkgname, "sources", "{0}-{1}.tar.gz".format(pkgname, pkgvers)
+        )
         patch = make_temp_file(
-            textwrap.dedent("""
+            textwrap.dedent(
+                """
                 diff --git a/packages/pkg/Containerfile b/packages/pkg/Containerfile
                 deleted file mode 100644
                 index b3c1dc24..00000000
@@ -363,7 +377,9 @@ class PatchTest(RiftProjectTestCase):
                 @@ -1 +0,0 @@
                 -ACACACACACACACAC
                 \ No newline at end of file
-                """.format(pkgsrc)))
+                """.format(pkgsrc)
+            )
+        )
 
         with open(patch.name) as p:
             (updated, removed) = get_packages_from_patch(
@@ -371,11 +387,11 @@ class PatchTest(RiftProjectTestCase):
             )
             self.assertEqual(len(updated), 0)
             self.assertEqual(len(removed), 1)
-            self.assertEqual(removed[0].name, 'pkg')
-            self.assertEqual(removed[0].format, '_virtual')
+            self.assertEqual(removed[0].name, "pkg")
+            self.assertEqual(removed[0].format, "_virtual")
 
     def test_tests_directory(self):
-        """ Test if package tests directory structure is fine """
+        """Test if package tests directory structure is fine"""
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/tests/sources/deep/source.c b/packages/pkg/tests/sources/deep/source.c
@@ -389,18 +405,21 @@ class PatchTest(RiftProjectTestCase):
                 +    exit(0);
                 +}
                 \ No newline at end of file
-                """))
+                """)
+        )
         # Ensure package exists
-        self.make_pkg('pkg')
-        with open(patch.name, 'r') as f:
+        self.make_pkg("pkg")
+        with open(patch.name, "r") as f:
             (updated, removed) = get_packages_from_patch(
                 f, self.config, self.modules, self.staff
             )
             self.assertEqual(len(updated), 2)
             self.assertEqual(len(removed), 0)
             for package in updated:
-                self.assertEqual(package.name, 'pkg')
-            self.assertCountEqual([package.format for package in updated], ['rpm', 'oci'])
+                self.assertEqual(package.name, "pkg")
+            self.assertCountEqual(
+                [package.format for package in updated], ["rpm", "oci"]
+            )
 
     def test_invalid_file(self):
         """Test invalid project file is detected in patch"""
@@ -419,13 +438,11 @@ class PatchTest(RiftProjectTestCase):
                 +++ b/wrong
                 @@ -0,0 +1 @@
                 +README
-                """))
-        with open(patch.name, 'r') as f:
-            with self.assertRaisesRegex(RiftError,
-                                        "Unknown file pattern: wrong"):
-                get_packages_from_patch(
-                    f, self.config, self.modules, self.staff
-                )
+                """)
+        )
+        with open(patch.name, "r") as f:
+            with self.assertRaisesRegex(RiftError, "Unknown file pattern: wrong"):
+                get_packages_from_patch(f, self.config, self.modules, self.staff)
 
     def test_invalid_pkg_file(self):
         """Test invalid package file is detected in patch"""
@@ -444,14 +461,13 @@ class PatchTest(RiftProjectTestCase):
                 +++ b/packages/pkg/wrong
                 @@ -0,0 +1 @@
                 +README
-                """))
-        with open(patch.name, 'r') as f:
+                """)
+        )
+        with open(patch.name, "r") as f:
             with self.assertRaisesRegex(
-                RiftError,
-                "Unknown file pattern in 'pkg' directory: packages/pkg/wrong"):
-                get_packages_from_patch(
-                    f, self.config, self.modules, self.staff
-                )
+                RiftError, "Unknown file pattern in 'pkg' directory: packages/pkg/wrong"
+            ):
+                get_packages_from_patch(f, self.config, self.modules, self.staff)
 
     def test_info(self):
         patch = make_temp_file(
@@ -474,11 +490,12 @@ class PatchTest(RiftProjectTestCase):
                 -  origin: Somewhere
                 +  origin: Elsewhere
                    reason: Missing feature
-                """))
+                """)
+        )
         self.make_pkg()
         # For this patch, get_packages_from_patch() must not return updated nor
         # removed packages.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
@@ -503,10 +520,11 @@ class PatchTest(RiftProjectTestCase):
                 +modules:
                 +  User Tools:
                 +    manager: John Doe
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must not return updated nor
         # removed packages.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
@@ -514,7 +532,7 @@ class PatchTest(RiftProjectTestCase):
         self.assertEqual(len(removed), 0)
 
     def test_readme(self):
-        """ Should allow README files """
+        """Should allow README files"""
         self.make_pkg()
         patch_template = textwrap.dedent("""
             commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
@@ -532,12 +550,12 @@ class PatchTest(RiftProjectTestCase):
             +README
             """)
 
-        for fmt in '', 'rst', 'md', 'txt':
-            filename = 'README'
+        for fmt in "", "rst", "md", "txt":
+            filename = "README"
             if fmt:
                 filename = "{0}.{1}".format(filename, fmt)
             patch = make_temp_file(patch_template.format(filename))
-            with open(patch.name, 'r') as f:
+            with open(patch.name, "r") as f:
                 (updated, removed) = get_packages_from_patch(
                     f, self.config, self.modules, self.staff
                 )
@@ -545,14 +563,16 @@ class PatchTest(RiftProjectTestCase):
                 self.assertEqual(len(removed), 0)
 
     def test_binary(self):
-        """ Should fail if source file is a binary file """
-        pkgname = 'pkg'
+        """Should fail if source file is a binary file"""
+        pkgname = "pkg"
         pkgvers = 1.0
         self.make_pkg(name=pkgname, version=pkgvers)
-        pkgsrc = os.path.join('packages', 'pkgname', 'sources',
-                              '{0}-{1}.tar.gz'.format(pkgname, pkgvers))
+        pkgsrc = os.path.join(
+            "packages", "pkgname", "sources", "{0}-{1}.tar.gz".format(pkgname, pkgvers)
+        )
         patch = make_temp_file(
-            textwrap.dedent("""
+            textwrap.dedent(
+                """
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
@@ -562,24 +582,26 @@ class PatchTest(RiftProjectTestCase):
                 diff --git /dev/null b/{0}
                 index fcd49dd..91ef207 100644
                 Binary files a/sources/a.tar.gz and b/sources/a.tar.gz differ
-                """.format(pkgsrc)))
-        with open(patch.name, 'r') as f:
+                """.format(pkgsrc)
+            )
+        )
+        with open(patch.name, "r") as f:
             with self.assertRaisesRegex(
-                RiftError,
-                "Binary file detected: {0}".format(pkgsrc)):
-                get_packages_from_patch(
-                    f, self.config, self.modules, self.staff
-                )
+                RiftError, "Binary file detected: {0}".format(pkgsrc)
+            ):
+                get_packages_from_patch(f, self.config, self.modules, self.staff)
 
     def test_binary_with_content(self):
-        """ Should fail if source file is a binary file (diff --binary) """
-        pkgname = 'pkg'
+        """Should fail if source file is a binary file (diff --binary)"""
+        pkgname = "pkg"
         pkgvers = 1.0
         self.make_pkg(name=pkgname, version=pkgvers)
-        pkgsrc = os.path.join('packages', 'pkgname', 'sources',
-                              '{0}-{1}.tar.gz'.format(pkgname, pkgvers))
+        pkgsrc = os.path.join(
+            "packages", "pkgname", "sources", "{0}-{1}.tar.gz".format(pkgname, pkgvers)
+        )
         patch = make_temp_file(
-            textwrap.dedent("""
+            textwrap.dedent(
+                """
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
@@ -594,18 +616,20 @@ class PatchTest(RiftProjectTestCase):
                 
                 literal 4
                 LcmZQ%;Sc}}-05kv|
-                """.format(pkgsrc)))
-        with open(patch.name, 'r') as f:
-            with self.assertRaisesRegex(RiftError, "Binary file detected: {0}".format(pkgsrc)):
-                get_packages_from_patch(
-                    f, self.config, self.modules, self.staff
-                )
+                """.format(pkgsrc)
+            )
+        )
+        with open(patch.name, "r") as f:
+            with self.assertRaisesRegex(
+                RiftError, "Binary file detected: {0}".format(pkgsrc)
+            ):
+                get_packages_from_patch(f, self.config, self.modules, self.staff)
 
     def test_rename_rpm_package(self):
-        """ Test if renaming RPM package trigger a build """
-        pkgname = 'pkgnew'
+        """Test if renaming RPM package trigger a build"""
+        pkgname = "pkgnew"
         pkgvers = 1.0
-        self.make_pkg(name=pkgname, version=pkgvers, formats=['rpm'])
+        self.make_pkg(name=pkgname, version=pkgvers, formats=["rpm"])
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/pkg.spec b/packages/pkgnew/pkgnew.spec
@@ -620,23 +644,24 @@ class PatchTest(RiftProjectTestCase):
                 similarity index 100%
                 rename from packages/pkg/sources/pkg-1.0.tar.gz
                 rename to packages/pkgnew/sources/pkgnew-1.0.tar.gz
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must return an updated
         # RPM package named pkgnew.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
         self.assertEqual(len(updated), 1)
         self.assertEqual(len(removed), 0)
-        self.assertEqual(updated[0].name, 'pkgnew')
-        self.assertEqual(updated[0].format, 'rpm')
+        self.assertEqual(updated[0].name, "pkgnew")
+        self.assertEqual(updated[0].format, "rpm")
 
     def test_rename_oci_package(self):
-        """ Test if renaming OCI package trigger a build """
-        pkgname = 'pkgnew'
+        """Test if renaming OCI package trigger a build"""
+        pkgname = "pkgnew"
         pkgvers = 1.0
-        self.make_pkg(name=pkgname, version=pkgvers, formats=['oci'])
+        self.make_pkg(name=pkgname, version=pkgvers, formats=["oci"])
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/Containerfile b/packages/pkgnew/Containerfile
@@ -651,21 +676,22 @@ class PatchTest(RiftProjectTestCase):
                 similarity index 100%
                 rename from packages/pkg/sources/pkg-1.0.tar.gz
                 rename to packages/pkgnew/sources/pkg-1.0.tar.gz
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must return an updated
         # OCI package named pkgnew.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
         self.assertEqual(len(updated), 1)
         self.assertEqual(len(removed), 0)
-        self.assertEqual(updated[0].name, 'pkgnew')
-        self.assertEqual(updated[0].format, 'oci')
+        self.assertEqual(updated[0].name, "pkgnew")
+        self.assertEqual(updated[0].format, "oci")
 
     def test_rename_multiformats_package(self):
-        """ Test if renaming multiformats package trigger a build """
-        pkgname = 'pkgnew'
+        """Test if renaming multiformats package trigger a build"""
+        pkgname = "pkgnew"
         pkgvers = 1.0
         self.make_pkg(name=pkgname, version=pkgvers)
         patch = make_temp_file(
@@ -686,24 +712,25 @@ class PatchTest(RiftProjectTestCase):
                 similarity index 100%
                 rename from packages/pkg/sources/pkg-1.0.tar.gz
                 rename to packages/pkgnew/sources/pkg-1.0.tar.gz
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must return updated RPM and
         # OCI packages named pkgnew.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
         self.assertEqual(len(updated), 2)
         self.assertEqual(len(removed), 0)
         for package in updated:
-            self.assertEqual(package.name, 'pkgnew')
-        self.assertCountEqual([package.format for package in updated], ['rpm', 'oci'])
+            self.assertEqual(package.name, "pkgnew")
+        self.assertCountEqual([package.format for package in updated], ["rpm", "oci"])
 
     def test_rename_and_update_rpm_package(self):
-        """ Test if renaming and updating RPM package trigger a build """
-        pkgname = 'pkgnew'
+        """Test if renaming and updating RPM package trigger a build"""
+        pkgname = "pkgnew"
         pkgvers = 1.0
-        self.make_pkg(name=pkgname, version=pkgvers, formats=['rpm'])
+        self.make_pkg(name=pkgname, version=pkgvers, formats=["rpm"])
         patch = make_temp_file(
             textwrap.dedent("""
                 commit f8c1a88ea96adfccddab0bf43c0a90f05ab26dc5 (HEAD -> playground)
@@ -736,23 +763,24 @@ class PatchTest(RiftProjectTestCase):
                 similarity index 100%
                 rename from packages/pkg/sources/pkg-1.0.tar.gz
                 rename to packages/pkgnew/sources/pkgnew-1.0.tar.gz
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must return an updated
         # package named pkgnew.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
         self.assertEqual(len(updated), 1)
         self.assertEqual(len(removed), 0)
-        self.assertEqual(updated[0].name, 'pkgnew')
-        self.assertEqual(updated[0].format, 'rpm')
+        self.assertEqual(updated[0].name, "pkgnew")
+        self.assertEqual(updated[0].format, "rpm")
 
     def test_rename_and_update_oci_package(self):
-        """ Test if renaming and updating OCI package trigger a build """
-        pkgname = 'pkgnew'
+        """Test if renaming and updating OCI package trigger a build"""
+        pkgname = "pkgnew"
         pkgvers = 1.0
-        self.make_pkg(name=pkgname, version=pkgvers, formats=['oci'])
+        self.make_pkg(name=pkgname, version=pkgvers, formats=["oci"])
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/Containerfile b/packages/pkgnew/Containerfile
@@ -776,23 +804,24 @@ class PatchTest(RiftProjectTestCase):
                 similarity index 100%
                 rename from packages/pkg/sources/pkg-1.0.tar.gz
                 rename to packages/pkgnew/sources/pkg-1.0.tar.gz
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must return an updated
         # package named pkgnew.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
         self.assertEqual(len(updated), 1)
         self.assertEqual(len(removed), 0)
-        self.assertEqual(updated[0].name, 'pkgnew')
-        self.assertEqual(updated[0].format, 'oci')
+        self.assertEqual(updated[0].name, "pkgnew")
+        self.assertEqual(updated[0].format, "oci")
 
     def test_rename_and_update_multiformats_package(self):
-        """ Test if renaming and updating multiformats package trigger a build """
-        pkgname = 'pkgnew'
+        """Test if renaming and updating multiformats package trigger a build"""
+        pkgname = "pkgnew"
         pkgvers = 1.0
-        self.make_pkg(name=pkgname, version=pkgvers, formats=['rpm', 'oci'])
+        self.make_pkg(name=pkgname, version=pkgvers, formats=["rpm", "oci"])
         patch = make_temp_file(
             textwrap.dedent("""
                 diff --git a/packages/pkg/Containerfile b/packages/pkgnew/Containerfile
@@ -831,16 +860,16 @@ class PatchTest(RiftProjectTestCase):
                 similarity index 100%
                 rename from packages/pkg/sources/pkg-1.0.tar.gz
                 rename to packages/pkgnew/sources/pkg-1.0.tar.gz
-                """))
+                """)
+        )
         # For this patch, get_packages_from_patch() must return an updated
         # package named pkgnew.
-        with open(patch.name, 'r') as p:
+        with open(patch.name, "r") as p:
             (updated, removed) = get_packages_from_patch(
                 p, config=self.config, modules=self.modules, staff=self.staff
             )
         self.assertEqual(len(updated), 2)
         self.assertEqual(len(removed), 0)
         for package in updated:
-            self.assertEqual(package.name, 'pkgnew')
-        self.assertCountEqual(
-            [package.format for package in updated], ['rpm', 'oci'])
+            self.assertEqual(package.name, "pkgnew")
+        self.assertCountEqual([package.format for package in updated], ["rpm", "oci"])

--- a/tests/patches.py
+++ b/tests/patches.py
@@ -30,6 +30,9 @@
 # knowledge of the CeCILL license and that you accept its terms.
 #
 
+# Embedded git-diff fixtures contain long lines that must stay intact.
+# ruff: noqa: E501
+
 import os
 import textwrap
 

--- a/tests/patches.py
+++ b/tests/patches.py
@@ -431,9 +431,9 @@ class PatchTest(RiftProjectTestCase):
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     project wrong file
-                
+
                 diff --git a/wrong b/wrong
                 new file mode 100644
                 index 0000000..68344bf
@@ -454,9 +454,9 @@ class PatchTest(RiftProjectTestCase):
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     packages: Wrong file
-                
+
                 diff --git a/packages/pkg/wrong b/packages/pkg/wrong
                 new file mode 100644
                 index 0000000..68344bf
@@ -478,9 +478,9 @@ class PatchTest(RiftProjectTestCase):
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     packages: update 'pkg' infos
-                
+
                 diff --git a/packages/pkg/info.yaml b/packages/pkg/info.yaml
                 new file mode 100644
                 index 0000000..68344bf
@@ -511,9 +511,9 @@ class PatchTest(RiftProjectTestCase):
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     modules: add 'Section'
-                
+
                 diff --git a/packages/modules.yaml b/packages/modules.yaml
                 new file mode 100644
                 index 0000000..68344bf
@@ -541,9 +541,9 @@ class PatchTest(RiftProjectTestCase):
             commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
             Author: Myself <buddy@somewhere.org>
             Date:   Thu Apr 25 14:30:41 2019 +0200
-        
+
                 packages: document 'pkg'
-            
+
             diff --git a/packages/pkg/{0} b/packages/pkg/{0}
             new file mode 100644
             index 0000000..e845566
@@ -579,9 +579,9 @@ class PatchTest(RiftProjectTestCase):
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     packages: update 'pkg' sources
-                
+
                 diff --git /dev/null b/{0}
                 index fcd49dd..91ef207 100644
                 Binary files a/sources/a.tar.gz and b/sources/a.tar.gz differ
@@ -608,15 +608,15 @@ class PatchTest(RiftProjectTestCase):
                 commit 0ac8155e2655321ceb28bbf716ff66d1a9e30f29 (HEAD -> master)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     packages: update 'pkg' sources
-                
+
                 diff --git /dev/null b/{0}
                 index 6cd0ff6ec591f7f51a3479d7b66c6951a2b4afa9..91ef2076b67f3158ec1670fa7b88d88b2816aa91 100644
                 GIT binary patch
                 literal 8
                 PcmZQ%;Sf+z_{{#tQ1BL-x
-                
+
                 literal 4
                 LcmZQ%;Sc}}-05kv|
                 """.format(pkgsrc)
@@ -739,9 +739,9 @@ class PatchTest(RiftProjectTestCase):
                 commit f8c1a88ea96adfccddab0bf43c0a90f05ab26dc5 (HEAD -> playground)
                 Author: Myself <buddy@somewhere.org>
                 Date:   Thu Apr 25 14:30:41 2019 +0200
-                
+
                     packages: rename 'pkg' to 'pkgnew'
-                
+
                 diff --git a/packages/pkg/info.yaml b/packages/pkgnew/info.yaml
                 similarity index 100%
                 rename from packages/pkg/info.yaml

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -9,6 +9,7 @@ from rift.proxy import (
     AuthenticatedRepositoryProxyRuntime,
     _TokenAuthRepositoryProxyHandler,
 )
+
 from .TestUtils import RiftTestCase
 
 

--- a/tests/repository/base.py
+++ b/tests/repository/base.py
@@ -3,11 +3,13 @@
 #
 
 from rift.repository._base import ArchRepositoriesBase, StagingRepositoryBase
+
 from ..TestUtils import RiftProjectTestCase
 
 
 class ArchRepositoriesTestingConcrete(ArchRepositoriesBase):
     """Dummy ArchRepositories concrete child for testing purpose."""
+
     def __init__(self, working_dir, arch):
         super().__init__(working_dir, arch)
 
@@ -17,6 +19,7 @@ class ArchRepositoriesTestingConcrete(ArchRepositoriesBase):
 
 class StagingRepositoryConcrete(StagingRepositoryBase):
     """Dummy ArchRepositories concrete child for testing purpose."""
+
     def __init__(self, repo):
         super().__init__(repo)
 
@@ -28,16 +31,15 @@ class ArchRepositoriesBaseTest(RiftProjectTestCase):
 
     def test_init_abstract(self):
         with self.assertRaisesRegex(
-            TypeError,
-            "^Can't instantiate abstract class ArchRepositoriesBase .*"
+            TypeError, "^Can't instantiate abstract class ArchRepositoriesBase .*"
         ):
-            ArchRepositoriesBase(None, 'x86_64')
+            ArchRepositoriesBase(None, "x86_64")
 
     def test_init_concrete(self):
-        """ Test ArchRepositories initialisation """
-        repo = ArchRepositoriesTestingConcrete('/path/to/working', 'x86_64')
-        self.assertEqual(repo.working_dir, '/path/to/working')
-        self.assertEqual(repo.arch, 'x86_64')
+        """Test ArchRepositories initialisation"""
+        repo = ArchRepositoriesTestingConcrete("/path/to/working", "x86_64")
+        self.assertEqual(repo.working_dir, "/path/to/working")
+        self.assertEqual(repo.arch, "x86_64")
 
 
 class StagingRepositoryBaseTest(RiftProjectTestCase):
@@ -47,12 +49,11 @@ class StagingRepositoryBaseTest(RiftProjectTestCase):
 
     def test_init_abstract(self):
         with self.assertRaisesRegex(
-            TypeError,
-            "^Can't instantiate abstract class StagingRepositoryBase .*"
+            TypeError, "^Can't instantiate abstract class StagingRepositoryBase .*"
         ):
-            StagingRepositoryBase('test')
+            StagingRepositoryBase("test")
 
     def test_init_concrete(self):
-        """ Test StagingRepository initialisation """
-        staging = StagingRepositoryConcrete('test')
-        self.assertEqual(staging.repo, 'test')
+        """Test StagingRepository initialisation"""
+        staging = StagingRepositoryConcrete("test")
+        self.assertEqual(staging.repo, "test")

--- a/tests/repository/oci.py
+++ b/tests/repository/oci.py
@@ -11,38 +11,36 @@ from ..TestUtils import RiftProjectTestCase, make_temp_dir
 
 
 class ArchRepositoriesOCITest(RiftProjectTestCase):
-
     def test_init(self):
         """Test ArchRepositoriesOCI initialisation without working directory."""
-        repo = ArchRepositoriesOCI(self.config, None, 'x86_64')
+        repo = ArchRepositoriesOCI(self.config, None, "x86_64")
         self.assertIsNone(repo.path)
         self.assertIsNone(repo.working_dir)
-        self.assertEqual(repo.arch, 'x86_64')
+        self.assertEqual(repo.arch, "x86_64")
 
     def test_init_working(self):
         """Test ArchRepositoriesOCI initialisation with working directory."""
         working_repo_path = make_temp_dir()
-        repo = ArchRepositoriesOCI(self.config, working_repo_path, 'x86_64')
-        self.assertEqual(repo.path, os.path.join(working_repo_path, 'oci'))
+        repo = ArchRepositoriesOCI(self.config, working_repo_path, "x86_64")
+        self.assertEqual(repo.path, os.path.join(working_repo_path, "oci"))
         self.assertEqual(repo.working_dir, working_repo_path)
-        self.assertEqual(repo.arch, 'x86_64')
+        self.assertEqual(repo.arch, "x86_64")
         shutil.rmtree(working_repo_path)
 
     def test_ensure_created(self):
         """Test ArchRepositoriesOCI ensure_created method."""
         working_repo_path = make_temp_dir()
         os.rmdir(working_repo_path)
-        repo = ArchRepositoriesOCI(self.config, working_repo_path, 'x86_64')
+        repo = ArchRepositoriesOCI(self.config, working_repo_path, "x86_64")
         self.assertFalse(os.path.exists(repo.working_dir))
-        with self.assertLogs(level='DEBUG') as log:
+        with self.assertLogs(level="DEBUG") as log:
             repo.ensure_created()
         self.assertIn(
-            f"DEBUG:root:Creating working directory {working_repo_path}",
-            log.output
+            f"DEBUG:root:Creating working directory {working_repo_path}", log.output
         )
         self.assertIn(
             f"DEBUG:root:Creating oci repository directory {working_repo_path}/oci",
-            log.output
+            log.output,
         )
         self.assertTrue(os.path.exists(repo.working_dir))
         self.assertTrue(os.path.exists(repo.path))
@@ -51,17 +49,16 @@ class ArchRepositoriesOCITest(RiftProjectTestCase):
     def test_delete_matching(self):
         """Test ArchRepositoriesOCI delete_matching method."""
         working_repo_path = make_temp_dir()
-        repo = ArchRepositoriesOCI(self.config, working_repo_path, 'x86_64')
+        repo = ArchRepositoriesOCI(self.config, working_repo_path, "x86_64")
         repo.ensure_created()
-        open(f"{repo.path}/pkg_1.0-2.x86_64.tar", 'w+').close()
-        open(f"{repo.path}/pkg_1.0-2.aarch64.tar", 'w+').close()
-        open(f"{repo.path}/other-pkg_2.0-3.x86_64.tar", 'w+').close()
-        open(f"{repo.path}/other-pkg_2.0-3.aarch64.tar", 'w+').close()
-        with self.assertLogs(level='INFO') as log:
-            repo.delete_matching('pkg')
+        open(f"{repo.path}/pkg_1.0-2.x86_64.tar", "w+").close()
+        open(f"{repo.path}/pkg_1.0-2.aarch64.tar", "w+").close()
+        open(f"{repo.path}/other-pkg_2.0-3.x86_64.tar", "w+").close()
+        open(f"{repo.path}/other-pkg_2.0-3.aarch64.tar", "w+").close()
+        with self.assertLogs(level="INFO") as log:
+            repo.delete_matching("pkg")
         self.assertIn(
-            f"INFO:root:Deleting OCI image {repo.path}/pkg_1.0-2.x86_64.tar",
-            log.output
+            f"INFO:root:Deleting OCI image {repo.path}/pkg_1.0-2.x86_64.tar", log.output
         )
         self.assertFalse(os.path.exists(f"{repo.path}/pkg_1.0-2.x86_64.tar"))
         self.assertTrue(os.path.exists(f"{repo.path}/pkg_1.0-2.aarch64.tar"))
@@ -72,17 +69,17 @@ class ArchRepositoriesOCITest(RiftProjectTestCase):
     def test_delete_matching_other_arch(self):
         """Test ArchRepositoriesOCI delete_matching on another architecture."""
         working_repo_path = make_temp_dir()
-        repo = ArchRepositoriesOCI(self.config, working_repo_path, 'aarch64')
+        repo = ArchRepositoriesOCI(self.config, working_repo_path, "aarch64")
         repo.ensure_created()
-        open(f"{repo.path}/pkg_1.0-2.x86_64.tar", 'w+').close()
-        open(f"{repo.path}/pkg_1.0-2.aarch64.tar", 'w+').close()
-        open(f"{repo.path}/other-pkg_2.0-3.x86_64.tar", 'w+').close()
-        open(f"{repo.path}/other-pkg_2.0-3.aarch64.tar", 'w+').close()
-        with self.assertLogs(level='INFO') as log:
-            repo.delete_matching('other-pkg')
+        open(f"{repo.path}/pkg_1.0-2.x86_64.tar", "w+").close()
+        open(f"{repo.path}/pkg_1.0-2.aarch64.tar", "w+").close()
+        open(f"{repo.path}/other-pkg_2.0-3.x86_64.tar", "w+").close()
+        open(f"{repo.path}/other-pkg_2.0-3.aarch64.tar", "w+").close()
+        with self.assertLogs(level="INFO") as log:
+            repo.delete_matching("other-pkg")
         self.assertIn(
             f"INFO:root:Deleting OCI image {repo.path}/other-pkg_2.0-3.aarch64.tar",
-            log.output
+            log.output,
         )
         self.assertTrue(os.path.exists(f"{repo.path}/pkg_1.0-2.x86_64.tar"))
         self.assertTrue(os.path.exists(f"{repo.path}/pkg_1.0-2.aarch64.tar"))

--- a/tests/repository/project.py
+++ b/tests/repository/project.py
@@ -6,32 +6,30 @@ import os
 import shutil
 from unittest.mock import Mock
 
-from ..TestUtils import make_temp_dir, RiftTestCase
-
 from rift import RiftError
 from rift.Config import Config
-from rift.repository._project import ProjectArchRepositories, StagingRepository
 from rift.repository._base import ArchRepositoriesBase
+from rift.repository._project import ProjectArchRepositories, StagingRepository
 from rift.repository.rpm import ArchRepositoriesRPM, StagingRepositoryRPM
+
+from ..TestUtils import RiftTestCase, make_temp_dir
+
 
 class ProjectArchRepositoriesTest(RiftTestCase):
     """
     Tests class for ProjectArchRepositories
     """
+
     def setUp(self):
         self.config = Config()
 
     def test_working_with_arch(self):
         """Test working repo with $arch placeholder and arch specific value"""
         working_repo_path = make_temp_dir()
-        self.config.options['working_repo'] = os.path.join(
-                working_repo_path, '$arch'
-        )
-        self.config.options['repos'] = {}
-        repos = ProjectArchRepositories(self.config, 'x86_64')
-        self.assertEqual(
-            repos.working_dir, os.path.join(working_repo_path, 'x86_64')
-        )
+        self.config.options["working_repo"] = os.path.join(working_repo_path, "$arch")
+        self.config.options["repos"] = {}
+        repos = ProjectArchRepositories(self.config, "x86_64")
+        self.assertEqual(repos.working_dir, os.path.join(working_repo_path, "x86_64"))
 
         # If an arch specific working_repo parameter is defined in
         # configuration, it should override generic working_repo parameter for
@@ -39,49 +37,48 @@ class ProjectArchRepositoriesTest(RiftTestCase):
 
         other_working_repo_path = make_temp_dir()
         # Declare supported architectures.
-        self.config.options['arch'] = ['x86_64', 'aarch64']
-        self.config.options['x86_64'] = {
-            'working_repo': other_working_repo_path
-        }
-        repos = ProjectArchRepositories(self.config, 'x86_64')
+        self.config.options["arch"] = ["x86_64", "aarch64"]
+        self.config.options["x86_64"] = {"working_repo": other_working_repo_path}
+        repos = ProjectArchRepositories(self.config, "x86_64")
         self.assertEqual(repos.working_dir, other_working_repo_path)
-        repos = ProjectArchRepositories(self.config, 'aarch64')
-        self.assertEqual(
-            repos.working_dir, os.path.join(working_repo_path, 'aarch64')
-        )
+        repos = ProjectArchRepositories(self.config, "aarch64")
+        self.assertEqual(repos.working_dir, os.path.join(working_repo_path, "aarch64"))
         shutil.rmtree(working_repo_path)
         shutil.rmtree(other_working_repo_path)
 
     def test_can_publish(self):
         """Test ProjectArchRepositories.can_publish() with working_repo"""
         working_repo_path = make_temp_dir()
-        self.config.options['working_repo'] = working_repo_path
-        repos = ProjectArchRepositories(self.config, 'x86_64')
+        self.config.options["working_repo"] = working_repo_path
+        repos = ProjectArchRepositories(self.config, "x86_64")
         self.assertTrue(repos.can_publish())
         shutil.rmtree(working_repo_path)
 
     def test_cannot_publish(self):
         """Test ProjectArchRepositories.can_publish() without working_repo"""
-        self.assertNotIn('working_repo', self.config.options)
-        repos = ProjectArchRepositories(self.config, 'x86_64')
+        self.assertNotIn("working_repo", self.config.options)
+        repos = ProjectArchRepositories(self.config, "x86_64")
         self.assertFalse(repos.can_publish())
 
     def test_delete_matching(self):
-        repos = ProjectArchRepositories(self.config, 'x86_64')
+        repos = ProjectArchRepositories(self.config, "x86_64")
         # mock all format specific classes
-        repos.FORMAT_CLASSES = { _format: Mock(spec=ArchRepositoriesBase)
-                                 for _format in repos.FORMAT_CLASSES.keys() }
-        repos.delete_matching('pkg')
+        repos.FORMAT_CLASSES = {
+            _format: Mock(spec=ArchRepositoriesBase)
+            for _format in repos.FORMAT_CLASSES.keys()
+        }
+        repos.delete_matching("pkg")
         # Check delete_matching() method has been called with provided package
         # for all supported formats.
         for _format in repos.FORMAT_CLASSES.keys():
-            repos.FORMAT_CLASSES[_format].return_value.delete_matching \
-                .assert_called_once_with('pkg')
+            repos.FORMAT_CLASSES[
+                _format
+            ].return_value.delete_matching.assert_called_once_with("pkg")
 
     def test_for_format(self):
         """Test ProjectArchRepositories.for_format()"""
-        repos = ProjectArchRepositories(self.config, 'x86_64')
-        format_repos = repos.for_format('rpm')
+        repos = ProjectArchRepositories(self.config, "x86_64")
+        format_repos = repos.for_format("rpm")
         self.assertIsInstance(format_repos, ArchRepositoriesBase)
         self.assertIsInstance(format_repos, ArchRepositoriesRPM)
 
@@ -89,9 +86,9 @@ class ProjectArchRepositoriesTest(RiftTestCase):
         """Test ProjectArchRepositories.for_format() unsupported format"""
         with self.assertRaisesRegex(
             RiftError,
-            "^Unable to get configuration option for unsupported architecture 'fail'$"
+            "^Unable to get configuration option for unsupported architecture 'fail'$",
         ):
-            ProjectArchRepositories(self.config, 'fail')
+            ProjectArchRepositories(self.config, "fail")
 
 
 class StagingRepositoryTest(RiftTestCase):
@@ -111,10 +108,10 @@ class StagingRepositoryTest(RiftTestCase):
         self.assertFalse(os.path.exists(path))
 
     def test_formats(self):
-        self.assertIsInstance(self.staging.for_format('rpm'), StagingRepositoryRPM)
+        self.assertIsInstance(self.staging.for_format("rpm"), StagingRepositoryRPM)
 
     def test_format_unsupported(self):
         with self.assertRaisesRegex(
             RiftError, "^Unsupported staging repository format fail$"
         ):
-            self.staging.for_format('fail')
+            self.staging.for_format("fail")

--- a/tests/repository/rpm.py
+++ b/tests/repository/rpm.py
@@ -513,7 +513,7 @@ class ArchRepositoriesRPMTest(RiftTestCase):
         shutil.rmtree(working_repo_path)
 
     def test_delete_matching_not_found(self):
-        """Test delete_matching() call expected method on working repo when package not found"""
+        """Test delete_matching() when package is not found."""
         working_repo_path = make_temp_dir()
         repos = ArchRepositoriesRPM(self.config, working_repo_path, "x86_64")
         repos.working = Mock(spec=LocalRepository)

--- a/tests/repository/rpm.py
+++ b/tests/repository/rpm.py
@@ -6,80 +6,74 @@ import os
 import shutil
 from unittest.mock import Mock, call, patch
 
-from ..TestUtils import make_temp_dir, read_file, RiftTestCase
+from rift import RiftError
+from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS, Config
 from rift.repository.rpm import (
+    ArchRepositoriesRPM,
     ConsumableRepository,
     LocalRepository,
-    ArchRepositoriesRPM,
     StagingRepositoryRPM,
 )
-from rift.Config import _DEFAULT_REPO_CMD, _DEFAULT_REPOS_VARIANTS, Config
 from rift.RPM import RPM
-from rift import RiftError
+
+from ..TestUtils import RiftTestCase, make_temp_dir, read_file
 
 
 class LocalRepositoryTest(RiftTestCase):
     """
     Tests class for Repository
     """
+
     def setUp(self):
         self.config = Config()
 
     def test_init(self):
-        """ Test LocalRepository instanciation with a specific configuration """
-        arch = 'x86_64'
-        self.config.update({ 'arch': [arch], 'createrepo': 'mycustom_create_repo' })
+        """Test LocalRepository instanciation with a specific configuration"""
+        arch = "x86_64"
+        self.config.update({"arch": [arch], "createrepo": "mycustom_create_repo"})
         _options = {
-            'module_hotfixes': True,
-            'excludepkgs': 'somepkg',
-            'proxy': 'myproxy',
+            "module_hotfixes": True,
+            "excludepkgs": "somepkg",
+            "proxy": "myproxy",
         }
-        repo_name = 'nowhere'
-        repo = LocalRepository(
-            '/{}'.format(repo_name),
-            self.config,
-            options=_options
-        )
+        repo_name = "nowhere"
+        repo = LocalRepository("/{}".format(repo_name), self.config, options=_options)
 
-        self.assertEqual(repo.path, '/{}'.format(repo_name))
-        self.assertEqual(repo.srpms_dir, '/{}/{}'.format(repo_name, 'SRPMS'))
+        self.assertEqual(repo.path, "/{}".format(repo_name))
+        self.assertEqual(repo.srpms_dir, "/{}/{}".format(repo_name, "SRPMS"))
         self.assertEqual(list(repo.consumables.keys()), [arch])
         self.assertEqual(repo.consumables[arch].name, repo_name)
         self.assertEqual(
-            repo.consumables[arch].url, 'file:///{}/{}'.format(repo_name, arch)
+            repo.consumables[arch].url, "file:///{}/{}".format(repo_name, arch)
         )
-        self.assertEqual(
-            repo.rpms_dir(arch), '/{}/{}'.format(repo_name, arch)
-        )
+        self.assertEqual(repo.rpms_dir(arch), "/{}/{}".format(repo_name, arch))
         self.assertEqual(repo.consumables[arch].priority, 1)
         self.assertEqual(repo.consumables[arch].module_hotfixes, True)
-        self.assertEqual(repo.consumables[arch].excludepkgs, 'somepkg')
-        self.assertEqual(repo.consumables[arch].proxy, 'myproxy')
-        self.assertEqual(repo.createrepo, self.config.get('createrepo'))
+        self.assertEqual(repo.consumables[arch].excludepkgs, "somepkg")
+        self.assertEqual(repo.consumables[arch].proxy, "myproxy")
+        self.assertEqual(repo.createrepo, self.config.get("createrepo"))
 
     def test_init_multiple_archs(self):
-        """ Test LocalRepository instanciation with multiple architectures """
-        archs = ['x86_64', 'aarch64']
-        self.config.update({ 'arch': archs })
-        repo_name = 'nowhere'
-        repo = LocalRepository('/{}'.format(repo_name), self.config)
+        """Test LocalRepository instanciation with multiple architectures"""
+        archs = ["x86_64", "aarch64"]
+        self.config.update({"arch": archs})
+        repo_name = "nowhere"
+        repo = LocalRepository("/{}".format(repo_name), self.config)
 
         self.assertEqual(repo.createrepo, _DEFAULT_REPO_CMD)
         self.assertEqual(list(repo.consumables.keys()), archs)
         for arch in archs:
             self.assertEqual(repo.consumables[arch].name, repo_name)
             self.assertEqual(
-                repo.consumables[arch].url, 'file:///{}/{}'.format(repo_name, arch)
+                repo.consumables[arch].url, "file:///{}/{}".format(repo_name, arch)
             )
-            self.assertEqual(
-                repo.rpms_dir(arch), '/{}/{}'.format(repo_name, arch)
-            )
+            self.assertEqual(repo.rpms_dir(arch), "/{}/{}".format(repo_name, arch))
 
     def test_init_rpms_dir(self):
-        """ Test LocalRepository rpm_dirs """
-        archs = ['x86_64', 'aarch64']
-        self.config.update({ 'arch': archs })
-        repo_name = 'nowhere'
+        """Test LocalRepository rpm_dirs"""
+        archs = ["x86_64", "aarch64"]
+        self.config.update({"arch": archs})
+        repo_name = "nowhere"
         path = f"/{repo_name}"
         repo = LocalRepository(path, self.config)
 
@@ -87,18 +81,18 @@ class LocalRepositoryTest(RiftTestCase):
         self.assertEqual(repo.rpms_dir(archs[1]), os.path.join(path, archs[1]))
         with self.assertRaisesRegex(
             RiftError,
-            '^Unable to get repository RPM directory for unsupported '
-            'architecture fail$'
+            "^Unable to get repository RPM directory for unsupported "
+            "architecture fail$",
         ):
-            repo.rpms_dir('fail')
+            repo.rpms_dir("fail")
 
-    @patch('rift.repository.rpm.Popen')
+    @patch("rift.repository.rpm.Popen")
     def test_create(self, mock_popen):
-        """ Test LocalRepository create """
+        """Test LocalRepository create"""
         # Emulate successful createrepo execution
         mock_popen.return_value.__enter__.return_value.returncode = 0
-        arch = 'x86_64'
-        self.config.update({ 'arch': [arch] })
+        arch = "x86_64"
+        self.config.update({"arch": [arch]})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
         repo.create()
@@ -106,27 +100,29 @@ class LocalRepositoryTest(RiftTestCase):
         self.assertTrue(os.path.exists(repo.rpms_dir(arch)))
         shutil.rmtree(local_repo_path)
 
-    @patch('rift.repository.rpm.Popen')
+    @patch("rift.repository.rpm.Popen")
     def test_create_failure(self, mock_popen):
-        """ Test LocalRepository create failure """
+        """Test LocalRepository create failure"""
         # Emulate createrepo execution failure
         mock_popen.return_value.__enter__.return_value.returncode = 1
-        mock_popen.return_value.__enter__.return_value.communicate.return_value = ["output"]
-        arch = 'x86_64'
-        self.config.update({ 'arch': [arch] })
+        mock_popen.return_value.__enter__.return_value.communicate.return_value = [
+            "output"
+        ]
+        arch = "x86_64"
+        self.config.update({"arch": [arch]})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
-        with self.assertRaisesRegex(RiftError, '^output$'):
+        with self.assertRaisesRegex(RiftError, "^output$"):
             repo.create()
         shutil.rmtree(local_repo_path)
 
-    @patch('rift.repository.rpm.Popen')
+    @patch("rift.repository.rpm.Popen")
     def test_update(self, mock_popen):
-        """ Test LocalRepository update """
+        """Test LocalRepository update"""
         # Emulate successful createrepo execution
         mock_popen.return_value.__enter__.return_value.returncode = 0
-        arch = 'x86_64'
-        self.config.update({ 'arch': [arch] })
+        arch = "x86_64"
+        self.config.update({"arch": [arch]})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
         repo.create()  # create() calls update()
@@ -139,19 +135,21 @@ class LocalRepositoryTest(RiftTestCase):
         self.assertEqual(mock_popen.call_count, 2)
         shutil.rmtree(local_repo_path)
 
-    @patch('rift.repository.rpm.Popen')
+    @patch("rift.repository.rpm.Popen")
     def test_update_failure(self, mock_popen):
-        """ Test LocalRepository update failure """
+        """Test LocalRepository update failure"""
         # Emulate createrepo execution failure
         mock_popen.return_value.__enter__.return_value.returncode = 0
-        arch = 'x86_64'
-        self.config.update({ 'arch': [arch] })
+        arch = "x86_64"
+        self.config.update({"arch": [arch]})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
         repo.create()
         mock_popen.return_value.__enter__.return_value.returncode = 1
-        mock_popen.return_value.__enter__.return_value.communicate.return_value = ["output"]
-        with self.assertRaisesRegex(RiftError, '^output$'):
+        mock_popen.return_value.__enter__.return_value.communicate.return_value = [
+            "output"
+        ]
+        with self.assertRaisesRegex(RiftError, "^output$"):
             repo.update()
         shutil.rmtree(local_repo_path)
 
@@ -160,14 +158,10 @@ class LocalRepositoryTest(RiftTestCase):
         """
         Add packages from tests materials to repository and return RPM objects.
         """
-        tests_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+        tests_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
         # Add source and binary packages from tests materials
-        src_rpm = RPM(
-            os.path.join(tests_dir, 'materials', 'pkg-1.0-1.src.rpm')
-        )
-        bin_rpm = RPM(
-            os.path.join(tests_dir, 'materials', 'pkg-1.0-1.noarch.rpm')
-        )
+        src_rpm = RPM(os.path.join(tests_dir, "materials", "pkg-1.0-1.src.rpm"))
+        bin_rpm = RPM(os.path.join(tests_dir, "materials", "pkg-1.0-1.noarch.rpm"))
         repo.add(bin_rpm)
         repo.add(src_rpm)
 
@@ -177,9 +171,9 @@ class LocalRepositoryTest(RiftTestCase):
         return src_rpm, bin_rpm
 
     def test_add(self):
-        """ Test LocalRepository add """
-        archs = ['x86_64', 'aarch64']
-        self.config.update({ 'arch': archs })
+        """Test LocalRepository add"""
+        archs = ["x86_64", "aarch64"]
+        self.config.update({"arch": archs})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
 
@@ -192,27 +186,25 @@ class LocalRepositoryTest(RiftTestCase):
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
-                        local_repo_path,
-                        arch,
-                        os.path.basename(bin_rpm.filepath)
+                        local_repo_path, arch, os.path.basename(bin_rpm.filepath)
                     )
                 )
             )
         self.assertTrue(
             os.path.exists(
                 os.path.join(
-                    local_repo_path, 'SRPMS', os.path.basename(src_rpm.filepath)
+                    local_repo_path, "SRPMS", os.path.basename(src_rpm.filepath)
                 )
             )
         )
 
         shutil.rmtree(local_repo_path)
 
-    @patch('rift.repository.rpm.Mock')
+    @patch("rift.repository.rpm.Mock")
     def test_search(self, mock_mock):
         """Test search packages on a repository"""
-        archs = ['x86_64', 'aarch64']
-        self.config.update({ 'arch': archs })
+        archs = ["x86_64", "aarch64"]
+        self.config.update({"arch": archs})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
 
@@ -227,13 +219,13 @@ class LocalRepositoryTest(RiftTestCase):
 
         # With a package name that does not exist in this repos, it must return
         # 0 result.
-        pkgs = repo.search('fail')
+        pkgs = repo.search("fail")
         self.assertEqual(len(pkgs), 0)
 
         # With the name of the package in testing materials, it must return 3
         # results: the source package, the binary package in x86_64 architecture
         # and the same binary package in aarch64 architecture.
-        pkgs = repo.search('pkg')
+        pkgs = repo.search("pkg")
         self.assertEqual(len(pkgs), 3)
 
         # Verify search results match source and binary packages from tests
@@ -241,23 +233,21 @@ class LocalRepositoryTest(RiftTestCase):
         for pkg in pkgs:
             if pkg.is_source:
                 self.assertEqual(
-                    os.path.basename(pkg.filepath),
-                    os.path.basename(src_rpm.filepath)
+                    os.path.basename(pkg.filepath), os.path.basename(src_rpm.filepath)
                 )
             else:
                 self.assertEqual(
-                    os.path.basename(pkg.filepath),
-                    os.path.basename(bin_rpm.filepath)
+                    os.path.basename(pkg.filepath), os.path.basename(bin_rpm.filepath)
                 )
 
         # Cleanup temporary repository
         shutil.rmtree(local_repo_path)
 
-    @patch('rift.repository.rpm.Mock')
+    @patch("rift.repository.rpm.Mock")
     def test_delete(self, mock_mock):
         """Test delete packages on a repository"""
-        archs = ['x86_64', 'aarch64']
-        self.config.update({ 'arch': archs })
+        archs = ["x86_64", "aarch64"]
+        self.config.update({"arch": archs})
         local_repo_path = make_temp_dir()
         repo = LocalRepository(local_repo_path, self.config)
 
@@ -269,12 +259,12 @@ class LocalRepositoryTest(RiftTestCase):
         mock_mock.return_value.read_spec = read_file
 
         # Search and retrieve packages from repo
-        pkgs = repo.search('pkg')
+        pkgs = repo.search("pkg")
 
         # Search must return 3 results: the source package, the binary package
         # in x86_64 architecture and the same binary package in aarch64
         # architecture.
-        self.assertEqual(len(repo.search('pkg')), 3)
+        self.assertEqual(len(repo.search("pkg")), 3)
 
         # Delete packages from repository
         for pkg in pkgs:
@@ -286,25 +276,24 @@ class LocalRepositoryTest(RiftTestCase):
             self.assertFalse(
                 os.path.exists(
                     os.path.join(
-                        local_repo_path,
-                        arch,
-                        os.path.basename(bin_rpm.filepath)
+                        local_repo_path, arch, os.path.basename(bin_rpm.filepath)
                     )
                 )
             )
         self.assertFalse(
             os.path.exists(
                 os.path.join(
-                    local_repo_path, 'SRPMS', os.path.basename(src_rpm.filepath)
+                    local_repo_path, "SRPMS", os.path.basename(src_rpm.filepath)
                 )
             )
         )
 
         # Verify search does not return any result
-        self.assertEqual(len(repo.search('pkg')), 0)
+        self.assertEqual(len(repo.search("pkg")), 0)
 
         # Cleanup temporary repository
         shutil.rmtree(local_repo_path)
+
 
 class ConsumableRepositoryTest(RiftTestCase):
     """
@@ -324,43 +313,43 @@ class ConsumableRepositoryTest(RiftTestCase):
     def test_init_full(self):
         repo = ConsumableRepository(
             "http://repo",
-            name='testrepo',
+            name="testrepo",
             priority=99,
             options={
-                'module_hotfixes': True,
-                'excludepkgs': ['pkg1', 'pkg2'],
-                'proxy': 'http://proxy',
+                "module_hotfixes": True,
+                "excludepkgs": ["pkg1", "pkg2"],
+                "proxy": "http://proxy",
             },
-            variants=['variant1', 'variant2']
+            variants=["variant1", "variant2"],
         )
         self.assertEqual(repo.url, "http://repo")
-        self.assertEqual(repo.name, 'testrepo')
+        self.assertEqual(repo.name, "testrepo")
         self.assertEqual(repo.priority, 99)
         self.assertTrue(repo.module_hotfixes)
-        self.assertCountEqual(repo.excludepkgs, ['pkg1', 'pkg2'])
-        self.assertEqual(repo.proxy, 'http://proxy')
-        self.assertCountEqual(repo.variants, ['variant1', 'variant2'])
+        self.assertCountEqual(repo.excludepkgs, ["pkg1", "pkg2"])
+        self.assertEqual(repo.proxy, "http://proxy")
+        self.assertCountEqual(repo.variants, ["variant1", "variant2"])
 
     def test_path_local_file(self):
-        """ test path method """
-        directory = '/somewhere'
+        """test path method"""
+        directory = "/somewhere"
         repo = ConsumableRepository(directory)
         self.assertEqual(repo.path, directory)
         self.assertTrue(repo.is_file())
         self.assertFalse(repo.exists())
 
     def test_path_local_file_url(self):
-        """ test path method with a local url"""
-        directory = '/somewhere'
-        repo = ConsumableRepository('file://{}'.format(directory))
+        """test path method with a local url"""
+        directory = "/somewhere"
+        repo = ConsumableRepository("file://{}".format(directory))
         self.assertEqual(repo.path, directory)
         self.assertTrue(repo.is_file())
         self.assertFalse(repo.exists())
 
     def test_path_remote_url(self):
-        """ test path method with a remote url"""
-        directory = '/somewhere'
-        repo =  ConsumableRepository('http://{}'.format(directory))
+        """test path method with a remote url"""
+        directory = "/somewhere"
+        repo = ConsumableRepository("http://{}".format(directory))
         self.assertFalse(repo.is_file())
         with self.assertRaisesRegex(
             RiftError, "^Unable to return path of remote repository$"
@@ -372,11 +361,11 @@ class ConsumableRepositoryTest(RiftTestCase):
             repo.exists()
 
     def test_generic_url(self):
-        directory = '/some/where/there'
-        repo =  ConsumableRepository('http:/{}'.format(directory))
-        self.assertEqual(repo.generic_url('x86_64'), 'http:/{}'.format(directory))
-        repo =  ConsumableRepository('http://some/where/x86_64')
-        self.assertEqual(repo.generic_url('x86_64'), 'http://some/where/$basearch')
+        directory = "/some/where/there"
+        repo = ConsumableRepository("http:/{}".format(directory))
+        self.assertEqual(repo.generic_url("x86_64"), "http:/{}".format(directory))
+        repo = ConsumableRepository("http://some/where/x86_64")
+        self.assertEqual(repo.generic_url("x86_64"), "http://some/where/$basearch")
 
     def test_authenticated(self):
         local_repo = ConsumableRepository(
@@ -395,136 +384,130 @@ class ConsumableRepositoryTest(RiftTestCase):
         self.assertFalse(remote_without_auth_repo.authenticated())
         self.assertTrue(remote_auth_repo.authenticated())
 
+
 class ArchRepositoriesRPMTest(RiftTestCase):
     """
     Tests class for ArchRepositoriesRPM
     """
+
     def setUp(self):
         self.config = Config()
 
     def test_basic(self):
         """Test one simple supplementary repository"""
-        self.config.options['repos'] = {
-            'os': {
-                'url': 'file:///rift/packages/x86_64/os',
-                'priority': 90,
+        self.config.options["repos"] = {
+            "os": {
+                "url": "file:///rift/packages/x86_64/os",
+                "priority": 90,
             }
         }
-        repos = ArchRepositoriesRPM(self.config, None, 'x86_64')
+        repos = ArchRepositoriesRPM(self.config, None, "x86_64")
         self.assertEqual(repos.working, None)
         self.assertEqual(len(repos.supplementaries), 1)
         self.assertEqual(len(repos.all), 1)
-        self.assertEqual(repos.supplementaries[0].name, 'os')
+        self.assertEqual(repos.supplementaries[0].name, "os")
         self.assertEqual(repos.all[0], repos.supplementaries[0])
 
     def test_working(self):
         """Test working repository without supplementary repository"""
         working_repo_path = make_temp_dir()
-        self.config.options['repos'] = {}
-        repos = ArchRepositoriesRPM(self.config, working_repo_path, 'x86_64')
+        self.config.options["repos"] = {}
+        repos = ArchRepositoriesRPM(self.config, working_repo_path, "x86_64")
         self.assertIsInstance(repos.working, LocalRepository)
         self.assertEqual(len(repos.supplementaries), 0)
         self.assertEqual(len(repos.all), 1)
-        self.assertEqual(repos.working.consumables['x86_64'].name, 'working')
+        self.assertEqual(repos.working.consumables["x86_64"].name, "working")
         self.assertEqual(repos.working.path, working_repo_path)
-        self.assertEqual(repos.all[0], repos.working.consumables['x86_64'])
+        self.assertEqual(repos.all[0], repos.working.consumables["x86_64"])
         shutil.rmtree(working_repo_path)
 
     def test_working_and_supplementaries(self):
         """Test working repository and two supplementary repositories"""
         working_repo_path = make_temp_dir()
-        self.config.options['repos'] = {
-            'os': {
-                'url': 'file:///rift/packages/x86_64/os',
-                'priority': 90,
+        self.config.options["repos"] = {
+            "os": {
+                "url": "file:///rift/packages/x86_64/os",
+                "priority": 90,
             },
-            'extra': {
-                'url': 'file:///rift/packages/x86_64/extra',
-                'priority': 90,
+            "extra": {
+                "url": "file:///rift/packages/x86_64/extra",
+                "priority": 90,
             },
         }
-        repos = ArchRepositoriesRPM(self.config, working_repo_path, 'x86_64')
+        repos = ArchRepositoriesRPM(self.config, working_repo_path, "x86_64")
         self.assertIsInstance(repos.working, LocalRepository)
         self.assertEqual(len(repos.supplementaries), 2)
         self.assertEqual(len(repos.all), 3)
-        self.assertEqual(repos.working.consumables['x86_64'].name, 'working')
-        self.assertEqual(repos.supplementaries[0].name, 'os')
-        self.assertEqual(repos.all[0], repos.working.consumables['x86_64'])
+        self.assertEqual(repos.working.consumables["x86_64"].name, "working")
+        self.assertEqual(repos.supplementaries[0].name, "os")
+        self.assertEqual(repos.all[0], repos.working.consumables["x86_64"])
         self.assertEqual(repos.all[1], repos.supplementaries[0])
         shutil.rmtree(working_repo_path)
 
     def test_supplementaries_with_arch(self):
         """Test supplementary with $arch placeholder and arch specific value"""
-        self.config.options['repos'] = {
-            'os': {
-                'url': 'file:///rift/packages/$arch/os',
-                'priority': 90,
+        self.config.options["repos"] = {
+            "os": {
+                "url": "file:///rift/packages/$arch/os",
+                "priority": 90,
             },
-            'extra': {
-                'url': 'file:///rift/packages/$arch/extra',
-                'priority': 90,
+            "extra": {
+                "url": "file:///rift/packages/$arch/extra",
+                "priority": 90,
             },
         }
-        repos = ArchRepositoriesRPM(self.config, None, 'x86_64')
-        self.assertEqual(repos.supplementaries[0].name, 'os')
+        repos = ArchRepositoriesRPM(self.config, None, "x86_64")
+        self.assertEqual(repos.supplementaries[0].name, "os")
         self.assertEqual(
-            repos.supplementaries[0].url,
-            'file:///rift/packages/x86_64/os'
+            repos.supplementaries[0].url, "file:///rift/packages/x86_64/os"
         )
-        self.assertEqual(repos.supplementaries[1].name, 'extra')
+        self.assertEqual(repos.supplementaries[1].name, "extra")
         self.assertEqual(
-            repos.supplementaries[1].url,
-            'file:///rift/packages/x86_64/extra'
+            repos.supplementaries[1].url, "file:///rift/packages/x86_64/extra"
         )
 
         # If an arch specific repos parameter is defined in configuration, it
         # should override generic repos parameter for this arch.
 
         # Declare supported architectures.
-        self.config.options['arch'] = ['x86_64', 'aarch64']
-        self.config.options['x86_64'] = {}
-        self.config.options['x86_64']['repos'] = {
-            'other-os': {
-                'url': 'file:///rift/other/packages/os',
-                'priority': 90,
+        self.config.options["arch"] = ["x86_64", "aarch64"]
+        self.config.options["x86_64"] = {}
+        self.config.options["x86_64"]["repos"] = {
+            "other-os": {
+                "url": "file:///rift/other/packages/os",
+                "priority": 90,
             },
-            'other-extra': {
-                'url': 'file:///rift/other/packages/extra',
-                'priority': 90,
+            "other-extra": {
+                "url": "file:///rift/other/packages/extra",
+                "priority": 90,
             },
         }
-        repos = ArchRepositoriesRPM(self.config,  None,'x86_64')
-        self.assertEqual(repos.supplementaries[0].name, 'other-os')
+        repos = ArchRepositoriesRPM(self.config, None, "x86_64")
+        self.assertEqual(repos.supplementaries[0].name, "other-os")
+        self.assertEqual(repos.supplementaries[0].url, "file:///rift/other/packages/os")
+        self.assertEqual(repos.supplementaries[1].name, "other-extra")
         self.assertEqual(
-            repos.supplementaries[0].url,
-            'file:///rift/other/packages/os'
-        )
-        self.assertEqual(repos.supplementaries[1].name, 'other-extra')
-        self.assertEqual(
-            repos.supplementaries[1].url,
-            'file:///rift/other/packages/extra'
+            repos.supplementaries[1].url, "file:///rift/other/packages/extra"
         )
 
-        repos = ArchRepositoriesRPM(self.config, None, 'aarch64')
-        self.assertEqual(repos.supplementaries[0].name, 'os')
+        repos = ArchRepositoriesRPM(self.config, None, "aarch64")
+        self.assertEqual(repos.supplementaries[0].name, "os")
         self.assertEqual(
-            repos.supplementaries[0].url,
-            'file:///rift/packages/aarch64/os'
+            repos.supplementaries[0].url, "file:///rift/packages/aarch64/os"
         )
-        self.assertEqual(repos.supplementaries[1].name, 'extra')
+        self.assertEqual(repos.supplementaries[1].name, "extra")
         self.assertEqual(
-            repos.supplementaries[1].url,
-            'file:///rift/packages/aarch64/extra'
+            repos.supplementaries[1].url, "file:///rift/packages/aarch64/extra"
         )
 
     def test_delete_matching(self):
         """Test delete_matching() call expected method on working repo"""
         working_repo_path = make_temp_dir()
-        repos = ArchRepositoriesRPM(self.config, working_repo_path, 'x86_64')
+        repos = ArchRepositoriesRPM(self.config, working_repo_path, "x86_64")
         repos.working = Mock(spec=LocalRepository)
         repos.working.search.return_value = []
-        repos.delete_matching('pkg')
-        repos.working.search.assert_called_once_with('pkg')
+        repos.delete_matching("pkg")
+        repos.working.search.assert_called_once_with("pkg")
         repos.working.delete.assert_not_called()
         repos.working.update.assert_called_once()
         shutil.rmtree(working_repo_path)
@@ -532,49 +515,43 @@ class ArchRepositoriesRPMTest(RiftTestCase):
     def test_delete_matching_not_found(self):
         """Test delete_matching() call expected method on working repo when package not found"""
         working_repo_path = make_temp_dir()
-        repos = ArchRepositoriesRPM(self.config, working_repo_path, 'x86_64')
+        repos = ArchRepositoriesRPM(self.config, working_repo_path, "x86_64")
         repos.working = Mock(spec=LocalRepository)
-        repos.working.search.return_value = ['/path/to/pkg.rpm', '/path/to/pkg.src.rpm']
-        repos.delete_matching('pkg')
-        repos.working.search.assert_called_once_with('pkg')
-        repos.working.delete.assert_has_calls([call('/path/to/pkg.rpm'), call('/path/to/pkg.src.rpm')])
+        repos.working.search.return_value = ["/path/to/pkg.rpm", "/path/to/pkg.src.rpm"]
+        repos.delete_matching("pkg")
+        repos.working.search.assert_called_once_with("pkg")
+        repos.working.delete.assert_has_calls(
+            [call("/path/to/pkg.rpm"), call("/path/to/pkg.src.rpm")]
+        )
         repos.working.update.assert_called_once()
         shutil.rmtree(working_repo_path)
 
     def test_for_variant(self):
-        self.config.options['repos'] = {
-            'base': {
-                'url': 'http://base/',
+        self.config.options["repos"] = {
+            "base": {
+                "url": "http://base/",
             },
-            'repo1': {
-                'url': 'http://repo1',
-                'variants': ['variant1']
-            },
-            'repo2': {
-                'url': 'http://repo2',
-                'variants': ['variant2']
-            },
-            'repo3': {
-                'url': 'http://repo3',
-                'variants': ['variant1', 'variant2']
-            },
+            "repo1": {"url": "http://repo1", "variants": ["variant1"]},
+            "repo2": {"url": "http://repo2", "variants": ["variant2"]},
+            "repo3": {"url": "http://repo3", "variants": ["variant1", "variant2"]},
         }
-        repos = ArchRepositoriesRPM(self.config, None, 'x86_64')
+        repos = ArchRepositoriesRPM(self.config, None, "x86_64")
         expected_results = {
-            'main': ['base'],
-            'variant1': ['repo1', 'repo3'],
-            'variant2': ['repo2', 'repo3'],
+            "main": ["base"],
+            "variant1": ["repo1", "repo3"],
+            "variant2": ["repo2", "repo3"],
         }
         for variant, expected_result in expected_results.items():
             self.assertCountEqual(
-                [repo.name for repo in repos.for_variant(variant)],
-                expected_result
+                [repo.name for repo in repos.for_variant(variant)], expected_result
             )
+
 
 class StagingRepositoryRPMTest(RiftTestCase):
     """
     Tests class for StagingRepositoryRPM
     """
+
     def setUp(self):
         self.config = Config()
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -5,8 +5,10 @@
 from io import StringIO
 from unittest.mock import patch
 
-from .TestUtils import RiftTestCase
 from rift.run import RunResult, run_command
+
+from .TestUtils import RiftTestCase
+
 
 class RunTest(RiftTestCase):
     """
@@ -14,7 +16,7 @@ class RunTest(RiftTestCase):
     """
 
     def test_run_command(self):
-        """ Test run_command() with basic successful command. """
+        """Test run_command() with basic successful command."""
         proc = run_command(["/bin/true"])
         self.assertIsInstance(proc, RunResult)
         self.assertEqual(proc.returncode, 0)
@@ -22,15 +24,15 @@ class RunTest(RiftTestCase):
         self.assertIsNone(proc.err)
 
     def test_run_command_failed(self):
-        """ Test run_command() with basic failed command. """
+        """Test run_command() with basic failed command."""
         proc = run_command(["/bin/false"])
         self.assertEqual(proc.returncode, 1)
         self.assertIsNone(proc.out)
         self.assertIsNone(proc.err)
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_run_command_capture_stdout(self, mock_stdout):
-        """ Test run_command() with captured standard output. """
+        """Test run_command() with captured standard output."""
         proc = run_command(["/bin/echo", "output_data"], capture_output=True)
         # Standard output must be available in out attribute of RunResult named
         # tuple.
@@ -40,9 +42,9 @@ class RunTest(RiftTestCase):
         # Standard output must also be streamed into current process stdout.
         self.assertEqual(mock_stdout.getvalue(), "output_data\n")
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_run_command_stdout(self, mock_stdout):
-        """ Test run_command() with standard output. """
+        """Test run_command() with standard output."""
         proc = run_command(["/bin/echo", "output_data"])
         # Standard output must be available in out attribute of RunResult named
         # tuple.
@@ -52,9 +54,9 @@ class RunTest(RiftTestCase):
         # Standard output must also be streamed into current process stdout.
         self.assertEqual(mock_stdout.getvalue(), "output_data\n")
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
     def test_run_command_capture_stderr(self, mock_stderr):
-        """ Test run_command() with captured standard error. """
+        """Test run_command() with captured standard error."""
         proc = run_command("/bin/echo error_data 1>&2", capture_output=True, shell=True)
         # Standard err must be available in err attribute of RunResult named
         # tuple.
@@ -64,11 +66,15 @@ class RunTest(RiftTestCase):
         # Standard error must also be streamed into current process stderr.
         self.assertEqual(mock_stderr.getvalue(), "error_data\n")
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
     def test_run_command_capture_stderr_merged(self, mock_stderr):
-        """ Test run_command() with merged error output capture. """
-        proc = run_command("/bin/echo error_data 1>&2", capture_output=True,
-                merge_out_err=True, shell=True)
+        """Test run_command() with merged error output capture."""
+        proc = run_command(
+            "/bin/echo error_data 1>&2",
+            capture_output=True,
+            merge_out_err=True,
+            shell=True,
+        )
         # With merged_capture, standard err must be available in out attribute
         # of RunResult named tuple, and err attribute must be None.
         self.assertEqual(proc.out, "error_data\n")
@@ -76,11 +82,15 @@ class RunTest(RiftTestCase):
         # Standard error must also be streamed into current process stderr.
         self.assertEqual(mock_stderr.getvalue(), "error_data\n")
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
     def test_run_command_capture_both_merged(self, mock_stderr):
-        """ Test run_command() with merged error and standard output capture. """
-        proc = run_command("/bin/echo error_data 1>&2 && /bin/echo output_data",
-                capture_output=True, merge_out_err=True, shell=True)
+        """Test run_command() with merged error and standard output capture."""
+        proc = run_command(
+            "/bin/echo error_data 1>&2 && /bin/echo output_data",
+            capture_output=True,
+            merge_out_err=True,
+            shell=True,
+        )
         # With merge_out_err, standard err must be available in out attribute
         # of RunResult named tuple, and err attribute must be None.
         self.assertEqual(proc.out, "error_data\noutput_data\n")
@@ -88,10 +98,10 @@ class RunTest(RiftTestCase):
         # Standard error must also be streamed into current process stderr.
         self.assertEqual(mock_stderr.getvalue(), "error_data\n")
 
-    @patch('sys.stderr', new_callable=StringIO)
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_run_command_no_output(self, mock_stdout, mock_stderr):
-        """ Test run_command() without live output. """
+        """Test run_command() without live output."""
         # With live_output disabled, standard output and standard error must not
         # be redirected in current process stdout.
         run_command(["/bin/echo", "output_data"], live_output=False)
@@ -99,7 +109,7 @@ class RunTest(RiftTestCase):
         self.assertEqual(mock_stderr.getvalue(), "")
 
     def test_run_command_dont_manage_output(self):
-        """ Test run_command() with manage_output disabled. """
+        """Test run_command() with manage_output disabled."""
         proc = run_command(["/bin/echo", "output_data"], manage_output=False)
         self.assertEqual(proc.returncode, 0)
         # Child stdout/stderr inherit OS fds 1 and 2; that is not the same as

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -33,7 +33,7 @@ class RepoSyncFactoryTest(RiftTestCase):
         RepoSyncFactory.check_valid_method("epel")
 
     def test_check_valid_method_invalid_value(self):
-        """Test RepoSyncFactory check_valid_method() raises RiftError with invalid value."""
+        """Test check_valid_method() raises RiftError on invalid value."""
         with self.assertRaisesRegex(
             RiftError, "^Unsupported repository synchronization method fail$"
         ):
@@ -309,7 +309,7 @@ class RepoSyncEpelTest(RiftTestCase):
         )
 
     def test_clean(self):
-        """Test RepoSyncEpelTest synchronization clean unindexed files and directories."""
+        """Test RepoSyncEpel clean removes unindexed files and dirs."""
         self._init_fake_epel_repo(
             {
                 "repo1": {

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -7,50 +7,52 @@ import shutil
 import urllib
 from unittest.mock import patch
 
-from .TestUtils import RiftTestCase, make_temp_dir
+from rift import RiftError
 from rift.Config import Config
 from rift.repository.rpm import LocalRepository
 from rift.RPM import RPM
 from rift.sync import (
-    RepoSyncFactory,
     RepoSyncBase,
-    RepoSyncLftp,
-    RepoSyncEpel,
     RepoSyncDnf,
+    RepoSyncEpel,
+    RepoSyncFactory,
+    RepoSyncLftp,
 )
-from rift import RiftError
+
+from .TestUtils import RiftTestCase, make_temp_dir
+
 
 class RepoSyncFactoryTest(RiftTestCase):
     """
     Tests class for RepoSyncFactory
     """
+
     def test_check_valid_method_valid(self):
-        """ Test RepoSyncFactory check_valid_method() does not fail with valid value."""
-        RepoSyncFactory.check_valid_method('lftp')
-        RepoSyncFactory.check_valid_method('epel')
+        """Test RepoSyncFactory check_valid_method() does not fail with valid value."""
+        RepoSyncFactory.check_valid_method("lftp")
+        RepoSyncFactory.check_valid_method("epel")
 
     def test_check_valid_method_invalid_value(self):
-        """ Test RepoSyncFactory check_valid_method() raises RiftError with invalid value."""
+        """Test RepoSyncFactory check_valid_method() raises RiftError with invalid value."""
         with self.assertRaisesRegex(
-            RiftError,
-            '^Unsupported repository synchronization method fail$'
+            RiftError, "^Unsupported repository synchronization method fail$"
         ):
-            RepoSyncFactory.check_valid_method('fail')
+            RepoSyncFactory.check_valid_method("fail")
 
     def test_get(self):
-        """ Test RepoSyncFactory get() return instance corresponding to method. """
+        """Test RepoSyncFactory get() return instance corresponding to method."""
         sync = {
-            'method': 'lftp',
-            'source': 'http://repo',
-            'include': [],
-            'exclude': [],
+            "method": "lftp",
+            "source": "http://repo",
+            "include": [],
+            "exclude": [],
         }
         self.assertIsInstance(
-            RepoSyncFactory.get(Config(), 'repo', '/output', sync), RepoSyncLftp
+            RepoSyncFactory.get(Config(), "repo", "/output", sync), RepoSyncLftp
         )
-        sync['method'] = 'epel'
+        sync["method"] = "epel"
         self.assertIsInstance(
-            RepoSyncFactory.get(Config(), 'repo', '/output', sync), RepoSyncEpel
+            RepoSyncFactory.get(Config(), "repo", "/output", sync), RepoSyncEpel
         )
 
 
@@ -58,16 +60,17 @@ class RepoSyncBaseTest(RiftTestCase):
     """
     Tests class for RepoSyncBase
     """
+
     def test_run(self):
-        """ Test RepoSyncBaseTest synchronization run raises NotImplementedError. """
+        """Test RepoSyncBaseTest synchronization run raises NotImplementedError."""
         sync = {
-            'method': 'lftp',
-            'source': 'http://repo/directory',
-            'include': [],
-            'exclude': [],
+            "method": "lftp",
+            "source": "http://repo/directory",
+            "include": [],
+            "exclude": [],
         }
         output = make_temp_dir()
-        synchronizer = RepoSyncBase(Config(), 'repo', output, sync)
+        synchronizer = RepoSyncBase(Config(), "repo", output, sync)
         with self.assertRaises(NotImplementedError):
             synchronizer.run()
         shutil.rmtree(output)
@@ -77,6 +80,7 @@ class RepoSyncLftpTest(RiftTestCase):
     """
     Tests class for RepoSyncLftp
     """
+
     def setUp(self):
         # Create temporary directory to store local mirror of remote repository
         self.output = make_temp_dir()
@@ -86,43 +90,45 @@ class RepoSyncLftpTest(RiftTestCase):
         # Remove temporary directory with local mirror
         shutil.rmtree(self.output)
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run(self, mock_subprocess_run):
-        """ Test RepoSyncLftpTest synchronization run. """
+        """Test RepoSyncLftpTest synchronization run."""
         sync = {
-            'method': 'lftp',
-            'source': 'http://repo/directory',
-            'include': [],
-            'exclude': [],
+            "method": "lftp",
+            "source": "http://repo/directory",
+            "include": [],
+            "exclude": [],
         }
-        synchronizer = RepoSyncLftp(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncLftp(self.config, "repo", self.output, sync)
         synchronizer.run()
         mock_subprocess_run.assert_called()
         args = mock_subprocess_run.call_args[0]
-        self.assertEqual(args[0][0], 'lftp')
-        self.assertEqual(args[0][1], 'http://repo')
+        self.assertEqual(args[0][0], "lftp")
+        self.assertEqual(args[0][1], "http://repo")
         self.assertTrue(f"/directory/ {self.output}/repo" in args[0][5])
         self.assertFalse("--include" in args[0][4])
         self.assertFalse("--exclude" in args[0][4])
         self.assertFalse("--log {self.output}/sync_repo_" in args[0][5])
 
         # Test with log file enabled
-        synchronizer = RepoSyncLftp(self.config, 'repo', self.output, sync, enable_log_file=True)
+        synchronizer = RepoSyncLftp(
+            self.config, "repo", self.output, sync, enable_log_file=True
+        )
         synchronizer.run()
         mock_subprocess_run.assert_called()
         args = mock_subprocess_run.call_args[0]
         self.assertTrue(f"--log {self.output}/sync_repo_" in args[0][5])
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_with_include_exclude(self, mock_subprocess_run):
-        """ Test RepoSyncLftpTest synchronization run with include/exclude. """
+        """Test RepoSyncLftpTest synchronization run with include/exclude."""
         sync = {
-            'method': 'lftp',
-            'source': 'http://repo/directory',
-            'include': [ 'include1', 'include2'],
-            'exclude': [ 'exclude1', 'exclude2'],
+            "method": "lftp",
+            "source": "http://repo/directory",
+            "include": ["include1", "include2"],
+            "exclude": ["exclude1", "exclude2"],
         }
-        synchronizer = RepoSyncLftp(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncLftp(self.config, "repo", self.output, sync)
         synchronizer.run()
         mock_subprocess_run.assert_called_once()
         args = mock_subprocess_run.call_args[0]
@@ -131,10 +137,12 @@ class RepoSyncLftpTest(RiftTestCase):
         self.assertTrue("--exclude=exclude1" in args[0][4])
         self.assertTrue("--exclude=exclude2" in args[0][4])
 
+
 class RepoSyncEpelTest(RiftTestCase):
     """
     Tests class for RepoSyncEpel
     """
+
     def setUp(self):
         self.config = Config()
         # Create temporary directory to store fake EPEL repository, set it as
@@ -155,7 +163,7 @@ class RepoSyncEpelTest(RiftTestCase):
 
     def _init_fake_epel_repo(self, content):
         with open(
-            os.path.join(self.fake_epel_dir, 'fullfiletimelist-epel'), 'w+'
+            os.path.join(self.fake_epel_dir, "fullfiletimelist-epel"), "w+"
         ) as fh:
             fh.write("[Files]\n")
             for repo, dirs in content.items():
@@ -163,10 +171,7 @@ class RepoSyncEpelTest(RiftTestCase):
                 for _dir, items in dirs.items():
                     fh.write(f"1\td\t0\t{repo}/{_dir}\n")
                     for item in items:
-                        fh.write(
-                            f"{item[0]}\t{item[1]}\t0\t"
-                            f"{repo}/{_dir}/{item[2]}\n"
-                        )
+                        fh.write(f"{item[0]}\t{item[1]}\t0\t{repo}/{_dir}/{item[2]}\n")
 
         for repo, dirs in content.items():
             os.mkdir(os.path.join(self.fake_epel_dir, repo))
@@ -174,229 +179,205 @@ class RepoSyncEpelTest(RiftTestCase):
                 os.mkdir(os.path.join(self.fake_epel_dir, repo, _dir))
                 for item in items:
                     open(
-                        os.path.join(
-                            self.fake_epel_dir, repo, _dir, item[2]
-                        ), 'w+'
+                        os.path.join(self.fake_epel_dir, repo, _dir, item[2]), "w+"
                     ).close()
 
     def test_run(self):
-        """ Test RepoSyncEpelTest synchronization run. """
-        self._init_fake_epel_repo({
-            'repo1': {
-                'p': [
-                    (1, 'f', 'package1.rpm'),
-                    (1, 'l', 'package2.rpm'),
-                ],
-            },
-            'repo2': {
-                'p': [
-                    (1, 'f', 'package3.rpm'),
-                ],
-            },
-        })
+        """Test RepoSyncEpelTest synchronization run."""
+        self._init_fake_epel_repo(
+            {
+                "repo1": {
+                    "p": [
+                        (1, "f", "package1.rpm"),
+                        (1, "l", "package2.rpm"),
+                    ],
+                },
+                "repo2": {
+                    "p": [
+                        (1, "f", "package3.rpm"),
+                    ],
+                },
+            }
+        )
         sync = {
-            'method': 'epel',
-            'source': f"file://{self.fake_epel_dir}/repo1",
-            'include': [],
-            'exclude': [],
+            "method": "epel",
+            "source": f"file://{self.fake_epel_dir}/repo1",
+            "include": [],
+            "exclude": [],
         }
-        synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncEpel(self.config, "repo", self.output, sync)
         synchronizer.run()
-        self.assertTrue(os.path.isdir(os.path.join(self.output, 'repo', 'p')))
+        self.assertTrue(os.path.isdir(os.path.join(self.output, "repo", "p")))
         # File package1.rpm in repo1 must be present
         self.assertTrue(
-            os.path.isfile(
-                os.path.join(self.output, 'repo', 'p', 'package1.rpm')
-            )
+            os.path.isfile(os.path.join(self.output, "repo", "p", "package1.rpm"))
         )
         # File declared as symlink in repo1 must not be present
         self.assertFalse(
-            os.path.exists(
-                os.path.join(self.output, 'repo', 'p', 'package2.rpm')
-            )
+            os.path.exists(os.path.join(self.output, "repo", "p", "package2.rpm"))
         )
         # File in repo2 must not be present
         self.assertFalse(
-            os.path.exists(
-                os.path.join(self.output, 'repo', 'p', 'package3.rpm')
-            )
+            os.path.exists(os.path.join(self.output, "repo", "p", "package3.rpm"))
         )
 
     def test_include_exclude(self):
-        """ Test RepoSyncEpelTest synchronization run with include/exclude. """
-        self._init_fake_epel_repo({
-            'repo1': {
-                'e': [
-                    (1, 'f', 'exclude1.rpm'),
-                    (1, 'f', 'exclude2.rpm'),
-                ],
-                'o': [
-                    (1, 'f', 'other1.rpm'),
-                    (1, 'f', 'other2.rpm'),
-                ],
-                'p': [
-                    (1, 'f', 'package1.rpm'),
-                    (1, 'f', 'package2.rpm'),
-                ],
-            },
-        })
+        """Test RepoSyncEpelTest synchronization run with include/exclude."""
+        self._init_fake_epel_repo(
+            {
+                "repo1": {
+                    "e": [
+                        (1, "f", "exclude1.rpm"),
+                        (1, "f", "exclude2.rpm"),
+                    ],
+                    "o": [
+                        (1, "f", "other1.rpm"),
+                        (1, "f", "other2.rpm"),
+                    ],
+                    "p": [
+                        (1, "f", "package1.rpm"),
+                        (1, "f", "package2.rpm"),
+                    ],
+                },
+            }
+        )
         sync = {
-            'method': 'epel',
-            'source': f"file://{self.fake_epel_dir}/repo1",
-            'include': [
-                '^o/',
-                '^p/'
-            ],
-            'exclude': [
-                '/other2.rpm$',
+            "method": "epel",
+            "source": f"file://{self.fake_epel_dir}/repo1",
+            "include": ["^o/", "^p/"],
+            "exclude": [
+                "/other2.rpm$",
             ],
         }
-        synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncEpel(self.config, "repo", self.output, sync)
         synchronizer.run()
-        self.assertTrue(os.path.isdir(os.path.join(self.output, 'repo', 'o')))
-        self.assertTrue(os.path.isdir(os.path.join(self.output, 'repo', 'p')))
+        self.assertTrue(os.path.isdir(os.path.join(self.output, "repo", "o")))
+        self.assertTrue(os.path.isdir(os.path.join(self.output, "repo", "p")))
         # All files in e/* are not included
-        self.assertFalse(os.path.exists(os.path.join(self.output, 'repo', 'e')))
+        self.assertFalse(os.path.exists(os.path.join(self.output, "repo", "e")))
         self.assertTrue(
-            os.path.isfile(
-                os.path.join(self.output, 'repo', 'p', 'package1.rpm')
-            )
+            os.path.isfile(os.path.join(self.output, "repo", "p", "package1.rpm"))
         )
         self.assertTrue(
-            os.path.isfile(
-                os.path.join(self.output, 'repo', 'p', 'package2.rpm')
-            )
+            os.path.isfile(os.path.join(self.output, "repo", "p", "package2.rpm"))
         )
         self.assertTrue(
-            os.path.isfile(os.path.join(self.output, 'repo', 'o', 'other1.rpm'))
+            os.path.isfile(os.path.join(self.output, "repo", "o", "other1.rpm"))
         )
         # Package other2.rpm is excluded
         self.assertFalse(
-            os.path.exists(os.path.join(self.output, 'repo', 'o', 'other2.rpm'))
+            os.path.exists(os.path.join(self.output, "repo", "o", "other2.rpm"))
         )
 
     def test_update(self):
-        """ Test RepoSyncEpelTest synchronization update packages based on timestamp. """
-        self._init_fake_epel_repo({
-            'repo1': {
-                'p': [
-                    (1, 'f', 'package1.rpm'),
-                    (2**32, 'f', 'package2.rpm'),
-                ],
-            },
-        })
-        sync = {
-            'method': 'epel',
-            'source': f"file://{self.fake_epel_dir}/repo1",
-            'include': [],
-            'exclude': [],
-        }
-        os.mkdir(os.path.join(self.output, 'repo'))
-        os.mkdir(os.path.join(self.output, 'repo', 'p'))
-        with open(
-            os.path.join(self.output, 'repo', 'p', 'package1.rpm'), 'w+'
-        ) as fh:
-            fh.write("content1")
-        with open(
-            os.path.join(self.output, 'repo', 'p', 'package2.rpm'), 'w+'
-        ) as fh:
-            fh.write("content2")
-        synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
-        synchronizer.run()
-        self.assertFalse(
-            os.path.isdir(os.path.join(self.output, 'repo', 'outside'))
+        """Test RepoSyncEpelTest synchronization update packages based on timestamp."""
+        self._init_fake_epel_repo(
+            {
+                "repo1": {
+                    "p": [
+                        (1, "f", "package1.rpm"),
+                        (2**32, "f", "package2.rpm"),
+                    ],
+                },
+            }
         )
+        sync = {
+            "method": "epel",
+            "source": f"file://{self.fake_epel_dir}/repo1",
+            "include": [],
+            "exclude": [],
+        }
+        os.mkdir(os.path.join(self.output, "repo"))
+        os.mkdir(os.path.join(self.output, "repo", "p"))
+        with open(os.path.join(self.output, "repo", "p", "package1.rpm"), "w+") as fh:
+            fh.write("content1")
+        with open(os.path.join(self.output, "repo", "p", "package2.rpm"), "w+") as fh:
+            fh.write("content2")
+        synchronizer = RepoSyncEpel(self.config, "repo", self.output, sync)
+        synchronizer.run()
+        self.assertFalse(os.path.isdir(os.path.join(self.output, "repo", "outside")))
         # package1 must not be updated (with content unchanged) as mtime on FS
         # is younger than timestamp in files index.
         self.assertEqual(
-            open(os.path.join(self.output, 'repo', 'p', 'package1.rpm')).read(),
-            "content1"
+            open(os.path.join(self.output, "repo", "p", "package1.rpm")).read(),
+            "content1",
         )
         # package2 must be updated (with content removed) as mtime on FS is
         # older than timestamp in files index
         self.assertEqual(
-            open(os.path.join(self.output, 'repo', 'p', 'package2.rpm')).read(),
-            ""
+            open(os.path.join(self.output, "repo", "p", "package2.rpm")).read(), ""
         )
 
     def test_clean(self):
-        """ Test RepoSyncEpelTest synchronization clean unindexed files and directories. """
-        self._init_fake_epel_repo({
-            'repo1': {
-                'p': [
-                    (1, 'f', 'package1.rpm'),
-                    (1, 'f', 'package2.rpm'),
-                ],
-            },
-        })
-        sync = {
-            'method': 'epel',
-            'source': f"file://{self.fake_epel_dir}/repo1",
-            'include': [],
-            'exclude': [],
-        }
-        os.mkdir(os.path.join(self.output, 'repo'))
-        os.mkdir(os.path.join(self.output, 'repo', 'outside'))
-        os.mkdir(os.path.join(self.output, 'repo', 'p'))
-        open(
-            os.path.join(self.output, 'repo', 'p', 'package3.rpm'), 'w+'
-        ).close()
-        synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
-        synchronizer.run()
-        self.assertFalse(
-            os.path.isdir(os.path.join(self.output, 'repo', 'outside'))
+        """Test RepoSyncEpelTest synchronization clean unindexed files and directories."""
+        self._init_fake_epel_repo(
+            {
+                "repo1": {
+                    "p": [
+                        (1, "f", "package1.rpm"),
+                        (1, "f", "package2.rpm"),
+                    ],
+                },
+            }
         )
+        sync = {
+            "method": "epel",
+            "source": f"file://{self.fake_epel_dir}/repo1",
+            "include": [],
+            "exclude": [],
+        }
+        os.mkdir(os.path.join(self.output, "repo"))
+        os.mkdir(os.path.join(self.output, "repo", "outside"))
+        os.mkdir(os.path.join(self.output, "repo", "p"))
+        open(os.path.join(self.output, "repo", "p", "package3.rpm"), "w+").close()
+        synchronizer = RepoSyncEpel(self.config, "repo", self.output, sync)
+        synchronizer.run()
+        self.assertFalse(os.path.isdir(os.path.join(self.output, "repo", "outside")))
         # File package1.rpm in repo1 must be present
         self.assertTrue(
-            os.path.isfile(
-                os.path.join(self.output, 'repo', 'p', 'package1.rpm')
-            )
+            os.path.isfile(os.path.join(self.output, "repo", "p", "package1.rpm"))
         )
         # File declared as symlink in repo1 must not be present
         self.assertTrue(
-            os.path.exists(
-                os.path.join(self.output, 'repo', 'p', 'package2.rpm')
-            )
+            os.path.exists(os.path.join(self.output, "repo", "p", "package2.rpm"))
         )
         # File in repo2 must not be present
         self.assertFalse(
-            os.path.exists(
-                os.path.join(self.output, 'repo', 'p', 'package3.rpm')
-            )
+            os.path.exists(os.path.join(self.output, "repo", "p", "package3.rpm"))
         )
 
     def test_wrong_url(self):
-        """ Test RepoSyncEpelTest synchronization raises RiftError with wrong URLs. """
+        """Test RepoSyncEpelTest synchronization raises RiftError with wrong URLs."""
         sync = {
-            'method': 'epel',
-            'source': 'http://test',
-            'include': [],
-            'exclude': [],
+            "method": "epel",
+            "source": "http://test",
+            "include": [],
+            "exclude": [],
         }
-        synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncEpel(self.config, "repo", self.output, sync)
         with patch(
-            'rift.utils.urllib.request.urlopen',
-            side_effect=urllib.error.URLError('fake URL error'),
+            "rift.utils.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("fake URL error"),
         ):
-            with self.assertLogs(level='WARNING') as log:
+            with self.assertLogs(level="WARNING") as log:
                 synchronizer.run()
                 self.assertRegex(
                     log.output[0],
                     r"WARNING:root:Download failed, skipping entry: "
-                    r"Error while downloading http://test/.*: .*$"
+                    r"Error while downloading http://test/.*: .*$",
                 )
-        synchronizer = RepoSyncEpel(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncEpel(self.config, "repo", self.output, sync)
         with patch(
-            'rift.utils.urllib.request.urlopen',
-            side_effect=urllib.error.HTTPError(404, "404", 'Not Found', None, None),
+            "rift.utils.urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(404, "404", "Not Found", None, None),
         ):
-            with self.assertLogs(level='WARNING') as log:
+            with self.assertLogs(level="WARNING") as log:
                 synchronizer.run()
                 self.assertRegex(
                     log.output[0],
                     r"WARNING:root:Download failed, skipping entry: "
                     r"Error while downloading http://test/.*: "
-                    r"HTTP Error 404: Not Found"
+                    r"HTTP Error 404: Not Found",
                 )
 
 
@@ -404,9 +385,10 @@ class RepoSyncDnfTest(RiftTestCase):
     """
     Tests class for RepoSyncDnf
     """
+
     def setUp(self):
         self.config = Config()
-        self.arch = self.config.get('arch')[0]
+        self.arch = self.config.get("arch")[0]
         # Create temporary directory to store fake DNF repository.
         self.fake_dnf_repo = make_temp_dir()
         # Create repository
@@ -414,12 +396,8 @@ class RepoSyncDnfTest(RiftTestCase):
         repo.create()
         tests_dir = os.path.dirname(os.path.abspath(__file__))
         # Add source and binary packages from tests materials
-        self.src_rpm = RPM(
-            os.path.join(tests_dir, 'materials', 'pkg-1.0-1.src.rpm')
-        )
-        self.bin_rpm = RPM(
-            os.path.join(tests_dir, 'materials', 'pkg-1.0-1.noarch.rpm')
-        )
+        self.src_rpm = RPM(os.path.join(tests_dir, "materials", "pkg-1.0-1.src.rpm"))
+        self.bin_rpm = RPM(os.path.join(tests_dir, "materials", "pkg-1.0-1.noarch.rpm"))
         repo.add(self.bin_rpm)
         repo.add(self.src_rpm)
         # Update repository
@@ -434,15 +412,15 @@ class RepoSyncDnfTest(RiftTestCase):
         shutil.rmtree(self.output)
 
     def test_run(self):
-        """ Test RepoSyncDnfTest synchronization run. """
+        """Test RepoSyncDnfTest synchronization run."""
         sync = {
-            'method': 'dnf',
-            'source': f"file://{self.fake_dnf_repo}",
-            'subdir': self.arch,
-            'include': [],
-            'exclude': [],
+            "method": "dnf",
+            "source": f"file://{self.fake_dnf_repo}",
+            "subdir": self.arch,
+            "include": [],
+            "exclude": [],
         }
-        repo_name = 'repo'
+        repo_name = "repo"
         synchronizer = RepoSyncDnf(self.config, repo_name, self.output, sync)
         synchronizer.run()
         self.assertTrue(
@@ -451,36 +429,31 @@ class RepoSyncDnfTest(RiftTestCase):
                     self.output,
                     repo_name,
                     self.arch,
-                    os.path.basename(self.bin_rpm.filepath)
+                    os.path.basename(self.bin_rpm.filepath),
                 )
             )
         )
         self.assertTrue(
-            os.path.isdir(
-                os.path.join(self.output, repo_name, self.arch, 'repodata')
-            )
+            os.path.isdir(os.path.join(self.output, repo_name, self.arch, "repodata"))
         )
 
     def test_include_exclude(self):
-        """ Test RepoSyncDnfTest synchronization run with include/exclude. """
+        """Test RepoSyncDnfTest synchronization run with include/exclude."""
         # First test without exclude pattern but with an include pattern that
         # does not match any package. The binary package must not be
         # synchronized (because it does not match include pattern).
         sync = {
-            'method': 'dnf',
-            'source': f"file://{self.fake_dnf_repo}",
-            'subdir': self.arch,
-            'include': [
+            "method": "dnf",
+            "source": f"file://{self.fake_dnf_repo}",
+            "subdir": self.arch,
+            "include": [
                 r"fail",
             ],
-            'exclude': [],
+            "exclude": [],
         }
-        repo_name = 'repo'
+        repo_name = "repo"
         bin_pkg_path = os.path.join(
-            self.output,
-            repo_name,
-            self.arch,
-            os.path.basename(self.bin_rpm.filepath)
+            self.output, repo_name, self.arch, os.path.basename(self.bin_rpm.filepath)
         )
         synchronizer = RepoSyncDnf(self.config, repo_name, self.output, sync)
         synchronizer.run()
@@ -488,57 +461,54 @@ class RepoSyncDnfTest(RiftTestCase):
         # Then test without exclude pattern but with an include pattern that
         # matches the binary package name. The binary package must be
         # synchronized.
-        sync['include'] = [os.path.basename(self.bin_rpm.filepath)]
+        sync["include"] = [os.path.basename(self.bin_rpm.filepath)]
         synchronizer = RepoSyncDnf(self.config, repo_name, self.output, sync)
         synchronizer.run()
         self.assertTrue(os.path.isfile(bin_pkg_path))
         # Finally test without include pattern but with an exclude pattern that
         # matches the binary package name. The binary package must be removed.
-        sync['include'] = []
-        sync['exclude'] = [ r"^pkg-\d" ]
+        sync["include"] = []
+        sync["exclude"] = [r"^pkg-\d"]
         synchronizer = RepoSyncDnf(self.config, repo_name, self.output, sync)
         synchronizer.run()
         self.assertFalse(os.path.exists(bin_pkg_path))
 
     def test_skip_downloaded(self):
-        """ Test RepoSyncDnfTest skip already downloaded packages. """
+        """Test RepoSyncDnfTest skip already downloaded packages."""
         # First test without exclude pattern but with an include pattern that
         # does not match any package. The binary package must not be
         # synchronized (because it does not match include pattern).
         sync = {
-            'method': 'dnf',
-            'source': f"file://{self.fake_dnf_repo}",
-            'subdir': self.arch,
-            'include': [],
-            'exclude': [],
+            "method": "dnf",
+            "source": f"file://{self.fake_dnf_repo}",
+            "subdir": self.arch,
+            "include": [],
+            "exclude": [],
         }
-        repo_name = 'repo'
+        repo_name = "repo"
         bin_pkg_path = os.path.join(
-            self.output,
-            repo_name,
-            self.arch,
-            os.path.basename(self.bin_rpm.filepath)
+            self.output, repo_name, self.arch, os.path.basename(self.bin_rpm.filepath)
         )
         synchronizer = RepoSyncDnf(self.config, repo_name, self.output, sync)
         # Create empty file to simulate package presence
         os.makedirs(os.path.dirname(bin_pkg_path))
-        open(bin_pkg_path, 'w+').close()
+        open(bin_pkg_path, "w+").close()
         # Check debug log to indicate skipped file is emited
-        with self.assertLogs(level='DEBUG') as log:
+        with self.assertLogs(level="DEBUG") as log:
             synchronizer.run()
             self.assertIn(
                 f"DEBUG:root:Ignoring existing file {bin_pkg_path}", log.output
             )
 
     def test_wrong_url(self):
-        """ Test RepoSyncDnfTest synchronization raises RiftError with wrong URLs. """
+        """Test RepoSyncDnfTest synchronization raises RiftError with wrong URLs."""
         sync = {
-            'method': 'dnf',
-            'source': 'https://127.0.0.1/fail',
-            'include': [],
-            'exclude': [],
+            "method": "dnf",
+            "source": "https://127.0.0.1/fail",
+            "include": [],
+            "exclude": [],
         }
-        synchronizer = RepoSyncDnf(self.config, 'repo', self.output, sync)
+        synchronizer = RepoSyncDnf(self.config, "repo", self.output, sync)
         with self.assertRaisesRegex(
             RiftError,
             r"^Unable to download repository metadata from URL "

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,24 +2,24 @@
 # Copyright (C) 2025 CEA
 #
 
-from io import StringIO, BytesIO
-from unittest.mock import patch, Mock, call, MagicMock
 import os
 import urllib.error
+from io import BytesIO, StringIO
+from unittest.mock import MagicMock, Mock, call, patch
 
 from rift import RiftError
-from rift.utils import message, banner, download_file, last_modified
+from rift.utils import banner, download_file, last_modified, message
+
 from .TestUtils import RiftTestCase
 
 
 class UtilsTest(RiftTestCase):
-
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_message(self, mock_stdout):
         message("foo")
         self.assertEqual(mock_stdout.getvalue(), "> foo\n")
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_banner(self, mock_stdout):
         banner("bar")
         self.assertEqual(mock_stdout.getvalue(), "** bar **\n")
@@ -29,52 +29,50 @@ class UtilsTest(RiftTestCase):
         self.assert_file_exists("/tmp/blob")
         os.remove("/tmp/blob")
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_download_file_bearer_token(self, mock_urlopen):
-        mock_urlopen.return_value.__enter__.return_value = BytesIO(b'x')
-        download_file('https://test', '/tmp/blob', bearer_token='tok')
+        mock_urlopen.return_value.__enter__.return_value = BytesIO(b"x")
+        download_file("https://test", "/tmp/blob", bearer_token="tok")
         # Check that Authorization header is set
         req = mock_urlopen.call_args[0][0]
         hdrs = dict(req.header_items())
-        self.assertEqual(hdrs.get('Authorization'), 'Bearer tok')
-        os.remove('/tmp/blob')
+        self.assertEqual(hdrs.get("Authorization"), "Bearer tok")
+        os.remove("/tmp/blob")
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_download_file_too_large(self, mock_urlopen):
         mock_url = Mock()
-        mock_url.info.return_value = {
-            "Content-Length": "50"
-        }
+        mock_url.info.return_value = {"Content-Length": "50"}
         mock_urlopen.return_value.__enter__.return_value = mock_url
         with self.assertRaisesRegex(
-                RiftError,
-                "'https://test' has a size of '50' bytes, larger than "
-                "max size '20', skipping download"
+            RiftError,
+            "'https://test' has a size of '50' bytes, larger than "
+            "max size '20', skipping download",
         ):
             download_file("https://test", "/tmp/blob", 20)
 
     def test_download_file_url_error(self):
         with self.assertRaisesRegex(
-                RiftError,
-                "Error while downloading blob:localhost: "
-                "<urlopen error unknown url type: blob>"
+            RiftError,
+            "Error while downloading blob:localhost: "
+            "<urlopen error unknown url type: blob>",
         ):
             download_file("blob:localhost", "/tmp/blob")
 
-    @patch('rift.utils.time.sleep')
-    @patch('urllib.request.urlopen')
+    @patch("rift.utils.time.sleep")
+    @patch("urllib.request.urlopen")
     def test_download_file_retries_success(self, mock_urlopen, mock_sleep):
-        url = 'https://example.test/file'
+        url = "https://example.test/file"
 
         open_cm = MagicMock()
-        open_cm.__enter__.return_value = BytesIO(b'payload')
+        open_cm.__enter__.return_value = BytesIO(b"payload")
         open_cm.__exit__.return_value = False
 
         # Simulate a transient error followed by a successful download
-        mock_urlopen.side_effect = [urllib.error.URLError('transient'), open_cm]
+        mock_urlopen.side_effect = [urllib.error.URLError("transient"), open_cm]
 
-        out = '/tmp/rift-dl-retry-test'
-        with self.assertLogs(level='INFO') as log_cm:
+        out = "/tmp/rift-dl-retry-test"
+        with self.assertLogs(level="INFO") as log_cm:
             download_file(url, out, retries=2)
 
         self.assert_file_exists(out)
@@ -83,27 +81,26 @@ class UtilsTest(RiftTestCase):
         self.assertEqual(
             log_cm.output,
             [
-                f'INFO:root:Error while downloading {url}: <urlopen error transient>, '
-                f'will retry in 3 seconds…',
+                f"INFO:root:Error while downloading {url}: <urlopen error transient>, "
+                f"will retry in 3 seconds…",
             ],
         )
         os.remove(out)
 
-    @patch('rift.utils.time.sleep')
-    @patch('urllib.request.urlopen')
-    def test_download_file_retries_failure(
-            self, mock_urlopen, mock_sleep):
-        url = 'https://example.test/missing'
-        out = '/tmp/never-written'
+    @patch("rift.utils.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_download_file_retries_failure(self, mock_urlopen, mock_sleep):
+        url = "https://example.test/missing"
+        out = "/tmp/never-written"
         mock_urlopen.side_effect = urllib.error.HTTPError(
-            url, 503, 'Service Unavailable', None, None
+            url, 503, "Service Unavailable", None, None
         )
 
-        with self.assertLogs(level='INFO') as log_cm:
+        with self.assertLogs(level="INFO") as log_cm:
             with self.assertRaisesRegex(
                 RiftError,
-                r'^Error while downloading https://example\.test/missing: '
-                r'HTTP Error 503: Service Unavailable$',
+                r"^Error while downloading https://example\.test/missing: "
+                r"HTTP Error 503: Service Unavailable$",
             ):
                 download_file(url, out, retries=2)
 
@@ -111,33 +108,33 @@ class UtilsTest(RiftTestCase):
         self.assertCountEqual(
             log_cm.output,
             [
-                f'INFO:root:Error while downloading {url}: HTTP Error 503: '
-                f'Service Unavailable, will retry in 3 seconds…',
-                f'INFO:root:Error while downloading {url}: HTTP Error 503: '
-                f'Service Unavailable, will retry in 6 seconds…',
+                f"INFO:root:Error while downloading {url}: HTTP Error 503: "
+                f"Service Unavailable, will retry in 3 seconds…",
+                f"INFO:root:Error while downloading {url}: HTTP Error 503: "
+                f"Service Unavailable, will retry in 6 seconds…",
             ],
         )
         mock_sleep.assert_has_calls([call(3), call(6)])
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_last_modified(self, mock_urlopen):
         mock_response = Mock()
         mock_response.getheader.return_value = "Sat, 1 Jan 2000 00:00:00 GMT"
         mock_urlopen.return_value.__enter__.return_value = mock_response
         self.assertEqual(last_modified("http://test"), 946684800)
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_last_modified_bearer_token(self, mock_urlopen):
         mock_response = Mock()
         mock_response.getheader.return_value = "Sat, 1 Jan 2000 00:00:00 GMT"
         mock_urlopen.return_value.__enter__.return_value = mock_response
-        self.assertEqual(last_modified("http://test", bearer_token='tok'), 946684800)
+        self.assertEqual(last_modified("http://test", bearer_token="tok"), 946684800)
         # Check that Authorization header is set
         req = mock_urlopen.call_args[0][0]
         hdrs = dict(req.header_items())
-        self.assertEqual(hdrs.get('Authorization'), 'Bearer tok')
+        self.assertEqual(hdrs.get("Authorization"), "Bearer tok")
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_last_modified_header_not_found(self, mock_urlopen):
         mock_response = Mock()
         mock_response.getheader.return_value = None
@@ -147,20 +144,19 @@ class UtilsTest(RiftTestCase):
         ):
             last_modified("http://test")
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_last_modified_header_conversion_error(self, mock_urlopen):
         mock_response = Mock()
         mock_response.getheader.return_value = "Sat, 1 Jan 2000 00:00:00"
         mock_urlopen.return_value.__enter__.return_value = mock_response
         with self.assertRaisesRegex(
             RiftError,
-            "^Unable to convert Last-Modified header to datetime for URL http://test$"
+            "^Unable to convert Last-Modified header to datetime for URL http://test$",
         ):
             last_modified("http://test")
 
     def test_last_modified_url_error(self):
         with self.assertRaisesRegex(
-            RiftError,
-            "^Unable to send HTTP HEAD request for URL http://localhost: .*$"
+            RiftError, "^Unable to send HTTP HEAD request for URL http://localhost: .*$"
         ):
             last_modified("http://localhost")


### PR DESCRIPTION
Format Python code automatically with [ruff](https://docs.astral.sh/ruff/). Adopt default ruff conventions, and enable _isort_, _Pyflakes_ and _pycodestyle_ options.

Use [prek](https://prek.j178.dev/) to run _ruff_ automatically on Git _pre-commit_ hook and GHA CI. Also enable some _prek_ generic builtin checks for on all other files.

Some documentation is added in `README.md` to explain how to install _ruff_ and _prek_ in developers environment.