### PR TITLE
Start IDP authenticated repositories proxy on rift vm connect

### DIFF
--- a/lib/rift/controller.py
+++ b/lib/rift/controller.py
@@ -364,7 +364,12 @@ def make_parser():
     subprs = subparsers.add_parser("vm", help="Manipulate VM process")
     subprs.add_argument("-a", "--arch", help="CPU architecture of the VM")
     subprs_vm = subprs.add_subparsers(dest="vm_cmd", title="possible commands")
-    subprs_vm.add_parser("connect", help="connect to running VM")
+    subsubprs = subprs_vm.add_parser("connect", help="connect to running VM")
+    subsubprs.add_argument(
+        "--noproxy",
+        action="store_true",
+        help="do not start the IDP repository proxy",
+    )
     subsubprs = subprs_vm.add_parser("start", help="launch a new VM")
     subsubprs.add_argument(
         "--force",
@@ -835,7 +840,7 @@ def action_vm(args, config):
         raise RiftError(f"Project does not support architecture '{args.arch}'")
     vm = VM(config, args.arch)
     if args.vm_cmd == "connect":
-        ret = vm.connect()
+        ret = vm.connect(proxy=not args.noproxy)
     elif args.vm_cmd == "console":
         ret = vm.console()
     elif args.vm_cmd == "cmd":

--- a/lib/rift/controller.py
+++ b/lib/rift/controller.py
@@ -835,7 +835,7 @@ def action_vm(args, config):
         raise RiftError(f"Project does not support architecture '{args.arch}'")
     vm = VM(config, args.arch)
     if args.vm_cmd == "connect":
-        ret = vm.cmd(options=None, manage_output=False).returncode
+        ret = vm.connect()
     elif args.vm_cmd == "console":
         ret = vm.console()
     elif args.vm_cmd == "cmd":

--- a/lib/rift/vm.py
+++ b/lib/rift/vm.py
@@ -36,6 +36,7 @@ Class to start, stop and manipulate VM used mostly for testing.
 
 import atexit
 import datetime
+import errno
 import grp
 import hashlib
 import logging
@@ -164,7 +165,7 @@ class VM:
         self._auth_proxy = AuthenticatedRepositoryProxyRuntime(config, self._repos)
 
         self.address = vm_config.get("address")
-        self.port = self.default_port(vm_config.get("port_range"))
+        self.port, self.proxy_port = self.default_ports(vm_config.get("port_range"))
         self.cpus = vm_config.get("cpus", 1)
         self.memory = vm_config.get("memory")
         self.qemu = config.get("qemu", arch=arch)
@@ -239,10 +240,13 @@ class VM:
             return True
         raise RiftError(f"Unsupported VM image URL scheme {self._image_src.scheme}")
 
-    def default_port(self, port_range):
+    def default_ports(self, port_range):
         """
-        Return the default port number for this VM considering its unique
-        identifier and the given port range.
+        Return (ssh_port, proxy_port) in the given range for this VM.
+
+        SSH port is derived from the VM unique identifier. Proxy port is the
+        next port in the range (wrapping) so it never matches this VM's SSH
+        port.
         """
         try:
             assert port_range["max"] > port_range["min"]
@@ -250,9 +254,33 @@ class VM:
             raise RiftError(
                 "VM port range maximum must be greater than the minimum"
             ) from exc
-        return (
-            int(self.vmid, 16) % (port_range["max"] - port_range["min"])
-        ) + port_range["min"]
+        span = port_range["max"] - port_range["min"]
+        ssh = (int(self.vmid, 16) % span) + port_range["min"]
+        proxy = port_range["min"] + ((ssh - port_range["min"] + 1) % span)
+        return ssh, proxy
+
+    def _start_auth_proxy(self, reuse=False):
+        """
+        Start the IDP repository proxy on this VM's proxy port.
+
+        Return True if this call started the server and the caller must stop
+        it. If reuse is True and the port is already bound, log and return
+        False so an existing listener can be used.
+        """
+        if not self._auth_proxy.required:
+            return False
+        try:
+            self._auth_proxy.start(port=self.proxy_port)
+        except OSError as err:
+            if reuse and err.errno == errno.EADDRINUSE:
+                logging.info(
+                    "Repository proxy port %s already in use, "
+                    "reusing existing listener",
+                    self.proxy_port,
+                )
+                return False
+            raise
+        return True
 
     def _vm_image_bearer_token(self):
         """Return bearer token for remote VM image HTTP(S) requests, or None."""
@@ -649,7 +677,13 @@ class VM:
 
     def connect(self):
         """Open an interactive SSH session to the running VM."""
-        return self.cmd(options=None, manage_output=False).returncode
+        started = False
+        try:
+            started = self._start_auth_proxy(reuse=True)
+            return self.cmd(options=None, manage_output=False).returncode
+        finally:
+            if started:
+                self._auth_proxy.stop()
 
     def copy(self, source, dest, stderr=None):
         """Copy files from or to VM"""
@@ -847,7 +881,7 @@ class VM:
 
         message("Launching VM ...")
         # Start authenticated repositories proxy
-        self._auth_proxy.start()
+        self._start_auth_proxy()
         self.spawn()
         self.ready()
         self.prepare()
@@ -1040,7 +1074,7 @@ class VM:
         base_image_path = self._dl_base_image(url, force)
 
         # Start authenticated repositories proxy
-        self._auth_proxy.start()
+        self._start_auth_proxy()
 
         # Build cloud-init seed iso
         seed_iso_file = self._build_seed_iso()

--- a/lib/rift/vm.py
+++ b/lib/rift/vm.py
@@ -675,11 +675,12 @@ class VM:
         logging.debug("Running command in VM: %s", " ".join(cmd))
         return run_command(cmd, **kwargs)
 
-    def connect(self):
+    def connect(self, proxy=True):
         """Open an interactive SSH session to the running VM."""
         started = False
         try:
-            started = self._start_auth_proxy(reuse=True)
+            if proxy:
+                started = self._start_auth_proxy(reuse=True)
             return self.cmd(options=None, manage_output=False).returncode
         finally:
             if started:

--- a/lib/rift/vm.py
+++ b/lib/rift/vm.py
@@ -647,6 +647,10 @@ class VM:
         logging.debug("Running command in VM: %s", " ".join(cmd))
         return run_command(cmd, **kwargs)
 
+    def connect(self):
+        """Open an interactive SSH session to the running VM."""
+        return self.cmd(options=None, manage_output=False).returncode
+
     def copy(self, source, dest, stderr=None):
         """Copy files from or to VM"""
         cmd = [

--- a/tests/controller.py
+++ b/tests/controller.py
@@ -2478,7 +2478,16 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
         mock_vm.connect.return_value = 0
 
         self.assertEqual(main(["vm", "connect"]), 0)
-        mock_vm.connect.assert_called_once_with()
+        mock_vm.connect.assert_called_once_with(proxy=True)
+
+    @patch("rift.controller.VM")
+    def test_action_vm_connect_noproxy(self, mock_vm_class):
+        """'rift vm connect --noproxy' disables IDP proxy startup"""
+        mock_vm = mock_vm_class.return_value
+        mock_vm.connect.return_value = 0
+
+        self.assertEqual(main(["vm", "connect", "--noproxy"]), 0)
+        mock_vm.connect.assert_called_once_with(proxy=False)
 
     @patch("rift.controller.VM")
     def test_action_vm_build(self, mock_vm_class):
@@ -3629,6 +3638,12 @@ class ControllerArgumentsTest(RiftTestCase):
         args = ["vm", "connect"]
         opts = parser.parse_args(args)
         self.assertEqual(opts.vm_cmd, "connect")
+        self.assertFalse(opts.noproxy)
+
+        args = ["vm", "connect", "--noproxy"]
+        opts = parser.parse_args(args)
+        self.assertEqual(opts.vm_cmd, "connect")
+        self.assertTrue(opts.noproxy)
 
         args = ["vm", "--arch", "x86_64", "connect"]
         opts = parser.parse_args(args)

--- a/tests/controller.py
+++ b/tests/controller.py
@@ -2472,6 +2472,15 @@ class ControllerProjectActionVMTest(RiftProjectTestCase):
         self.clean_mock_environments()
 
     @patch("rift.controller.VM")
+    def test_action_vm_connect(self, mock_vm_class):
+        """simple 'rift vm connect' calls VM.connect()"""
+        mock_vm = mock_vm_class.return_value
+        mock_vm.connect.return_value = 0
+
+        self.assertEqual(main(["vm", "connect"]), 0)
+        mock_vm.connect.assert_called_once_with()
+
+    @patch("rift.controller.VM")
     def test_action_vm_build(self, mock_vm_class):
         """simple 'rift vm build' is ok"""
 

--- a/tests/vm.py
+++ b/tests/vm.py
@@ -712,6 +712,16 @@ class VMTest(RiftTestCase):
         vm.ready.assert_called_once()
         vm.prepare.assert_called_once()
 
+    def test_connect(self):
+        """Test VM connect opens an interactive SSH session"""
+        vm = VM(self.config, platform.machine())
+        ssh = Mock()
+        ssh.returncode = 0
+        vm.cmd = Mock(return_value=ssh)
+
+        self.assertEqual(vm.connect(), 0)
+        vm.cmd.assert_called_once_with(options=None, manage_output=False)
+
     @patch("rift.vm.message")
     def test_start_force(self, mock_message):
         """Test VM force start not running"""

--- a/tests/vm.py
+++ b/tests/vm.py
@@ -772,6 +772,20 @@ class VMTest(RiftTestCase):
         vm._auth_proxy.start.assert_not_called()
         vm._auth_proxy.stop.assert_not_called()
 
+    def test_connect_skips_proxy_when_noproxy(self):
+        """Test VM connect does not start the proxy with proxy=False"""
+        vm = VM(self.config, platform.machine())
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = True
+        ssh = Mock()
+        ssh.returncode = 0
+        vm.cmd = Mock(return_value=ssh)
+
+        self.assertEqual(vm.connect(proxy=False), 0)
+        vm._auth_proxy.start.assert_not_called()
+        vm._auth_proxy.stop.assert_not_called()
+        vm.cmd.assert_called_once_with(options=None, manage_output=False)
+
     def test_connect_reuses_proxy_on_addr_in_use(self):
         """Test VM connect reuses an existing proxy listener"""
         vm = VM(self.config, platform.machine())

--- a/tests/vm.py
+++ b/tests/vm.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2024 CEA
 #
 import atexit
+import errno
 import os
 import platform
 import shutil
@@ -210,34 +211,48 @@ class VMTest(RiftTestCase):
             vm = VM(self.config, "x86_64")
             self.assertEqual(vm.image_is_remote(), expected_value[1])
 
-    def test_default_port(self):
-        """Check VM default port uniqueness and range conformity"""
+    def test_default_ports(self):
+        """Check VM default SSH and proxy ports uniqueness and range conformity"""
         # Declare 2 supported architectures for this test
         self.config.set("arch", ["x86_64", "aarch64"])
+        port_range = {"min": 2000, "max": 3000}
+        self.config.set("vm", {"image": "/path/to/image", "port_range": port_range})
         vm1 = VM(self.config, "x86_64")
         vm2 = VM(self.config, "aarch64")
         vm3 = VM(self.config, "x86_64")
-        port_range = {"min": 2000, "max": 3000}
-        # Verify vm1 and vm2 default are different because of their different
-        # architecture.
-        self.assertNotEqual(vm1.default_port(port_range), vm2.default_port(port_range))
-        # Verify vm1 and vm3 have the same default port because they share the
-        # same combination of user/arch/version.
-        self.assertEqual(vm1.default_port(port_range), vm3.default_port(port_range))
-        # Verify both default ports are included in range
-        self.assertTrue(vm1.default_port(port_range) >= port_range["min"])
-        self.assertTrue(vm1.default_port(port_range) < port_range["max"])
-        self.assertTrue(vm2.default_port(port_range) >= port_range["min"])
-        self.assertTrue(vm2.default_port(port_range) < port_range["max"])
 
-    def test_default_port_invalid_range(self):
-        """Check VM default port raise error with invalid range"""
+        ssh1, proxy1 = vm1.default_ports(port_range)
+        ssh2, proxy2 = vm2.default_ports(port_range)
+        ssh3, proxy3 = vm3.default_ports(port_range)
+
+        # Verify vm1 and vm2 defaults are different because of their different
+        # architecture.
+        self.assertNotEqual((ssh1, proxy1), (ssh2, proxy2))
+        # Verify vm1 and vm3 have the same default ports because they share the
+        # same combination of user/arch/version.
+        self.assertEqual((ssh1, proxy1), (ssh3, proxy3))
+        # Verify both default ports are included in range and proxy != SSH
+        for ssh, proxy in ((ssh1, proxy1), (ssh2, proxy2)):
+            self.assertGreaterEqual(ssh, port_range["min"])
+            self.assertLess(ssh, port_range["max"])
+            self.assertGreaterEqual(proxy, port_range["min"])
+            self.assertLess(proxy, port_range["max"])
+            self.assertNotEqual(ssh, proxy)
+        # Proxy port is SSH + 1 wrapped in the range
+        self.assertEqual(
+            proxy1, port_range["min"] + ((ssh1 - port_range["min"] + 1) % 1000)
+        )
+        # Instance attributes match default_ports() for the configured range
+        self.assertEqual((vm1.port, vm1.proxy_port), vm1.default_ports(port_range))
+
+    def test_default_ports_invalid_range(self):
+        """Check VM default ports raise error with invalid range"""
         vm1 = VM(self.config, "x86_64")
         port_range = {"min": 2001, "max": 2000}
         with self.assertRaisesRegex(
             RiftError, "^VM port range maximum must be greater than the minimum$"
         ):
-            vm1.default_port(port_range)
+            vm1.default_ports(port_range)
 
     def test_gen_virtiofs_args(self):
         """
@@ -705,22 +720,84 @@ class VMTest(RiftTestCase):
         vm.spawn = Mock()
         vm.ready = Mock()
         vm.prepare = Mock()
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = True
         self.assertTrue(vm.start(force=False))
         vm._download.assert_called_once_with(False)
         mock_message.assert_called_once_with("Launching VM ...")
         vm.spawn.assert_called_once()
         vm.ready.assert_called_once()
         vm.prepare.assert_called_once()
+        # Check IDP proxy is started with the VM proxy port
+        vm._auth_proxy.start.assert_called_once_with(port=vm.proxy_port)
+
+    @patch("rift.vm.message")
+    def test_start_skips_proxy_when_not_required(self, mock_message):
+        """Test VM start does not start the proxy without authenticated repos"""
+        vm = VM(self.config, platform.machine())
+        vm.running = Mock(return_value=False)
+        vm._download = Mock()
+        vm.spawn = Mock()
+        vm.ready = Mock()
+        vm.prepare = Mock()
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = False
+        self.assertTrue(vm.start(force=False))
+        vm._auth_proxy.start.assert_not_called()
 
     def test_connect(self):
-        """Test VM connect opens an interactive SSH session"""
+        """Test VM connect opens SSH and starts the IDP proxy when required"""
         vm = VM(self.config, platform.machine())
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = True
         ssh = Mock()
         ssh.returncode = 0
         vm.cmd = Mock(return_value=ssh)
 
         self.assertEqual(vm.connect(), 0)
+        vm._auth_proxy.start.assert_called_once_with(port=vm.proxy_port)
         vm.cmd.assert_called_once_with(options=None, manage_output=False)
+        vm._auth_proxy.stop.assert_called_once()
+
+    def test_connect_skips_proxy_when_not_required(self):
+        """Test VM connect does not start the proxy without authenticated repos"""
+        vm = VM(self.config, platform.machine())
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = False
+        ssh = Mock()
+        ssh.returncode = 0
+        vm.cmd = Mock(return_value=ssh)
+
+        self.assertEqual(vm.connect(), 0)
+        vm._auth_proxy.start.assert_not_called()
+        vm._auth_proxy.stop.assert_not_called()
+
+    def test_connect_reuses_proxy_on_addr_in_use(self):
+        """Test VM connect reuses an existing proxy listener"""
+        vm = VM(self.config, platform.machine())
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = True
+        vm._auth_proxy.start.side_effect = OSError(errno.EADDRINUSE, "in use")
+        ssh = Mock()
+        ssh.returncode = 0
+        vm.cmd = Mock(return_value=ssh)
+
+        self.assertEqual(vm.connect(), 0)
+        vm._auth_proxy.start.assert_called_once_with(port=vm.proxy_port)
+        vm.cmd.assert_called_once_with(options=None, manage_output=False)
+        vm._auth_proxy.stop.assert_not_called()
+
+    def test_connect_stops_proxy_ssh_error(self):
+        """Test VM connect stops the proxy it started if SSH fails"""
+        vm = VM(self.config, platform.machine())
+        vm._auth_proxy = Mock()
+        vm._auth_proxy.required = True
+        vm.cmd = Mock(side_effect=RuntimeError("ssh failed"))
+
+        with self.assertRaises(RuntimeError):
+            vm.connect()
+        vm._auth_proxy.start.assert_called_once_with(port=vm.proxy_port)
+        vm._auth_proxy.stop.assert_called_once()
 
     @patch("rift.vm.message")
     def test_start_force(self, mock_message):


### PR DESCRIPTION
IDP authenticated repositories proxy is now binded on deterministic TCP port with VM so successive rift vm command can use the same port and yum/dnf repositories configuration file deployed on prepare stay relevant during whole VM lifetime.

The proxy thread is started only in presence of IDP authenticated repositories in project configuration.

The feature can be optionally disabled with `rift vm connect --noproxy` command line option.