### PR TITLE
Support project w/o host arch for Mock chroot

### DIFF
--- a/lib/rift/config.py
+++ b/lib/rift/config.py
@@ -37,6 +37,7 @@ Config:
 import errno
 import logging
 import os
+import platform
 import warnings
 
 import yaml
@@ -408,6 +409,19 @@ class Config:
             filepath = os.path.join(self.project_dir, filepath)
 
         return filepath
+
+    def chroot_arch(self):
+        """
+        Return a project architecture suitable for a Mock chroot.
+
+        For performance reasons, prefer the host CPU architecture when it is listed in
+        the project, otherwise return the first project supported architecture.
+        """
+        host = platform.machine()
+        archs = self.get("arch")
+        if host in archs:
+            return host
+        return archs[0]
 
     def get(self, option, default=None, arch=None):
         """

--- a/lib/rift/controller.py
+++ b/lib/rift/controller.py
@@ -37,7 +37,6 @@ Controler.py:
 import argparse
 import logging
 import os
-import platform
 import time
 from operator import attrgetter
 
@@ -568,8 +567,9 @@ def action_check(args, config):
         if args.file is None:
             raise RiftError("You must specify a file path (-f)")
 
-        mock = Mock(config, platform.machine())
-        repos = ProjectArchRepositories(config, platform.machine()).for_format("rpm")
+        arch = config.chroot_arch()
+        mock = Mock(config, arch)
+        repos = ProjectArchRepositories(config, arch).for_format("rpm")
         spec = Spec(args.file, mock, repos.all, config=config)
         spec.check()
         logging.info("Spec file is OK.")

--- a/lib/rift/package/rpm.py
+++ b/lib/rift/package/rpm.py
@@ -33,7 +33,6 @@
 
 import logging
 import os
-import platform
 import random
 import re
 import shutil
@@ -96,7 +95,7 @@ class PackageRPM(Package):
         its main attributes."""
         # load infos.yaml with parent class
         super().load(infopath)
-        arch_pkg = self.for_arch(platform.machine())
+        arch_pkg = self.for_arch(self._config.chroot_arch())
         self.spec = Spec(
             self.buildfile, arch_pkg.mock, arch_pkg.repos.all, config=self._config
         )

--- a/lib/rift/repository/rpm.py
+++ b/lib/rift/repository/rpm.py
@@ -37,7 +37,6 @@ Helper class for YUM repository structure management.
 import glob
 import logging
 import os
-import platform
 import shutil
 import threading
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen, run
@@ -233,10 +232,11 @@ class LocalRepository:
             except CalledProcessError as err:
                 raise RiftError(err) from err
             # Parse spec file
+            arch = self.config.chroot_arch()
             spec = Spec(
                 os.path.join(tmp_dir.path, "SPECS", f"{src_rpm.name}.spec"),
-                Mock(self.config, platform.machine()),
-                ArchRepositoriesRPM(self.config, None, platform.machine()).all,
+                Mock(self.config, arch),
+                ArchRepositoriesRPM(self.config, None, arch).all,
             )
             # Remove tmp directory
             tmp_dir.delete()

--- a/tests/config.py
+++ b/tests/config.py
@@ -5,6 +5,7 @@
 import os
 import os.path
 import textwrap
+from unittest.mock import patch
 
 from rift import DeclError
 from rift.config import (
@@ -229,6 +230,22 @@ class ConfigTest(RiftTestCase):
             "^Unable to set configuration option for unsupported architecture 'fail'$",
         ):
             config.set("vm", {"image": "/path/to/image.qcow2"}, arch="fail")
+
+    def test_chroot_arch_host_supported(self):
+        """chroot_arch() returns host when it is a project architecture"""
+        config = Config()
+        config.set("arch", ["x86_64", "aarch64"])
+        with patch("rift.config.platform.machine", return_value="x86_64"):
+            self.assertEqual(config.chroot_arch(), "x86_64")
+        with patch("rift.config.platform.machine", return_value="aarch64"):
+            self.assertEqual(config.chroot_arch(), "aarch64")
+
+    def test_chroot_arch_host_unsupported(self):
+        """chroot_arch() returns first project arch when host is not supported"""
+        config = Config()
+        config.set("arch", ["aarch64"])
+        with patch("rift.config.platform.machine", return_value="x86_64"):
+            self.assertEqual(config.chroot_arch(), "aarch64")
 
     def test_load(self):
         """load() checks mandatory options are present"""


### PR DESCRIPTION
Rift launches some commands using Mock (eg. rpmspec, rpmlint) in target build environment to increase reproducibility and avoid differences due to mixed versions of these tools depending on system OS. Rift was systematically selecting Mock environment corresponding to host's native CPU architecture, but this didn't work when Rift project was not supporting this CPU architecture.

A helper is introduced in Config class to return the host CPU architecture when supported, or the first project architecture otherwise. And this helper is now called in every sites Mock was used with host CPU architecture in Rift code base.