### PR TITLE
tests: fix GPG home teardown race

### DIFF
--- a/tests/container.py
+++ b/tests/container.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2026 CEA
 #
 import os
-import shutil
 import subprocess
 from unittest.mock import Mock, patch
 
@@ -19,6 +18,7 @@ from .test_utils import (
     gen_containerfile,
     make_temp_file,
     make_temp_tar,
+    remove_gpg_home,
 )
 
 
@@ -254,12 +254,7 @@ class ContainerArchiveTest(RiftProjectTestCase):
             self.container_archive.sign()
 
         finally:
-            # Kill GPG agent launched for the test
-            cmd = ["gpgconf", "--homedir", gpg_home, "--kill", "gpg-agent"]
-            subprocess.run(cmd)
-
-            # Remove temporary GPG home with generated key
-            shutil.rmtree(gpg_home)
+            remove_gpg_home(gpg_home)
 
     def test_sign(self):
         """Container archive signature."""

--- a/tests/controller.py
+++ b/tests/controller.py
@@ -38,6 +38,7 @@ from .test_utils import (
     make_temp_file,
     make_temp_tar,
     read_file,
+    remove_gpg_home,
 )
 from .vm import GLOBAL_CACHE, PROXY, VALID_IMAGE_URL
 
@@ -2630,13 +2631,7 @@ class ControllerProjectActionSignTest(RiftProjectTestCase):
         self.update_project_conf()
 
     def tearDown(self):
-        # Kill GPG agent launched for the test
-        cmd = ["gpgconf", "--homedir", self.gpg_home, "--kill", "gpg-agent"]
-        subprocess.run(cmd)
-
-        # Remove temporary GPG home with generated key
-        shutil.rmtree(self.gpg_home)
-
+        remove_gpg_home(self.gpg_home)
         super().tearDown()
 
     def test_action_sign_rpm(self):

--- a/tests/rpm.py
+++ b/tests/rpm.py
@@ -20,6 +20,7 @@ from .test_utils import (
     host_rpmlint,
     make_temp_dir,
     read_file,
+    remove_gpg_home,
 )
 
 
@@ -435,12 +436,7 @@ class RPMTest(RiftProjectTestCase):
             # Remove signed copy of RPM package and keyring
             os.remove(rpm_copy)
 
-            # Kill GPG agent launched for the test
-            cmd = ["gpgconf", "--homedir", gpg_home, "--kill", "gpg-agent"]
-            subprocess.run(cmd)
-
-            # Remove temporary GPG home with generated key
-            shutil.rmtree(gpg_home)
+            remove_gpg_home(gpg_home)
 
     def test_sign_src_rpm(self):
         """Source RPM package signature."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ import pathlib as pl
 import random
 import shutil
 import string
+import subprocess
 import tarfile
 import tempfile
 import time
@@ -502,6 +503,28 @@ def host_rpmlint(filepath, configdir=None):
 def make_temp_dir():
     """Create and return the name of a temporary directory."""
     return tempfile.mkdtemp(prefix="rift-test-")
+
+
+def remove_gpg_home(gpg_home):
+    """Stop GnuPG daemons and remove a temporary GNUPGHOME directory.
+
+    In some race conditions, GnuPG may unlink sockets (e.g. S.scdaemon) while
+    shutil.rmtree is walking the directory, which raises FileNotFoundError eventually.
+    For this reason, shutil.rmtree is called with inner function helper to ignore
+    FileNotFoundError.
+    """
+    if not os.path.exists(gpg_home):
+        return
+    subprocess.run(
+        ["gpgconf", "--homedir", gpg_home, "--kill", "all"],
+        check=False,
+    )
+
+    def _ignore_missing(_func, _path, exc_info):
+        if not issubclass(exc_info[0], FileNotFoundError):
+            raise exc_info[1]
+
+    shutil.rmtree(gpg_home, onerror=_ignore_missing)
 
 
 def make_temp_filename():


### PR DESCRIPTION
Signing tests may fail in tearDown with shutil.rmtree hitting FileNotFoundError on S.scdaemon in some race condition.

gpgconf --kill gpg-agent (or unlinking S.gpg-agent during rmtree) makes GnuPG drop remaining sockets asynchronously. On its side, shutil.rmtree lists the directory first, then unlinks each name, so a socket that disappears in between raises instead of being skipped.

Centralize cleanup in remove_gpg_home(): kill all GnuPG components, then rmtree while ignoring only FileNotFoundError to avoid the race condition. We are sure all files are removed eventually anyway.